### PR TITLE
build: upgrade Testcontainers 1.20.4 to 2.0.3

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,7 +21,7 @@
         <java.version>21</java.version>
         <spring-modulith.version>1.3.2</spring-modulith.version>
         <jjwt.version>0.13.0</jjwt.version>
-        <testcontainers.version>1.20.4</testcontainers.version>
+        <testcontainers.version>2.0.3</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -212,12 +212,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/src/test/java/com/monteweb/TestContainerConfig.java
+++ b/backend/src/test/java/com/monteweb/TestContainerConfig.java
@@ -5,7 +5,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -21,8 +21,8 @@ public class TestContainerConfig {
     @ServiceConnection
     @SuppressWarnings("resource")
     @ConditionalOnProperty(name = "testcontainers.enabled", havingValue = "true", matchIfMissing = true)
-    public PostgreSQLContainer<?> postgresContainer() {
-        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
+    public PostgreSQLContainer postgresContainer() {
+        return new PostgreSQLContainer(DockerImageName.parse("postgres:16-alpine"))
                 .withDatabaseName("monteweb_test")
                 .withUsername("test")
                 .withPassword("test");


### PR DESCRIPTION
## Summary
- Upgrade Testcontainers from 1.20.4 to 2.0.3
- Rename artifacts: `junit-jupiter` → `testcontainers-junit-jupiter`, `postgresql` → `testcontainers-postgresql`
- Update `PostgreSQLContainer` import to new `org.testcontainers.postgresql` package
- Remove generic type parameter (no longer generic in 2.0)

## Test plan
- [x] All 408 backend tests pass (0 failures, 0 errors)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)