### PR TITLE
Comprehensive review: security, dependencies & use-case audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,29 @@
 # PostgreSQL
 POSTGRES_DB=monteweb
 POSTGRES_USER=monteweb
-POSTGRES_PASSWORD=changeme
+POSTGRES_PASSWORD=CHANGE_ME_strong_db_password
 
 # Redis
-REDIS_PASSWORD=changeme
+REDIS_PASSWORD=CHANGE_ME_strong_redis_password
 
-# JWT (generate with: openssl rand -base64 64)
-JWT_SECRET=change-this-to-a-secure-random-string-at-least-64-chars-long-for-hmac-sha256
+# JWT — REQUIRED, must be >= 64 chars. Generate with: openssl rand -base64 64
+# The backend refuses to start (outside the 'dev' profile) if this is blank,
+# shorter than 64 chars, or left as a placeholder.
+JWT_SECRET=CHANGE_ME
 
-# MinIO (S3-compatible storage)
-MINIO_ACCESS_KEY=minioadmin
-MINIO_SECRET_KEY=minioadmin
+# Encryption secret for TOTP/2FA secrets at rest (AES-256-GCM).
+# Should differ from JWT_SECRET and be >= 64 chars. Generate with: openssl rand -base64 64
+# If left blank, the AES key falls back to JWT_SECRET (not recommended).
+ENCRYPTION_SECRET=
+
+# MinIO (S3-compatible storage) — do NOT keep the well-known minioadmin defaults.
+MINIO_ACCESS_KEY=CHANGE_ME_minio_access_key
+MINIO_SECRET_KEY=CHANGE_ME_minio_secret_key
 MINIO_BUCKET=monteweb
+
+# Spring profile. Leave empty for production (enforces strong-secret validation).
+# Set to 'dev' for local development to relax secret validation.
+# SPRING_PROFILES_ACTIVE=dev
 
 # E-Mail (optional, disabled by default)
 EMAIL_ENABLED=false
@@ -43,8 +54,14 @@ APP_PORT=80
 FRONTEND_URL=http://localhost
 
 # Monitoring (optional, for docker compose --profile monitoring)
+# GRAFANA_PASSWORD is REQUIRED when the monitoring profile is enabled.
 GRAFANA_USER=admin
-GRAFANA_PASSWORD=admin
+GRAFANA_PASSWORD=CHANGE_ME_strong_grafana_password
+
+# ONLYOFFICE document server (optional, for docker compose --profile office)
+# REQUIRED when the office profile is enabled; must be identical on the backend
+# and the document server. Generate with: openssl rand -base64 48
+ONLYOFFICE_JWT_SECRET=
 
 # Backup (optional, for docker compose --profile backup)
 BACKUP_CRON=0 2 * * *

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ JWT_SECRET=CHANGE_ME
 # If left blank, the AES key falls back to JWT_SECRET (not recommended).
 ENCRYPTION_SECRET=
 
+# Cleaning QR check-in signing secret. REQUIRED — the backend fails closed on the
+# built-in default. Generate with: openssl rand -base64 48
+CLEANING_QR_SECRET=
+
 # MinIO (S3-compatible storage) — do NOT keep the well-known minioadmin defaults.
 MINIO_ACCESS_KEY=CHANGE_ME_minio_access_key
 MINIO_SECRET_KEY=CHANGE_ME_minio_secret_key

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -22,8 +22,6 @@
         <spring-modulith.version>2.0.3</spring-modulith.version>
         <jjwt.version>0.13.0</jjwt.version>
         <testcontainers.version>2.0.3</testcontainers.version>
-        <!-- Upgrade Jackson 3.x BOM to fix GHSA-72hv-8253-57qq (Number Length Constraint Bypass) -->
-        <jackson-bom.version>3.1.0</jackson-bom.version>
     </properties>
 
     <dependencyManagement>
@@ -178,7 +176,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.83</version>
+            <version>1.84</version>
         </dependency>
 
         <!-- MinIO (S3-compatible object storage) -->
@@ -331,13 +329,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>@{argLine} -Dnet.bytebuddy.experimental=true</argLine>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/backend/src/main/java/com/monteweb/admin/AdminModuleApi.java
+++ b/backend/src/main/java/com/monteweb/admin/AdminModuleApi.java
@@ -1,6 +1,8 @@
 package com.monteweb.admin;
 
 import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Public API: Facade interface for the admin module.
@@ -11,6 +13,22 @@ public interface AdminModuleApi {
     TenantConfigInfo getTenantConfig();
 
     boolean isModuleEnabled(String moduleName);
+
+    /**
+     * Records a security-relevant action in the persistent, queryable audit log
+     * (US-348). Intended for cross-module callers (e.g. role changes, account
+     * activation/deactivation, impersonation start/stop). {@code details} and
+     * {@code ipAddress} may be null.
+     *
+     * @param userId     the acting user (may be null for system actions)
+     * @param action     a short action code, e.g. "ROLE_CHANGE", "IMPERSONATION_START"
+     * @param entityType the type of affected entity, e.g. "USER"
+     * @param entityId   the id of the affected entity (may be null)
+     * @param details    optional structured details (stored as JSON)
+     * @param ipAddress  optional originating IP address
+     */
+    void recordAuditEvent(UUID userId, String action, String entityType, UUID entityId,
+                          Map<String, Object> details, String ipAddress);
 
     /**
      * Returns the stored LDAP bind password for authentication.

--- a/backend/src/main/java/com/monteweb/admin/internal/controller/AdminConfigController.java
+++ b/backend/src/main/java/com/monteweb/admin/internal/controller/AdminConfigController.java
@@ -12,6 +12,7 @@ import com.monteweb.shared.dto.ApiResponse;
 import com.monteweb.shared.dto.PageResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Instant;
 import java.util.Map;
 
 @RestController
@@ -53,6 +55,7 @@ public class AdminConfigController {
                 request.privacyPolicyText(), request.privacyPolicyVersion(),
                 request.termsText(), request.termsVersion(),
                 request.dataRetentionDaysNotifications(), request.dataRetentionDaysAudit(),
+                request.maxUploadSizeMb(),
                 request.schoolFullName(), request.schoolAddress(), request.schoolPrincipal(),
                 request.techContactName(), request.techContactEmail(),
                 request.twoFactorMode(),
@@ -130,8 +133,12 @@ public class AdminConfigController {
 
     @GetMapping("/audit-log")
     public ResponseEntity<ApiResponse<PageResponse<AuditLogEntry>>> getAuditLog(
+            @RequestParam(required = false) String action,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
             @PageableDefault(size = 50) Pageable pageable) {
-        return ResponseEntity.ok(ApiResponse.ok(PageResponse.from(auditService.findAll(pageable))));
+        return ResponseEntity.ok(ApiResponse.ok(
+                PageResponse.from(auditService.find(action, from, to, pageable))));
     }
 
     // --- CSV Import ---

--- a/backend/src/main/java/com/monteweb/admin/internal/dto/UpdateConfigRequest.java
+++ b/backend/src/main/java/com/monteweb/admin/internal/dto/UpdateConfigRequest.java
@@ -27,6 +27,7 @@ public record UpdateConfigRequest(
         @Size(max = 50) String termsVersion,
         @Min(1) @Max(3650) Integer dataRetentionDaysNotifications,
         @Min(1) @Max(3650) Integer dataRetentionDaysAudit,
+        @Min(1) @Max(1024) Integer maxUploadSizeMb,
         @Size(max = 255) String schoolFullName,
         @Size(max = 500) String schoolAddress,
         @Size(max = 255) String schoolPrincipal,

--- a/backend/src/main/java/com/monteweb/admin/internal/repository/AuditLogRepository.java
+++ b/backend/src/main/java/com/monteweb/admin/internal/repository/AuditLogRepository.java
@@ -4,7 +4,10 @@ import com.monteweb.admin.internal.model.AuditLogEntry;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.UUID;
 
 public interface AuditLogRepository extends JpaRepository<AuditLogEntry, UUID> {
@@ -12,4 +15,24 @@ public interface AuditLogRepository extends JpaRepository<AuditLogEntry, UUID> {
     Page<AuditLogEntry> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     Page<AuditLogEntry> findByUserIdOrderByCreatedAtDesc(UUID userId, Pageable pageable);
+
+    /**
+     * Filtered audit-log query (AC US-348: "Filtern nach Zeitraum oder Aktion").
+     * Any of the filter parameters may be null, in which case that filter is skipped.
+     *
+     * <p>The nullable parameters are CAST to their type inside the {@code IS NULL}
+     * checks so PostgreSQL can determine the bind-parameter types even when the value
+     * is null (otherwise: "could not determine data type of parameter").
+     */
+    @Query("""
+            SELECT a FROM AuditLogEntry a
+            WHERE (CAST(:action AS string) IS NULL OR a.action = :action)
+              AND (CAST(:from AS timestamp) IS NULL OR a.createdAt >= :from)
+              AND (CAST(:to AS timestamp) IS NULL OR a.createdAt <= :to)
+            ORDER BY a.createdAt DESC
+            """)
+    Page<AuditLogEntry> findFiltered(@Param("action") String action,
+                                     @Param("from") Instant from,
+                                     @Param("to") Instant to,
+                                     Pageable pageable);
 }

--- a/backend/src/main/java/com/monteweb/admin/internal/service/AdminService.java
+++ b/backend/src/main/java/com/monteweb/admin/internal/service/AdminService.java
@@ -18,6 +18,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,13 +27,23 @@ public class AdminService implements AdminModuleApi {
     private final TenantConfigRepository configRepository;
     private final AesEncryptionService aesEncryptionService;
     private final ErrorReportRepository errorReportRepository;
+    private final AuditService auditService;
 
     public AdminService(TenantConfigRepository configRepository,
                         AesEncryptionService aesEncryptionService,
-                        ErrorReportRepository errorReportRepository) {
+                        ErrorReportRepository errorReportRepository,
+                        AuditService auditService) {
         this.configRepository = configRepository;
         this.aesEncryptionService = aesEncryptionService;
         this.errorReportRepository = errorReportRepository;
+        this.auditService = auditService;
+    }
+
+    @Override
+    @Transactional
+    public void recordAuditEvent(UUID userId, String action, String entityType, UUID entityId,
+                                 Map<String, Object> details, String ipAddress) {
+        auditService.log(userId, action, entityType, entityId, details, ipAddress);
     }
 
     @Override
@@ -55,6 +66,7 @@ public class AdminService implements AdminModuleApi {
                                           String privacyPolicyText, String privacyPolicyVersion,
                                           String termsText, String termsVersion,
                                           Integer dataRetentionDaysNotifications, Integer dataRetentionDaysAudit,
+                                          Integer maxUploadSizeMb,
                                           String schoolFullName, String schoolAddress, String schoolPrincipal,
                                           String techContactName, String techContactEmail,
                                           String twoFactorMode,
@@ -88,6 +100,7 @@ public class AdminService implements AdminModuleApi {
         if (termsVersion != null) config.setTermsVersion(termsVersion);
         if (dataRetentionDaysNotifications != null) config.setDataRetentionDaysNotifications(dataRetentionDaysNotifications);
         if (dataRetentionDaysAudit != null) config.setDataRetentionDaysAudit(dataRetentionDaysAudit);
+        if (maxUploadSizeMb != null) config.setMaxUploadSizeMb(maxUploadSizeMb);
         if (schoolFullName != null) config.setSchoolFullName(schoolFullName);
         if (schoolAddress != null) config.setSchoolAddress(schoolAddress);
         if (schoolPrincipal != null) config.setSchoolPrincipal(schoolPrincipal);

--- a/backend/src/main/java/com/monteweb/admin/internal/service/AdminService.java
+++ b/backend/src/main/java/com/monteweb/admin/internal/service/AdminService.java
@@ -149,7 +149,12 @@ public class AdminService implements AdminModuleApi {
                 "Jitsi kann nicht aktiviert werden, ohne eine eigene Jitsi-Server-URL zu konfigurieren. " +
                 "Bitte tragen Sie zuerst die URL Ihres selbst-gehosteten Jitsi-Servers ein.");
         }
-        config.setModules(modules);
+        // Merge with existing toggles instead of replacing the whole map, so a partial
+        // update does not silently wipe unrelated flags (e.g. maintenance, wopi, clamav,
+        // ldap, directoryAdminOnly). Mirrors the copy-and-merge pattern in updateMaintenance().
+        var existing = new java.util.HashMap<>(config.getModules());
+        existing.putAll(modules);
+        config.setModules(existing);
         return toInfo(configRepository.save(config));
     }
 

--- a/backend/src/main/java/com/monteweb/admin/internal/service/AnalyticsService.java
+++ b/backend/src/main/java/com/monteweb/admin/internal/service/AnalyticsService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Service;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -18,16 +19,31 @@ public class AnalyticsService {
     public Map<String, Object> getAnalytics() {
         Map<String, Object> stats = new LinkedHashMap<>();
 
+        // User stats
         stats.put("totalUsers", countQuery("SELECT COUNT(*) FROM users"));
         stats.put("activeUsers", countQuery("SELECT COUNT(*) FROM users WHERE is_active = true"));
-        stats.put("rooms", countQuery("SELECT COUNT(*) FROM rooms WHERE is_archived = false"));
-        stats.put("posts", countQuery("SELECT COUNT(*) FROM feed_posts"));
-        stats.put("events", countQuery("SELECT COUNT(*) FROM calendar_events"));
-        stats.put("messages", countQuery("SELECT COUNT(*) FROM messages"));
-        stats.put("postsThisMonth", countQuery(
-                "SELECT COUNT(*) FROM feed_posts WHERE created_at >= date_trunc('month', CURRENT_TIMESTAMP)"));
+        // User stats by role (AC: "User-Stats nach Rolle")
+        stats.put("usersByRole", groupedCountQuery("SELECT role, COUNT(*) FROM users GROUP BY role"));
         stats.put("newThisWeek", countQuery(
                 "SELECT COUNT(*) FROM users WHERE created_at > CURRENT_TIMESTAMP - INTERVAL '7 days'"));
+
+        // Content stats
+        stats.put("rooms", countQuery("SELECT COUNT(*) FROM rooms WHERE is_archived = false"));
+        stats.put("posts", countQuery("SELECT COUNT(*) FROM feed_posts"));
+        stats.put("postsThisMonth", countQuery(
+                "SELECT COUNT(*) FROM feed_posts WHERE created_at >= date_trunc('month', CURRENT_TIMESTAMP)"));
+        stats.put("events", countQuery("SELECT COUNT(*) FROM calendar_events"));
+        stats.put("messages", countQuery("SELECT COUNT(*) FROM messages"));
+        // Content stats: Files (AC: "Content-Stats: Files")
+        stats.put("files", countQuery("SELECT COUNT(*) FROM room_files"));
+
+        // Engagement stats (AC: "Engagement-Stats: Kommentare, Reaktionen, Login-Haeufigkeit")
+        stats.put("comments", countQuery("SELECT COUNT(*) FROM feed_post_comments"));
+        stats.put("reactions", countQuery("SELECT COUNT(*) FROM feed_reactions")
+                + countQuery("SELECT COUNT(*) FROM message_reactions"));
+        // Login frequency: users who logged in within the last 7 days
+        stats.put("loginsThisWeek", countQuery(
+                "SELECT COUNT(*) FROM users WHERE last_login_at > CURRENT_TIMESTAMP - INTERVAL '7 days'"));
 
         return stats;
     }
@@ -35,5 +51,20 @@ public class AnalyticsService {
     private long countQuery(String sql) {
         Object result = entityManager.createNativeQuery(sql).getSingleResult();
         return ((Number) result).longValue();
+    }
+
+    /**
+     * Runs a two-column "key, count" grouped query and returns it as a key->count map.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Long> groupedCountQuery(String sql) {
+        List<Object[]> rows = entityManager.createNativeQuery(sql).getResultList();
+        Map<String, Long> result = new LinkedHashMap<>();
+        for (Object[] row : rows) {
+            String key = row[0] != null ? row[0].toString() : "UNKNOWN";
+            long count = row[1] != null ? ((Number) row[1]).longValue() : 0L;
+            result.put(key, count);
+        }
+        return result;
     }
 }

--- a/backend/src/main/java/com/monteweb/admin/internal/service/AuditService.java
+++ b/backend/src/main/java/com/monteweb/admin/internal/service/AuditService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
@@ -28,5 +29,17 @@ public class AuditService {
 
     public Page<AuditLogEntry> findAll(Pageable pageable) {
         return repository.findAllByOrderByCreatedAtDesc(pageable);
+    }
+
+    /**
+     * Returns audit-log entries optionally filtered by action and/or time range
+     * (AC US-348: "Filtern nach Zeitraum oder Aktion"). Null filters are ignored.
+     */
+    public Page<AuditLogEntry> find(String action, Instant from, Instant to, Pageable pageable) {
+        String normalizedAction = (action != null && !action.isBlank()) ? action : null;
+        if (normalizedAction == null && from == null && to == null) {
+            return repository.findAllByOrderByCreatedAtDesc(pageable);
+        }
+        return repository.findFiltered(normalizedAction, from, to, pageable);
     }
 }

--- a/backend/src/main/java/com/monteweb/auth/internal/config/OidcAuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/monteweb/auth/internal/config/OidcAuthenticationSuccessHandler.java
@@ -57,6 +57,17 @@ public class OidcAuthenticationSuccessHandler implements AuthenticationSuccessHa
             return;
         }
 
+        // Reject the whole SSO flow when the IdP has not asserted email ownership.
+        // OidcUserService links/creates accounts by email (findByEmail); without a verified
+        // email an attacker who registers the victim's email at the IdP could take over the
+        // victim's existing MonteWeb account on first SSO login (classic OIDC linking pitfall).
+        Boolean emailVerified = oidcUser.getEmailVerified();
+        if (!Boolean.TRUE.equals(emailVerified)) {
+            log.warn("OIDC login rejected: email not verified by IdP for subject {}", subject);
+            response.sendRedirect(frontendUrl().concat("/login?error=oidc_email_not_verified"));
+            return;
+        }
+
         String code = codeStore.storeVerifiedClaims(providerName, subject, email, firstName, lastName);
         log.info("OIDC authentication successful for {}, redirecting with auth code", email);
         response.sendRedirect(frontendUrl().concat("/login?oidc_code=" + code));

--- a/backend/src/main/java/com/monteweb/auth/internal/controller/AuthController.java
+++ b/backend/src/main/java/com/monteweb/auth/internal/controller/AuthController.java
@@ -126,6 +126,36 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    /**
+     * Self-service 2FA enrollment (step 1) for MANDATORY mode past the grace deadline.
+     * Authenticated by the 2FA temp token returned from /login (the user has no full
+     * session and no TOTP secret yet). Returns the QR URI to configure an authenticator.
+     */
+    @PostMapping("/2fa/setup-temp")
+    public ResponseEntity<ApiResponse<TwoFactorSetupResponse>> setup2faWithTempToken(
+            @Valid @RequestBody TwoFactorSetupTempRequest request) {
+        var response = authService.setup2faWithTempToken(request.tempToken());
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    /**
+     * Self-service 2FA enrollment (step 2) for MANDATORY mode past the grace deadline.
+     * Validates the temp token + code, enables 2FA, and logs the user in (sets auth cookies),
+     * returning recovery codes (shown once).
+     */
+    @PostMapping("/2fa/setup-temp/confirm")
+    public ResponseEntity<ApiResponse<TwoFactorEnrollmentResult>> confirm2faWithTempToken(
+            @Valid @RequestBody TwoFactorVerifyRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse) {
+        var result = authService.confirm2faWithTempToken(request.tempToken(), request.code());
+        var login = result.login();
+        if (login.accessToken() != null && login.refreshToken() != null) {
+            setAuthCookies(httpResponse, login.accessToken(), login.refreshToken(), httpRequest);
+        }
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
     @GetMapping("/2fa/status")
     public ResponseEntity<ApiResponse<java.util.Map<String, Boolean>>> get2faStatus() {
         var userId = SecurityUtils.requireCurrentUserId();

--- a/backend/src/main/java/com/monteweb/auth/internal/dto/TwoFactorEnrollmentResult.java
+++ b/backend/src/main/java/com/monteweb/auth/internal/dto/TwoFactorEnrollmentResult.java
@@ -1,0 +1,18 @@
+package com.monteweb.auth.internal.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * Result of completing self-service 2FA enrollment during a MANDATORY-mode login.
+ * Wraps the freshly issued session ({@link LoginResponse}) together with the one-time
+ * recovery codes so the user is logged in immediately after enrolling and can store the
+ * recovery codes (shown only once).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TwoFactorEnrollmentResult(
+        LoginResponse login,
+        List<String> recoveryCodes
+) {
+}

--- a/backend/src/main/java/com/monteweb/auth/internal/dto/TwoFactorSetupTempRequest.java
+++ b/backend/src/main/java/com/monteweb/auth/internal/dto/TwoFactorSetupTempRequest.java
@@ -1,0 +1,13 @@
+package com.monteweb.auth.internal.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request to begin self-service 2FA enrollment during login when 2FA is MANDATORY
+ * and the grace period has passed. Authenticated by the short-lived 2FA temp token
+ * (not a full session), so a user who has no TOTP secret yet can still enroll.
+ */
+public record TwoFactorSetupTempRequest(
+        @NotBlank String tempToken
+) {
+}

--- a/backend/src/main/java/com/monteweb/auth/internal/service/AuthService.java
+++ b/backend/src/main/java/com/monteweb/auth/internal/service/AuthService.java
@@ -343,6 +343,76 @@ public class AuthService implements AuthModuleApi {
     }
 
     /**
+     * Self-service 2FA enrollment (step 1) during a MANDATORY-mode login after the grace
+     * deadline. The login endpoint hands the client a 2FA temp token instead of a full
+     * session; here we authenticate with that temp token (the user has no full session and
+     * no TOTP secret yet) and generate + store a fresh TOTP secret, returning the QR URI.
+     * Does NOT consume the temp token — that happens on successful {@link #confirm2faWithTempToken}.
+     */
+    @Transactional
+    public TwoFactorSetupResponse setup2faWithTempToken(String tempToken) {
+        var claims = jwtService.validateTempToken(tempToken)
+                .orElseThrow(() -> new BadRequestException("Invalid or expired temp token"));
+        java.util.UUID userId = java.util.UUID.fromString(claims.getSubject());
+
+        UserInfo user = userModuleApi.findById(userId)
+                .orElseThrow(() -> new BusinessException("User not found"));
+
+        // Users who already have 2FA enabled must use the normal verify flow, not re-enroll.
+        if (userModuleApi.isTotpEnabled(userId)) {
+            throw new BadRequestException("2FA is already enabled");
+        }
+
+        String secret = totpService.generateSecret();
+        userModuleApi.setTotpSecret(userId, aesEncryptionService.encrypt(secret));
+
+        String qrUri = totpService.generateTotpUri(secret, user.email());
+        return new TwoFactorSetupResponse(secret, qrUri);
+    }
+
+    /**
+     * Self-service 2FA enrollment (step 2) during a MANDATORY-mode login. Validates the
+     * 2FA temp token + the code from the freshly configured authenticator, enables 2FA,
+     * single-use-consumes the temp token, and returns a real session plus the one-time
+     * recovery codes. This closes the lock-out where a user without 2FA past the grace
+     * deadline could neither log in nor enroll.
+     */
+    @Transactional
+    public TwoFactorEnrollmentResult confirm2faWithTempToken(String tempToken, String code) {
+        var claims = jwtService.validateTempToken(tempToken)
+                .orElseThrow(() -> new BadRequestException("Invalid or expired temp token"));
+        java.util.UUID userId = java.util.UUID.fromString(claims.getSubject());
+        String jti = claims.getId();
+
+        UserInfo user = userModuleApi.findById(userId)
+                .orElseThrow(() -> new BusinessException("User not found"));
+
+        if (userModuleApi.isTotpEnabled(userId)) {
+            throw new BadRequestException("2FA is already enabled");
+        }
+
+        String secret = userModuleApi.getTotpSecret(userId)
+                .map(aesEncryptionService::decrypt)
+                .orElseThrow(() -> new BadRequestException("2FA not set up. Call setup first."));
+
+        if (!totpService.verifyCode(secret, code, userId)) {
+            throw new BusinessException("Invalid 2FA code");
+        }
+
+        var recoveryCodes = totpService.generateRecoveryCodes();
+        var hashedCodes = recoveryCodes.stream()
+                .map(totpService::hashRecoveryCode)
+                .toArray(String[]::new);
+        userModuleApi.enableTotp(userId, hashedCodes);
+
+        // Only consume the temp token once enrollment fully succeeds, so a wrong code can be retried.
+        consumeTempToken(jti, userId);
+        userModuleApi.updateLastLogin(userId);
+
+        return new TwoFactorEnrollmentResult(generateTokenResponse(user), recoveryCodes);
+    }
+
+    /**
      * Returns whether TOTP is enabled for the given user.
      */
     public boolean is2faEnabled(java.util.UUID userId) {

--- a/backend/src/main/java/com/monteweb/auth/internal/service/AuthService.java
+++ b/backend/src/main/java/com/monteweb/auth/internal/service/AuthService.java
@@ -16,9 +16,12 @@ import com.monteweb.user.UserRole;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
 
 @Service
 @Transactional(readOnly = true)
@@ -33,6 +36,9 @@ public class AuthService implements AuthModuleApi {
     private final PasswordEncoder passwordEncoder;
     private final TotpService totpService;
     private final AesEncryptionService aesEncryptionService;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String TWO_FA_TEMP_USED_PREFIX = "2fa_temp_used:";
 
     @Autowired(required = false)
     private LdapAuthService ldapAuthService;
@@ -43,7 +49,8 @@ public class AuthService implements AuthModuleApi {
                        RefreshTokenService refreshTokenService,
                        PasswordEncoder passwordEncoder,
                        TotpService totpService,
-                       AesEncryptionService aesEncryptionService) {
+                       AesEncryptionService aesEncryptionService,
+                       StringRedisTemplate redisTemplate) {
         this.userModuleApi = userModuleApi;
         this.adminModuleApi = adminModuleApi;
         this.jwtService = jwtService;
@@ -51,6 +58,7 @@ public class AuthService implements AuthModuleApi {
         this.passwordEncoder = passwordEncoder;
         this.totpService = totpService;
         this.aesEncryptionService = aesEncryptionService;
+        this.redisTemplate = redisTemplate;
     }
 
     @Transactional
@@ -105,12 +113,17 @@ public class AuthService implements AuthModuleApi {
             }
         }
 
-        if (!localAuthSuccess || user == null) {
+        // Inactive/pending accounts must return the SAME generic error regardless of
+        // password correctness, otherwise the differing "PENDING_APPROVAL" response leaks
+        // (a) which emails are real pending accounts and (b) that a guessed password is
+        // correct for an inactive account (online password oracle). Check it before the
+        // credential-success branch so the response is identical for right/wrong passwords.
+        if (user != null && !user.active()) {
             throw new BusinessException("Invalid credentials");
         }
 
-        if (!user.active()) {
-            throw new BusinessException("PENDING_APPROVAL");
+        if (!localAuthSuccess || user == null) {
+            throw new BusinessException("Invalid credentials");
         }
 
         // Check if user has 2FA enabled
@@ -203,6 +216,13 @@ public class AuthService implements AuthModuleApi {
             return java.util.Optional.empty();
         }
         var claims = jwtService.extractClaims(token);
+        // Reject special-purpose tokens (e.g. 2fa_temp, image) that carry a "type" claim.
+        // Only full access tokens may authenticate sessions (e.g. WebSocket/STOMP).
+        // This mirrors the REST JwtAuthenticationFilter.authenticateWithJwt() check and
+        // closes the 2FA-bypass and image-token confusion at this shared entry point.
+        if (claims.get("type", String.class) != null) {
+            return java.util.Optional.empty();
+        }
         return java.util.Optional.of(new TokenClaims(
                 claims.getSubject(),
                 claims.get("role", String.class)
@@ -287,6 +307,7 @@ public class AuthService implements AuthModuleApi {
 
         var claims = claimsOpt.get();
         java.util.UUID userId = java.util.UUID.fromString(claims.getSubject());
+        String jti = claims.getId();
 
         UserInfo user = userModuleApi.findById(userId)
                 .orElseThrow(() -> new BusinessException("User not found"));
@@ -294,6 +315,7 @@ public class AuthService implements AuthModuleApi {
         // Try TOTP code first
         String secret = userModuleApi.getTotpSecret(userId).map(aesEncryptionService::decrypt).orElse(null);
         if (secret != null && totpService.verifyCode(secret, code, userId)) {
+            consumeTempToken(jti, userId);
             userModuleApi.updateLastLogin(userId);
             return generateTokenResponse(user);
         }
@@ -303,6 +325,7 @@ public class AuthService implements AuthModuleApi {
         if (recoveryCodes != null) {
             for (int i = 0; i < recoveryCodes.length; i++) {
                 if (recoveryCodes[i] != null && totpService.verifyRecoveryCode(code, recoveryCodes[i])) {
+                    consumeTempToken(jti, userId);
                     // Consume recovery code
                     recoveryCodes[i] = null;
                     // Filter out nulls
@@ -372,6 +395,24 @@ public class AuthService implements AuthModuleApi {
                 jwtService.generateAccessToken(adminUserId, admin.email(), admin.role().name()),
                 refreshTokenService.createRefreshToken(adminUserId),
                 admin.id(), admin.email(), admin.role().name());
+    }
+
+    /**
+     * Atomically marks a 2FA temp token (identified by its "jti") as used so it cannot be
+     * replayed within its 5-minute lifetime. Mirrors the replay-detection pattern used in
+     * {@link TotpService} (TOTP codes) and {@link RefreshTokenService} (used refresh tokens).
+     * A token without a jti (legacy/older issuance) is allowed through for backwards compatibility.
+     */
+    private void consumeTempToken(String jti, java.util.UUID userId) {
+        if (jti == null) {
+            return; // older temp tokens have no jti; cannot enforce single-use
+        }
+        Boolean wasAbsent = redisTemplate.opsForValue()
+                .setIfAbsent(TWO_FA_TEMP_USED_PREFIX + jti, userId.toString(), Duration.ofMinutes(5));
+        if (Boolean.FALSE.equals(wasAbsent)) {
+            log.warn("2FA temp token replay detected for user {}", userId);
+            throw new BusinessException("Token already used");
+        }
     }
 
     private LoginResponse generateTokenResponse(UserInfo user) {

--- a/backend/src/main/java/com/monteweb/auth/internal/service/JwtService.java
+++ b/backend/src/main/java/com/monteweb/auth/internal/service/JwtService.java
@@ -85,11 +85,14 @@ public class JwtService {
     /**
      * Generates a short-lived (5 min) temp token for 2FA verification.
      * Contains user ID, email, and role — but type="2fa_temp" prevents use as access token.
+     * A random "jti" (JWT ID) is included so the token can be marked single-use
+     * server-side once 2FA verification succeeds (replay protection).
      */
     public String generateTempToken(UUID userId, String email, String role) {
         Instant now = Instant.now();
         return Jwts.builder()
                 .subject(userId.toString())
+                .id(UUID.randomUUID().toString())
                 .claims(Map.of(
                         "email", email,
                         "role", role,

--- a/backend/src/main/java/com/monteweb/auth/internal/service/OidcUserService.java
+++ b/backend/src/main/java/com/monteweb/auth/internal/service/OidcUserService.java
@@ -43,6 +43,10 @@ public class OidcUserService {
         }
 
         // 2. Email-based linking: existing user with same email?
+        // SECURITY: This auto-links the external OIDC identity to an existing local account
+        // purely on email match. Safe ONLY because OidcAuthenticationSuccessHandler already
+        // rejected the flow unless the IdP asserted email_verified=true. Do not call this
+        // path with an unverified email. See finding [4]/[5] in the auth security review.
         Optional<UserInfo> byEmail = userModuleApi.findByEmail(email);
         if (byEmail.isPresent()) {
             log.info("Linking OIDC identity to existing user: {}", email);

--- a/backend/src/main/java/com/monteweb/bookmark/BookmarkInfo.java
+++ b/backend/src/main/java/com/monteweb/bookmark/BookmarkInfo.java
@@ -5,12 +5,18 @@ import java.util.UUID;
 
 /**
  * Public API: Read-only bookmark information for cross-module use.
+ *
+ * <p>{@code title} is a best-effort, denormalized label resolved from the
+ * source module (e.g. feed post title, calendar event title). It may be
+ * {@code null} when the source module is disabled, the source content was
+ * deleted, or the content type has no resolvable title yet.
  */
 public record BookmarkInfo(
         UUID id,
         UUID userId,
         String contentType,
         UUID contentId,
+        String title,
         Instant createdAt
 ) {
 }

--- a/backend/src/main/java/com/monteweb/bookmark/internal/controller/BookmarkController.java
+++ b/backend/src/main/java/com/monteweb/bookmark/internal/controller/BookmarkController.java
@@ -5,6 +5,7 @@ import com.monteweb.bookmark.internal.service.BookmarkService;
 import com.monteweb.shared.dto.ApiResponse;
 import com.monteweb.shared.dto.PageResponse;
 import com.monteweb.shared.util.SecurityUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/bookmarks")
+@ConditionalOnProperty(prefix = "monteweb.modules", name = "bookmarks.enabled", havingValue = "true")
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;

--- a/backend/src/main/java/com/monteweb/bookmark/internal/service/BookmarkService.java
+++ b/backend/src/main/java/com/monteweb/bookmark/internal/service/BookmarkService.java
@@ -6,6 +6,7 @@ import com.monteweb.bookmark.internal.model.Bookmark;
 import com.monteweb.bookmark.internal.repository.BookmarkRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 
 @Service
+@ConditionalOnProperty(prefix = "monteweb.modules", name = "bookmarks.enabled", havingValue = "true")
 @Transactional(readOnly = true)
 public class BookmarkService implements BookmarkModuleApi {
 

--- a/backend/src/main/java/com/monteweb/bookmark/internal/service/BookmarkService.java
+++ b/backend/src/main/java/com/monteweb/bookmark/internal/service/BookmarkService.java
@@ -4,8 +4,11 @@ import com.monteweb.bookmark.BookmarkInfo;
 import com.monteweb.bookmark.BookmarkModuleApi;
 import com.monteweb.bookmark.internal.model.Bookmark;
 import com.monteweb.bookmark.internal.repository.BookmarkRepository;
+import com.monteweb.calendar.CalendarModuleApi;
+import com.monteweb.feed.FeedModuleApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,8 +27,21 @@ public class BookmarkService implements BookmarkModuleApi {
 
     private final BookmarkRepository bookmarkRepository;
 
-    public BookmarkService(BookmarkRepository bookmarkRepository) {
+    /**
+     * Optional source-module facades used to resolve a human-readable title for
+     * each bookmark. They are {@code @Autowired(required = false)} because the
+     * feed/calendar modules can be disabled independently. JOB and WIKI_PAGE
+     * titles are not resolved yet — see {@link #resolveTitle}.
+     */
+    private final FeedModuleApi feedModuleApi;
+    private final CalendarModuleApi calendarModuleApi;
+
+    public BookmarkService(BookmarkRepository bookmarkRepository,
+                           @Autowired(required = false) FeedModuleApi feedModuleApi,
+                           @Autowired(required = false) CalendarModuleApi calendarModuleApi) {
         this.bookmarkRepository = bookmarkRepository;
+        this.feedModuleApi = feedModuleApi;
+        this.calendarModuleApi = calendarModuleApi;
     }
 
     @Transactional
@@ -90,7 +106,33 @@ public class BookmarkService implements BookmarkModuleApi {
                 bookmark.getUserId(),
                 bookmark.getContentType(),
                 bookmark.getContentId(),
+                resolveTitle(bookmark.getContentType(), bookmark.getContentId()),
                 bookmark.getCreatedAt()
         );
+    }
+
+    /**
+     * Best-effort resolution of a display title from the source module.
+     *
+     * <p>Currently supports POST (feed) and EVENT (calendar), whose public
+     * facades expose a single-item lookup with a title. JOB and WIKI_PAGE
+     * return {@code null} because {@code JobboardModuleApi}/{@code WikiModuleApi}
+     * do not yet expose a by-id title lookup (cross-module API gap — see flags).
+     * Returns {@code null} on any failure so listing a bookmark never breaks
+     * because a source item is missing or its module is disabled.
+     */
+    private String resolveTitle(String contentType, UUID contentId) {
+        try {
+            return switch (contentType) {
+                case "POST" -> feedModuleApi == null ? null
+                        : feedModuleApi.findPostById(contentId).map(p -> p.title()).orElse(null);
+                case "EVENT" -> calendarModuleApi == null ? null
+                        : calendarModuleApi.findById(contentId).map(e -> e.title()).orElse(null);
+                default -> null; // JOB, WIKI_PAGE: no by-id title facade yet
+            };
+        } catch (RuntimeException ex) {
+            log.debug("Could not resolve title for {} {}: {}", contentType, contentId, ex.getMessage());
+            return null;
+        }
     }
 }

--- a/backend/src/main/java/com/monteweb/calendar/internal/service/CalendarService.java
+++ b/backend/src/main/java/com/monteweb/calendar/internal/service/CalendarService.java
@@ -1,5 +1,6 @@
 package com.monteweb.calendar.internal.service;
 
+import com.monteweb.admin.AdminModuleApi;
 import com.monteweb.calendar.*;
 import com.monteweb.calendar.internal.model.CalendarEvent;
 import com.monteweb.calendar.internal.model.EventRsvp;
@@ -9,6 +10,7 @@ import com.monteweb.jobboard.JobboardModuleApi;
 import com.monteweb.room.RoomModuleApi;
 import com.monteweb.room.RoomRole;
 import com.monteweb.school.SchoolModuleApi;
+import com.monteweb.shared.exception.ForbiddenException;
 import com.monteweb.user.UserModuleApi;
 import com.monteweb.user.UserRole;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +40,7 @@ public class CalendarService implements CalendarModuleApi {
     private final UserModuleApi userModule;
     private final ApplicationEventPublisher eventPublisher;
     private final JobboardModuleApi jobboardModuleApi;
+    private final AdminModuleApi adminModule;
 
     public CalendarService(CalendarEventRepository eventRepository,
                            EventRsvpRepository rsvpRepository,
@@ -45,7 +48,8 @@ public class CalendarService implements CalendarModuleApi {
                            SchoolModuleApi schoolModule,
                            UserModuleApi userModule,
                            ApplicationEventPublisher eventPublisher,
-                           @Lazy @Autowired(required = false) JobboardModuleApi jobboardModuleApi) {
+                           @Lazy @Autowired(required = false) JobboardModuleApi jobboardModuleApi,
+                           AdminModuleApi adminModule) {
         this.eventRepository = eventRepository;
         this.rsvpRepository = rsvpRepository;
         this.roomModule = roomModule;
@@ -53,6 +57,7 @@ public class CalendarService implements CalendarModuleApi {
         this.userModule = userModule;
         this.eventPublisher = eventPublisher;
         this.jobboardModuleApi = jobboardModuleApi;
+        this.adminModule = adminModule;
     }
 
     public Page<EventInfo> getPersonalEvents(UUID userId, LocalDate from, LocalDate to, Pageable pageable) {
@@ -73,7 +78,7 @@ public class CalendarService implements CalendarModuleApi {
     }
 
     public Page<EventInfo> getRoomEvents(UUID roomId, UUID userId, LocalDate from, LocalDate to, Pageable pageable) {
-        if (!hasAdminRole(userId) && !roomModule.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRoleForRoom(userId, roomId) && !roomModule.isUserInRoom(userId, roomId)) {
             throw new IllegalArgumentException("User is not a member of this room");
         }
         return eventRepository.findByRoomId(roomId, from, to, pageable)
@@ -123,7 +128,7 @@ public class CalendarService implements CalendarModuleApi {
         var event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("Event not found"));
 
-        checkCreatePermission(event.getScope(), event.getScopeId(), userId);
+        checkManagePermission(event, userId);
 
         if (request.title() != null) event.setTitle(request.title());
         if (request.description() != null) event.setDescription(request.description());
@@ -145,7 +150,7 @@ public class CalendarService implements CalendarModuleApi {
         var event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("Event not found"));
 
-        checkCreatePermission(event.getScope(), event.getScopeId(), userId);
+        checkManagePermission(event, userId);
 
         event.setCancelled(true);
         event = eventRepository.save(event);
@@ -165,7 +170,7 @@ public class CalendarService implements CalendarModuleApi {
         var event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("Event not found"));
 
-        checkCreatePermission(event.getScope(), event.getScopeId(), userId);
+        checkManagePermission(event, userId);
 
         // Capture attending users before deletion for targeted feed post
         List<UUID> attendingUserIds = rsvpRepository.findUserIdsByEventIdAndStatus(eventId, RsvpStatus.ATTENDING);
@@ -239,7 +244,10 @@ public class CalendarService implements CalendarModuleApi {
     public EventInfo generateJitsiRoom(UUID eventId, UUID userId) {
         var event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new com.monteweb.shared.exception.ResourceNotFoundException("Event not found"));
-        checkReadAccess(event, userId);
+        // US-114: reject Jitsi requests when the module is disabled (DB toggle)
+        requireJitsiEnabled();
+        // US-113: only the event creator or a SUPERADMIN may add a video conference
+        checkManagePermission(event, userId);
         String shortId = eventId.toString().substring(0, 8);
         event.setJitsiRoomName("monteweb-event-" + shortId);
         eventRepository.save(event);
@@ -250,10 +258,19 @@ public class CalendarService implements CalendarModuleApi {
     public EventInfo removeJitsiRoom(UUID eventId, UUID userId) {
         var event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new com.monteweb.shared.exception.ResourceNotFoundException("Event not found"));
-        checkReadAccess(event, userId);
+        // US-114: reject Jitsi requests when the module is disabled (DB toggle)
+        requireJitsiEnabled();
+        // US-113: only the event creator or a SUPERADMIN may remove a video conference
+        checkManagePermission(event, userId);
         event.setJitsiRoomName(null);
         eventRepository.save(event);
         return toEventInfo(event, userId);
+    }
+
+    private void requireJitsiEnabled() {
+        if (adminModule == null || !adminModule.isModuleEnabled("jitsi")) {
+            throw new ForbiddenException("Jitsi video conferencing is not enabled");
+        }
     }
 
     @Override
@@ -303,10 +320,59 @@ public class CalendarService implements CalendarModuleApi {
                 .stream().map(e -> toEventInfo(e, null)).toList();
     }
 
-    private boolean hasAdminRole(UUID userId) {
+    private boolean isSuperAdmin(UUID userId) {
         return userModule.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
+                .map(u -> u.role() == UserRole.SUPERADMIN)
                 .orElse(false);
+    }
+
+    /**
+     * Returns true if the user is a global SUPERADMIN, or a SECTION_ADMIN scoped to the
+     * section the given room belongs to. SECTION_ADMINs are NOT global admins: a section
+     * admin scoped to e.g. Krippe must not gain access to an Oberstufe room.
+     * Mirrors {@code DiscussionThreadService.hasAdminRoleForRoom} / {@code RoomController.isAdminForSection}.
+     */
+    private boolean hasAdminRoleForRoom(UUID userId, UUID roomId) {
+        var user = userModule.findById(userId).orElse(null);
+        if (user == null) {
+            return false;
+        }
+        if (user.role() == UserRole.SUPERADMIN) {
+            return true;
+        }
+        if (user.role() == UserRole.SECTION_ADMIN) {
+            var sectionId = roomModule.findById(roomId).map(r -> r.sectionId()).orElse(null);
+            return sectionId != null && user.specialRoles() != null
+                    && user.specialRoles().contains("SECTION_ADMIN:" + sectionId);
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the user is a SECTION_ADMIN scoped to the given section.
+     */
+    private boolean administersSection(UUID userId, UUID sectionId) {
+        if (sectionId == null) return false;
+        var user = userModule.findById(userId).orElse(null);
+        if (user == null) return false;
+        return user.role() == UserRole.SECTION_ADMIN
+                && user.specialRoles() != null
+                && user.specialRoles().contains("SECTION_ADMIN:" + sectionId);
+    }
+
+    /**
+     * US-105/106/107/113: managing an existing event (update, cancel, delete, add/remove a
+     * video conference) is restricted to the event's creator or a SUPERADMIN. Having mere
+     * create-rights for the scope (another room LEADER, a section TEACHER, an ELTERNBEIRAT,
+     * a SECTION_ADMIN) is NOT sufficient.
+     */
+    private void checkManagePermission(CalendarEvent event, UUID userId) {
+        if (userId == null) {
+            throw new ForbiddenException("Authentication required");
+        }
+        if (userId.equals(event.getCreatedBy())) return;
+        if (isSuperAdmin(userId)) return;
+        throw new ForbiddenException("Only the event creator or a SUPERADMIN can manage this event");
     }
 
     private void checkCreatePermission(EventScope scope, UUID scopeId, UUID userId) {
@@ -370,18 +436,22 @@ public class CalendarService implements CalendarModuleApi {
             // pass null userId; those paths are already gated by their own callers.
             return;
         }
-        if (hasAdminRole(userId)) return;
+        // SUPERADMIN is a global admin and may read any event. SECTION_ADMIN is NOT a
+        // global admin (see hasAdminRoleForRoom / checkCreatePermission section-scoping):
+        // their access is evaluated per scope below.
+        if (isSuperAdmin(userId)) return;
 
         switch (event.getScope()) {
             case ROOM -> {
-                if (!roomModule.isUserInRoom(userId, event.getScopeId())) {
+                if (!hasAdminRoleForRoom(userId, event.getScopeId())
+                        && !roomModule.isUserInRoom(userId, event.getScopeId())) {
                     throw new IllegalArgumentException("User is not a member of this room");
                 }
             }
             case SECTION -> {
                 boolean inSection = roomModule.findByUserId(userId).stream()
                         .anyMatch(r -> event.getScopeId() != null && event.getScopeId().equals(r.sectionId()));
-                if (!inSection) {
+                if (!inSection && !administersSection(userId, event.getScopeId())) {
                     throw new IllegalArgumentException("User does not belong to this section");
                 }
             }

--- a/backend/src/main/java/com/monteweb/calendar/internal/service/CalendarService.java
+++ b/backend/src/main/java/com/monteweb/calendar/internal/service/CalendarService.java
@@ -73,7 +73,7 @@ public class CalendarService implements CalendarModuleApi {
     }
 
     public Page<EventInfo> getRoomEvents(UUID roomId, UUID userId, LocalDate from, LocalDate to, Pageable pageable) {
-        if (!isSuperAdmin(userId) && !roomModule.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRole(userId) && !roomModule.isUserInRoom(userId, roomId)) {
             throw new IllegalArgumentException("User is not a member of this room");
         }
         return eventRepository.findByRoomId(roomId, from, to, pageable)
@@ -298,9 +298,9 @@ public class CalendarService implements CalendarModuleApi {
                 .stream().map(e -> toEventInfo(e, null)).toList();
     }
 
-    private boolean isSuperAdmin(UUID userId) {
+    private boolean hasAdminRole(UUID userId) {
         return userModule.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN)
+                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
                 .orElse(false);
     }
 

--- a/backend/src/main/java/com/monteweb/calendar/internal/service/CalendarService.java
+++ b/backend/src/main/java/com/monteweb/calendar/internal/service/CalendarService.java
@@ -83,6 +83,7 @@ public class CalendarService implements CalendarModuleApi {
     public EventInfo getEvent(UUID eventId, UUID userId) {
         var event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("Event not found"));
+        checkReadAccess(event, userId);
         return toEventInfo(event, userId);
     }
 
@@ -184,6 +185,8 @@ public class CalendarService implements CalendarModuleApi {
         var event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("Event not found"));
 
+        checkReadAccess(event, userId);
+
         if (event.isCancelled()) {
             throw new IllegalStateException("Cannot RSVP to a cancelled event");
         }
@@ -236,6 +239,7 @@ public class CalendarService implements CalendarModuleApi {
     public EventInfo generateJitsiRoom(UUID eventId, UUID userId) {
         var event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new com.monteweb.shared.exception.ResourceNotFoundException("Event not found"));
+        checkReadAccess(event, userId);
         String shortId = eventId.toString().substring(0, 8);
         event.setJitsiRoomName("monteweb-event-" + shortId);
         eventRepository.save(event);
@@ -246,6 +250,7 @@ public class CalendarService implements CalendarModuleApi {
     public EventInfo removeJitsiRoom(UUID eventId, UUID userId) {
         var event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new com.monteweb.shared.exception.ResourceNotFoundException("Event not found"));
+        checkReadAccess(event, userId);
         event.setJitsiRoomName(null);
         eventRepository.save(event);
         return toEventInfo(event, userId);
@@ -325,12 +330,63 @@ public class CalendarService implements CalendarModuleApi {
                 }
             }
             case SECTION -> {
-                if (user.role() != UserRole.TEACHER && user.role() != UserRole.SECTION_ADMIN) {
+                if (scopeId == null) throw new IllegalArgumentException("Section ID required for SECTION scope");
+                if (user.role() == UserRole.SECTION_ADMIN) {
+                    // Section admins may only manage events for sections they actually administer
+                    if (user.specialRoles() == null
+                            || !user.specialRoles().contains("SECTION_ADMIN:" + scopeId)) {
+                        throw new IllegalArgumentException("You do not administer this section");
+                    }
+                } else if (user.role() == UserRole.TEACHER) {
+                    // The data model has no direct teacher->section assignment; derive section
+                    // membership from the teacher's rooms (a teacher in a room belonging to the
+                    // target section may manage that section's events).
+                    boolean inSection = roomModule.findByUserId(userId).stream()
+                            .anyMatch(r -> scopeId.equals(r.sectionId()));
+                    if (!inSection) {
+                        throw new IllegalArgumentException("You are not assigned to this section");
+                    }
+                } else {
                     throw new IllegalArgumentException("Only teachers or Elternbeirat can create section events");
                 }
             }
             case SCHOOL -> {
                 throw new IllegalArgumentException("Only admins can create school-wide events");
+            }
+        }
+    }
+
+    /**
+     * Ensures the user is allowed to read/interact with a single event based on its scope.
+     * Mirrors the membership guard used by getRoomEvents so a single-event-by-id path
+     * cannot be used to enumerate private ROOM/SECTION events (IDOR).
+     *  - SCHOOL events: readable by any authenticated user.
+     *  - ROOM events: admin role, or membership in the event's room.
+     *  - SECTION events: admin role, or membership in any room belonging to that section.
+     */
+    private void checkReadAccess(CalendarEvent event, UUID userId) {
+        if (userId == null) {
+            // Internal/system callers (toEventInfo passes null in *ModuleApi facade paths)
+            // pass null userId; those paths are already gated by their own callers.
+            return;
+        }
+        if (hasAdminRole(userId)) return;
+
+        switch (event.getScope()) {
+            case ROOM -> {
+                if (!roomModule.isUserInRoom(userId, event.getScopeId())) {
+                    throw new IllegalArgumentException("User is not a member of this room");
+                }
+            }
+            case SECTION -> {
+                boolean inSection = roomModule.findByUserId(userId).stream()
+                        .anyMatch(r -> event.getScopeId() != null && event.getScopeId().equals(r.sectionId()));
+                if (!inSection) {
+                    throw new IllegalArgumentException("User does not belong to this section");
+                }
+            }
+            case SCHOOL -> {
+                // school-wide events are visible to every authenticated user
             }
         }
     }

--- a/backend/src/main/java/com/monteweb/calendar/internal/service/ICalImportService.java
+++ b/backend/src/main/java/com/monteweb/calendar/internal/service/ICalImportService.java
@@ -44,7 +44,10 @@ public class ICalImportService {
         this.eventRepository = eventRepository;
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                // NEVER: redirects are followed manually so each hop is re-validated against
+                // the SSRF allow-list. NORMAL would follow a 30x to an internal host
+                // (cloud metadata, minio/postgres/redis, ...) without re-validation.
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build();
     }
 
@@ -72,6 +75,7 @@ public class ICalImportService {
     }
 
     private static final int MAX_RESPONSE_BYTES = 1024 * 1024; // 1 MB
+    private static final int MAX_REDIRECTS = 3;
 
     public void syncSubscription(UUID subId) {
         var subOpt = subscriptionRepository.findById(subId);
@@ -79,16 +83,37 @@ public class ICalImportService {
 
         var sub = subOpt.get();
         try {
-            // SSRF protection: block requests to private/internal networks
-            SsrfProtectionUtils.validateUrl(sub.getUrl());
-
-            var request = HttpRequest.newBuilder()
-                    .uri(URI.create(sub.getUrl()))
-                    .timeout(Duration.ofSeconds(10))
-                    .GET()
-                    .build();
-
-            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            // SSRF protection: follow redirects manually and re-validate EVERY hop
+            // (initial URL + each redirect target) so a public URL cannot 30x-redirect
+            // to a private/internal host (cloud metadata, minio/postgres/redis, ...).
+            HttpResponse<java.io.InputStream> response = null;
+            String currentUrl = sub.getUrl();
+            for (int redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+                SsrfProtectionUtils.validateUrl(currentUrl);
+                var uri = URI.create(currentUrl);
+                var request = HttpRequest.newBuilder()
+                        .uri(uri)
+                        .timeout(Duration.ofSeconds(10))
+                        .GET()
+                        .build();
+                var resp = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+                int status = resp.statusCode();
+                if (status >= 300 && status < 400) {
+                    var location = resp.headers().firstValue("Location").orElse(null);
+                    if (location == null || location.isBlank()) {
+                        log.warn("iCal fetch from {} returned a redirect with no Location header", currentUrl);
+                        return;
+                    }
+                    currentUrl = uri.resolve(location).toString();
+                    continue;
+                }
+                response = resp;
+                break;
+            }
+            if (response == null) {
+                log.warn("Too many redirects fetching iCal from {}", sub.getUrl());
+                return;
+            }
             if (response.statusCode() != 200) {
                 log.warn("Failed to fetch iCal from {}: HTTP {}", sub.getUrl(), response.statusCode());
                 return;

--- a/backend/src/main/java/com/monteweb/calendar/internal/service/ICalImportService.java
+++ b/backend/src/main/java/com/monteweb/calendar/internal/service/ICalImportService.java
@@ -19,6 +19,9 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
@@ -29,6 +32,7 @@ public class ICalImportService {
 
     private static final Logger log = LoggerFactory.getLogger(ICalImportService.class);
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter ICAL_DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
 
     private final ICalSubscriptionRepository subscriptionRepository;
     private final ICalEventRepository eventRepository;
@@ -182,18 +186,75 @@ public class ICalImportService {
                 pe.endDate = pe.startDate;
             }
         } else {
-            // DATETIME format: 20261225T180000 or 20261225T180000Z
+            // DATETIME format: 20261225T180000 (local), 20261225T180000Z (UTC),
+            // or with a TZID parameter (DTSTART;TZID=Europe/Berlin:20261225T180000).
             pe.allDay = false;
-            pe.startDate = LocalDate.parse(dtStart.substring(0, 8), DATE_FORMAT);
-            pe.startTime = dtStart.substring(9, 11) + ":" + dtStart.substring(11, 13);
+
+            ZoneId targetZone = ZoneId.systemDefault();
+
+            LocalDateTime start = toLocalDateTime(dtStart, extractTzid(block, "DTSTART"), targetZone);
+            pe.startDate = start.toLocalDate();
+            pe.startTime = formatTime(start);
 
             if (dtEnd != null && dtEnd.length() >= 13) {
-                pe.endDate = LocalDate.parse(dtEnd.substring(0, 8), DATE_FORMAT);
-                pe.endTime = dtEnd.substring(9, 11) + ":" + dtEnd.substring(11, 13);
+                LocalDateTime end = toLocalDateTime(dtEnd, extractTzid(block, "DTEND"), targetZone);
+                pe.endDate = end.toLocalDate();
+                pe.endTime = formatTime(end);
             } else {
                 pe.endDate = pe.startDate;
             }
         }
+    }
+
+    /**
+     * Converts an iCal date-time value into a {@link LocalDateTime} expressed in {@code targetZone}.
+     *  - Values ending in {@code Z} are UTC and are converted to the target zone.
+     *  - When a {@code TZID} is supplied, the value is interpreted in that zone and converted.
+     *  - Otherwise the value is treated as floating local time and returned unchanged.
+     */
+    private LocalDateTime toLocalDateTime(String value, String tzid, ZoneId targetZone) {
+        boolean utc = value.endsWith("Z");
+        String raw = utc ? value.substring(0, value.length() - 1) : value;
+        LocalDateTime local = LocalDateTime.parse(raw, ICAL_DATETIME_FORMAT);
+
+        if (utc) {
+            return local.atZone(ZoneOffset.UTC).withZoneSameInstant(targetZone).toLocalDateTime();
+        }
+        if (tzid != null) {
+            try {
+                return local.atZone(ZoneId.of(tzid)).withZoneSameInstant(targetZone).toLocalDateTime();
+            } catch (Exception e) {
+                // Unknown TZID -> fall back to treating the value as floating local time
+                log.debug("Unknown iCal TZID '{}', treating time as floating local", tzid);
+                return local;
+            }
+        }
+        return local;
+    }
+
+    private String formatTime(LocalDateTime dt) {
+        return String.format("%02d:%02d", dt.getHour(), dt.getMinute());
+    }
+
+    /**
+     * Extracts the {@code TZID} parameter for a given property from the raw VEVENT block,
+     * e.g. {@code DTSTART;TZID=Europe/Berlin:...} -> {@code Europe/Berlin}. Returns null if absent.
+     */
+    private String extractTzid(String block, String name) {
+        for (String line : block.split("\n")) {
+            line = line.trim();
+            if (line.startsWith(name + ";")) {
+                int colonIdx = line.indexOf(':');
+                String params = colonIdx >= 0 ? line.substring(name.length() + 1, colonIdx)
+                        : line.substring(name.length() + 1);
+                for (String param : params.split(";")) {
+                    if (param.startsWith("TZID=")) {
+                        return param.substring("TZID=".length()).trim();
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private String extractProperty(String block, String name) {

--- a/backend/src/main/java/com/monteweb/cleaning/internal/controller/CleaningAdminController.java
+++ b/backend/src/main/java/com/monteweb/cleaning/internal/controller/CleaningAdminController.java
@@ -119,10 +119,17 @@ public class CleaningAdminController {
     }
 
     @DeleteMapping("/slots/{id}")
-    public ResponseEntity<ApiResponse<Void>> cancelSlot(@PathVariable UUID id) {
+    public ResponseEntity<ApiResponse<Void>> cancelSlot(
+            @PathVariable UUID id,
+            @RequestParam(required = false) String reason,
+            @RequestBody(required = false) CancelSlotRequest body) {
         requireCleaningAdminFromSlot(id);
-        cleaningService.cancelSlot(id);
+        String cancelReason = (body != null && body.reason() != null) ? body.reason() : reason;
+        cleaningService.cancelSlot(id, cancelReason);
         return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    public record CancelSlotRequest(String reason) {
     }
 
     // ── QR Code ─────────────────────────────────────────────────────────

--- a/backend/src/main/java/com/monteweb/cleaning/internal/controller/CleaningController.java
+++ b/backend/src/main/java/com/monteweb/cleaning/internal/controller/CleaningController.java
@@ -8,9 +8,11 @@ import com.monteweb.shared.dto.ApiResponse;
 import com.monteweb.shared.dto.PageResponse;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import com.monteweb.shared.exception.BusinessException;
+import com.monteweb.shared.exception.ForbiddenException;
 import com.monteweb.shared.util.SecurityUtils;
 import com.monteweb.user.UserInfo;
 import com.monteweb.user.UserModuleApi;
+import com.monteweb.user.UserRole;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -92,6 +94,39 @@ public class CleaningController {
         return ResponseEntity.ok(ApiResponse.ok(cleaningService.getSwapOffers(id)));
     }
 
+    /**
+     * Section-wide (or, with no sectionId, global) list of upcoming slots that have an
+     * open swap offer, so other parents can discover slots to take over (US-230).
+     */
+    @GetMapping("/slots/swaps")
+    public ResponseEntity<ApiResponse<List<CleaningSlotInfo>>> getOpenSwapSlots(
+            @RequestParam(required = false) UUID sectionId) {
+        return ResponseEntity.ok(ApiResponse.ok(cleaningService.getOpenSwapSlots(sectionId)));
+    }
+
+    /**
+     * Take over a slot offered for swap by another participant (US-230 step 4).
+     */
+    @PostMapping("/slots/{id}/swap/take")
+    public ResponseEntity<ApiResponse<CleaningSlotInfo>> takeOverSwap(@PathVariable UUID id) {
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        UserInfo user = userModuleApi.findById(userId)
+                .orElseThrow(() -> new BusinessException("User not found"));
+        // SUPERADMIN, SECTION_ADMIN, TEACHER do not perform cleaning hours
+        if (user.role() == UserRole.SUPERADMIN
+                || user.role() == UserRole.SECTION_ADMIN
+                || user.role() == UserRole.TEACHER) {
+            throw new BusinessException("This role does not perform cleaning hours");
+        }
+        List<FamilyInfo> families = familyModuleApi.findByUserId(userId);
+        if (families.isEmpty()) {
+            throw new BusinessException("User must belong to a family to take over cleaning");
+        }
+        UUID familyId = families.get(0).id();
+        return ResponseEntity.ok(ApiResponse.ok(
+                cleaningService.takeOverSwap(id, userId, user.displayName(), familyId)));
+    }
+
     @PostMapping("/slots/{id}/checkin")
     public ResponseEntity<ApiResponse<CleaningSlotInfo>> checkIn(
             @PathVariable UUID id, @RequestBody CheckInRequest request) {
@@ -111,42 +146,21 @@ public class CleaningController {
 
     @GetMapping("/registrations/pending-confirmation")
     public ResponseEntity<ApiResponse<List<CleaningSlotInfo.RegistrationInfo>>> getPendingConfirmations() {
-        UUID userId = SecurityUtils.requireCurrentUserId();
-        var user = userModuleApi.findById(userId)
-                .orElseThrow(() -> new com.monteweb.shared.exception.ForbiddenException("User not found"));
-        if (user.role() != com.monteweb.user.UserRole.TEACHER
-                && user.role() != com.monteweb.user.UserRole.SECTION_ADMIN
-                && user.role() != com.monteweb.user.UserRole.SUPERADMIN) {
-            throw new com.monteweb.shared.exception.ForbiddenException("Not authorized");
-        }
+        requireCleaningAdmin();
         return ResponseEntity.ok(ApiResponse.ok(cleaningService.getPendingCleaningConfirmations()));
     }
 
     @PutMapping("/registrations/{registrationId}/confirm")
     public ResponseEntity<ApiResponse<CleaningSlotInfo.RegistrationInfo>> confirmRegistration(
             @PathVariable UUID registrationId) {
-        UUID userId = SecurityUtils.requireCurrentUserId();
-        var user = userModuleApi.findById(userId)
-                .orElseThrow(() -> new com.monteweb.shared.exception.ForbiddenException("User not found"));
-        if (user.role() != com.monteweb.user.UserRole.TEACHER
-                && user.role() != com.monteweb.user.UserRole.SECTION_ADMIN
-                && user.role() != com.monteweb.user.UserRole.SUPERADMIN) {
-            throw new com.monteweb.shared.exception.ForbiddenException("Not authorized");
-        }
+        UUID userId = requireCleaningAdmin();
         return ResponseEntity.ok(ApiResponse.ok(cleaningService.confirmCleaningRegistration(registrationId, userId)));
     }
 
     @PutMapping("/registrations/{registrationId}/reject")
     public ResponseEntity<ApiResponse<Void>> rejectRegistration(
             @PathVariable UUID registrationId) {
-        UUID userId = SecurityUtils.requireCurrentUserId();
-        var user = userModuleApi.findById(userId)
-                .orElseThrow(() -> new com.monteweb.shared.exception.ForbiddenException("User not found"));
-        if (user.role() != com.monteweb.user.UserRole.TEACHER
-                && user.role() != com.monteweb.user.UserRole.SECTION_ADMIN
-                && user.role() != com.monteweb.user.UserRole.SUPERADMIN) {
-            throw new com.monteweb.shared.exception.ForbiddenException("Not authorized");
-        }
+        requireCleaningAdmin();
         cleaningService.rejectCleaningRegistration(registrationId);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
@@ -155,10 +169,37 @@ public class CleaningController {
     public ResponseEntity<ApiResponse<CleaningSlotInfo.RegistrationInfo>> updateRegistrationMinutes(
             @PathVariable UUID registrationId,
             @Valid @RequestBody UpdateMinutesRequest request) {
-        UUID userId = SecurityUtils.requireCurrentUserId();
-        var result = cleaningService.updateRegistrationMinutes(registrationId, request.actualMinutes(), userId);
+        requireCleaningAdmin();
+        var result = cleaningService.updateRegistrationMinutes(registrationId, request.actualMinutes());
         return ResponseEntity.ok(ApiResponse.ok(result));
     }
 
     public record UpdateMinutesRequest(@Min(0) @Max(1440) int actualMinutes) {}
+
+    /**
+     * Authorizes the current user as a cleaning administrator. Accepts SUPERADMIN and
+     * SECTION_ADMIN role holders as well as the PUTZORGA / ELTERNBEIRAT / SECTION_ADMIN
+     * special roles (global or section-scoped). These registration-level actions are not
+     * tied to a single section, so any cleaning-admin scope is sufficient (US-231).
+     *
+     * @return the current user's id
+     */
+    private UUID requireCleaningAdmin() {
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        UserInfo user = userModuleApi.findById(userId)
+                .orElseThrow(() -> new ForbiddenException("User not found"));
+        if (user.role() == UserRole.SUPERADMIN || user.role() == UserRole.SECTION_ADMIN) {
+            return userId;
+        }
+        if (user.specialRoles() != null) {
+            for (String role : user.specialRoles()) {
+                if (role.equals("PUTZORGA") || role.equals("ELTERNBEIRAT")
+                        || role.startsWith("PUTZORGA:") || role.startsWith("ELTERNBEIRAT:")
+                        || role.startsWith("SECTION_ADMIN:")) {
+                    return userId;
+                }
+            }
+        }
+        throw new ForbiddenException("Not authorized to confirm cleaning hours");
+    }
 }

--- a/backend/src/main/java/com/monteweb/cleaning/internal/controller/CleaningController.java
+++ b/backend/src/main/java/com/monteweb/cleaning/internal/controller/CleaningController.java
@@ -11,6 +11,9 @@ import com.monteweb.shared.exception.BusinessException;
 import com.monteweb.shared.util.SecurityUtils;
 import com.monteweb.user.UserInfo;
 import com.monteweb.user.UserModuleApi;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -151,11 +154,11 @@ public class CleaningController {
     @PutMapping("/registrations/{registrationId}/update-minutes")
     public ResponseEntity<ApiResponse<CleaningSlotInfo.RegistrationInfo>> updateRegistrationMinutes(
             @PathVariable UUID registrationId,
-            @RequestBody UpdateMinutesRequest request) {
+            @Valid @RequestBody UpdateMinutesRequest request) {
         UUID userId = SecurityUtils.requireCurrentUserId();
         var result = cleaningService.updateRegistrationMinutes(registrationId, request.actualMinutes(), userId);
         return ResponseEntity.ok(ApiResponse.ok(result));
     }
 
-    public record UpdateMinutesRequest(int actualMinutes) {}
+    public record UpdateMinutesRequest(@Min(0) @Max(1440) int actualMinutes) {}
 }

--- a/backend/src/main/java/com/monteweb/cleaning/internal/repository/CleaningRegistrationRepository.java
+++ b/backend/src/main/java/com/monteweb/cleaning/internal/repository/CleaningRegistrationRepository.java
@@ -35,7 +35,7 @@ public interface CleaningRegistrationRepository extends JpaRepository<CleaningRe
     List<CleaningRegistration> findSwapOffersForSlot(@Param("slotId") UUID slotId);
 
     @Query("SELECT COUNT(r) FROM CleaningRegistration r JOIN CleaningSlot s ON r.slotId = s.id " +
-            "WHERE r.familyId = :familyId AND r.checkedOut = true " +
+            "WHERE r.familyId = :familyId AND r.checkedOut = true AND r.confirmed = true " +
             "AND s.slotDate BETWEEN :from AND :to")
     long countCompletedByFamilyInRange(@Param("familyId") UUID familyId,
                                        @Param("from") LocalDate from,
@@ -43,7 +43,7 @@ public interface CleaningRegistrationRepository extends JpaRepository<CleaningRe
 
     @Query("SELECT COALESCE(SUM(r.actualMinutes), 0) FROM CleaningRegistration r " +
             "JOIN CleaningSlot s ON r.slotId = s.id " +
-            "WHERE r.familyId = :familyId AND r.checkedOut = true " +
+            "WHERE r.familyId = :familyId AND r.checkedOut = true AND r.confirmed = true " +
             "AND s.slotDate BETWEEN :from AND :to")
     int sumActualMinutesByFamilyInRange(@Param("familyId") UUID familyId,
                                         @Param("from") LocalDate from,

--- a/backend/src/main/java/com/monteweb/cleaning/internal/repository/CleaningRegistrationRepository.java
+++ b/backend/src/main/java/com/monteweb/cleaning/internal/repository/CleaningRegistrationRepository.java
@@ -34,6 +34,15 @@ public interface CleaningRegistrationRepository extends JpaRepository<CleaningRe
     @Query("SELECT r FROM CleaningRegistration r WHERE r.slotId = :slotId AND r.swapOffered = true")
     List<CleaningRegistration> findSwapOffersForSlot(@Param("slotId") UUID slotId);
 
+    @Query("SELECT r FROM CleaningRegistration r WHERE r.swapOffered = true")
+    List<CleaningRegistration> findAllSwapOffers();
+
+    @Query("SELECT r FROM CleaningRegistration r JOIN CleaningSlot s ON r.slotId = s.id " +
+            "WHERE r.swapOffered = true AND s.sectionId = :sectionId AND s.slotDate >= :fromDate " +
+            "AND s.cancelled = false ORDER BY s.slotDate ASC")
+    List<CleaningRegistration> findUpcomingSwapOffersBySection(@Param("sectionId") UUID sectionId,
+                                                               @Param("fromDate") LocalDate fromDate);
+
     @Query("SELECT COUNT(r) FROM CleaningRegistration r JOIN CleaningSlot s ON r.slotId = s.id " +
             "WHERE r.familyId = :familyId AND r.checkedOut = true AND r.confirmed = true " +
             "AND s.slotDate BETWEEN :from AND :to")

--- a/backend/src/main/java/com/monteweb/cleaning/internal/service/CleaningService.java
+++ b/backend/src/main/java/com/monteweb/cleaning/internal/service/CleaningService.java
@@ -11,6 +11,8 @@ import com.monteweb.cleaning.internal.repository.CleaningSlotRepository;
 import com.monteweb.calendar.CalendarModuleApi;
 import com.monteweb.calendar.CreateEventRequest;
 import com.monteweb.calendar.EventScope;
+import com.monteweb.notification.NotificationModuleApi;
+import com.monteweb.notification.NotificationType;
 import com.monteweb.room.RoomModuleApi;
 import com.monteweb.school.SchoolModuleApi;
 import com.monteweb.school.SchoolSectionInfo;
@@ -58,6 +60,7 @@ public class CleaningService implements CleaningModuleApi {
     private final ApplicationEventPublisher eventPublisher;
     private final CalendarModuleApi calendarModuleApi;
     private final RoomModuleApi roomModuleApi;
+    private final NotificationModuleApi notificationModuleApi;
 
     public CleaningService(CleaningConfigRepository configRepository,
                            CleaningSlotRepository slotRepository,
@@ -66,7 +69,8 @@ public class CleaningService implements CleaningModuleApi {
                            SchoolModuleApi schoolModuleApi,
                            ApplicationEventPublisher eventPublisher,
                            @Autowired(required = false) CalendarModuleApi calendarModuleApi,
-                           @Autowired(required = false) RoomModuleApi roomModuleApi) {
+                           @Autowired(required = false) RoomModuleApi roomModuleApi,
+                           @Autowired(required = false) NotificationModuleApi notificationModuleApi) {
         this.configRepository = configRepository;
         this.slotRepository = slotRepository;
         this.registrationRepository = registrationRepository;
@@ -75,6 +79,7 @@ public class CleaningService implements CleaningModuleApi {
         this.eventPublisher = eventPublisher;
         this.calendarModuleApi = calendarModuleApi;
         this.roomModuleApi = roomModuleApi;
+        this.notificationModuleApi = notificationModuleApi;
     }
 
     // ── Config Management ───────────────────────────────────────────────
@@ -94,8 +99,16 @@ public class CleaningService implements CleaningModuleApi {
         config.setRoomId(request.roomId());
         if (request.participantCircle() != null) {
             config.setParticipantCircle(request.participantCircle());
+            config.setParticipantCircleId(request.participantCircleId());
+        } else if (request.roomId() != null) {
+            // Room-scoped config without an explicit circle: restrict registration to the
+            // room's members (US-235). Otherwise anyone in the section could register.
+            config.setParticipantCircle("ROOM");
+            config.setParticipantCircleId(request.participantCircleId() != null
+                    ? request.participantCircleId() : request.roomId());
+        } else {
+            config.setParticipantCircleId(request.participantCircleId());
         }
-        config.setParticipantCircleId(request.participantCircleId());
         if (request.specificDate() != null) {
             config.setSpecificDate(request.specificDate());
             config.setDayOfWeek(request.specificDate().getDayOfWeek().getValue());
@@ -362,11 +375,12 @@ public class CleaningService implements CleaningModuleApi {
         CleaningConfig config = configRepository.findById(slot.getConfigId())
                 .orElseThrow(() -> new ResourceNotFoundException("CleaningConfig", slot.getConfigId()));
         String circle = config.getParticipantCircle();
-        if (circle != null && !"SECTION".equals(circle)) {
-            if ("ROOM".equals(circle) && config.getParticipantCircleId() != null) {
-                if (roomModuleApi != null && !roomModuleApi.isUserInRoom(userId, config.getParticipantCircleId())) {
-                    throw new BusinessException("Registration restricted to members of the assigned room");
-                }
+        if ("ROOM".equals(circle)) {
+            UUID roomScopeId = config.getParticipantCircleId() != null
+                    ? config.getParticipantCircleId() : config.getRoomId();
+            if (roomScopeId != null && roomModuleApi != null
+                    && !roomModuleApi.isUserInRoom(userId, roomScopeId)) {
+                throw new BusinessException("Registration restricted to members of the assigned room");
             }
         }
 
@@ -427,6 +441,95 @@ public class CleaningService implements CleaningModuleApi {
         return registrationRepository.findSwapOffersForSlot(slotId).stream()
                 .map(this::toRegistrationInfo)
                 .toList();
+    }
+
+    /**
+     * Section-wide list of slots that currently have an open swap offer, so that other
+     * parents can discover and take over an offered slot (US-230). When sectionId is null,
+     * all upcoming swap offers are returned.
+     */
+    @Transactional(readOnly = true)
+    public List<CleaningSlotInfo> getOpenSwapSlots(UUID sectionId) {
+        List<CleaningRegistration> offers = (sectionId != null)
+                ? registrationRepository.findUpcomingSwapOffersBySection(sectionId, LocalDate.now())
+                : registrationRepository.findAllSwapOffers();
+        return offers.stream()
+                .map(CleaningRegistration::getSlotId)
+                .distinct()
+                .map(id -> slotRepository.findById(id).orElse(null))
+                .filter(s -> s != null && !s.isCancelled())
+                .map(s -> toSlotInfo(s, getConfigTitle(s.getConfigId())))
+                .toList();
+    }
+
+    /**
+     * Takes over a slot that another participant has offered for swap (US-230 step 4).
+     * The offered registration is transferred to the new user: the original registrant is
+     * released and the new user takes the spot. Hours will be credited to the new user's
+     * family on check-out.
+     */
+    @Transactional
+    public CleaningSlotInfo takeOverSwap(UUID slotId, UUID newUserId, String newUserName, UUID newFamilyId) {
+        CleaningSlot slot = slotRepository.findById(slotId)
+                .orElseThrow(() -> new ResourceNotFoundException("CleaningSlot", slotId));
+
+        if (slot.isCancelled()) {
+            throw new BusinessException("Cannot take over a swap for a cancelled slot");
+        }
+        if ("COMPLETED".equals(slot.getStatus()) || "IN_PROGRESS".equals(slot.getStatus())) {
+            throw new BusinessException("Cannot take over a swap for a slot that is already in progress or completed");
+        }
+        if (registrationRepository.existsBySlotIdAndUserId(slotId, newUserId)) {
+            throw new BusinessException("Already registered for this slot");
+        }
+
+        // Participant circle restriction also applies to the taker
+        CleaningConfig config = configRepository.findById(slot.getConfigId())
+                .orElseThrow(() -> new ResourceNotFoundException("CleaningConfig", slot.getConfigId()));
+        if ("ROOM".equals(config.getParticipantCircle())) {
+            UUID roomScopeId = config.getParticipantCircleId() != null
+                    ? config.getParticipantCircleId() : config.getRoomId();
+            if (roomScopeId != null && roomModuleApi != null
+                    && !roomModuleApi.isUserInRoom(newUserId, roomScopeId)) {
+                throw new BusinessException("Swap take-over restricted to members of the assigned room");
+            }
+        }
+
+        // Find the oldest open swap offer on this slot
+        CleaningRegistration offered = registrationRepository.findSwapOffersForSlot(slotId).stream()
+                .filter(r -> !r.isCheckedIn())
+                .findFirst()
+                .orElseThrow(() -> new BusinessException("No open swap offer for this slot"));
+
+        if (offered.getUserId().equals(newUserId)) {
+            throw new BusinessException("Cannot take over your own swap offer");
+        }
+
+        UUID previousUserId = offered.getUserId();
+        offered.setUserId(newUserId);
+        offered.setUserName(newUserName);
+        offered.setFamilyId(newFamilyId);
+        offered.setSwapOffered(false);
+        registrationRepository.save(offered);
+
+        // Notify the original registrant that their slot has been taken over
+        if (notificationModuleApi != null) {
+            try {
+                notificationModuleApi.sendNotification(
+                        previousUserId,
+                        NotificationType.SYSTEM,
+                        "Putzdienst übernommen",
+                        newUserName + " hat deinen angebotenen Putzdienst am "
+                                + slot.getSlotDate() + " übernommen.",
+                        "/cleaning",
+                        "CLEANING_SLOT",
+                        slotId);
+            } catch (Exception e) {
+                log.warn("Failed to notify user {} about swap take-over: {}", previousUserId, e.getMessage());
+            }
+        }
+
+        return toSlotInfo(slot, config.getTitle());
     }
 
     // ── Check-in / Check-out ────────────────────────────────────────────
@@ -536,16 +639,16 @@ public class CleaningService implements CleaningModuleApi {
     }
 
     /**
-     * Update actual minutes and confirm duration after checkout.
+     * Correct the recorded actual minutes for a participant and confirm the duration
+     * after check-out. Restricted to cleaning admins (US-232): the authorization check
+     * is enforced by the controller, so a Putz-Admin can correct another participant's
+     * minutes.
      */
     @Transactional
-    public CleaningSlotInfo.RegistrationInfo updateRegistrationMinutes(UUID registrationId, int actualMinutes, UUID userId) {
+    public CleaningSlotInfo.RegistrationInfo updateRegistrationMinutes(UUID registrationId, int actualMinutes) {
         CleaningRegistration reg = registrationRepository.findById(registrationId)
                 .orElseThrow(() -> new ResourceNotFoundException("CleaningRegistration", registrationId));
 
-        if (!reg.getUserId().equals(userId)) {
-            throw new BusinessException("Can only update own registration");
-        }
         if (!reg.isCheckedOut()) {
             throw new BusinessException("Must check out before confirming duration");
         }
@@ -623,11 +726,48 @@ public class CleaningService implements CleaningModuleApi {
 
     @Transactional
     public void cancelSlot(UUID slotId) {
+        cancelSlot(slotId, null);
+    }
+
+    /**
+     * Cancels a slot, records the cancellation reason, and notifies all registered
+     * participants (US-233).
+     */
+    @Transactional
+    public void cancelSlot(UUID slotId, String cancelReason) {
         CleaningSlot slot = slotRepository.findById(slotId)
                 .orElseThrow(() -> new ResourceNotFoundException("CleaningSlot", slotId));
+
+        boolean alreadyCancelled = slot.isCancelled();
         slot.setCancelled(true);
         slot.setStatus("CANCELLED");
+        if (cancelReason != null && !cancelReason.isBlank()) {
+            slot.setCancelReason(cancelReason.length() > 500 ? cancelReason.substring(0, 500) : cancelReason);
+        }
         slotRepository.save(slot);
+
+        // Notify registered participants once (not on repeated cancel calls)
+        if (!alreadyCancelled && notificationModuleApi != null) {
+            String configTitle = getConfigTitle(slot.getConfigId());
+            String message = "Der Putzdienst \"" + configTitle + "\" am " + slot.getSlotDate()
+                    + " wurde abgesagt."
+                    + (cancelReason != null && !cancelReason.isBlank() ? " Grund: " + cancelReason : "");
+            for (CleaningRegistration reg : registrationRepository.findBySlotId(slotId)) {
+                try {
+                    notificationModuleApi.sendNotification(
+                            reg.getUserId(),
+                            NotificationType.SYSTEM,
+                            "Putzdienst abgesagt",
+                            message,
+                            "/cleaning",
+                            "CLEANING_SLOT",
+                            slotId);
+                } catch (Exception e) {
+                    log.warn("Failed to notify user {} about slot cancellation: {}",
+                            reg.getUserId(), e.getMessage());
+                }
+            }
+        }
     }
 
     // ── Family Hours ────────────────────────────────────────────────────

--- a/backend/src/main/java/com/monteweb/cleaning/internal/service/CleaningService.java
+++ b/backend/src/main/java/com/monteweb/cleaning/internal/service/CleaningService.java
@@ -47,6 +47,9 @@ public class CleaningService implements CleaningModuleApi {
 
     private static final Logger log = LoggerFactory.getLogger(CleaningService.class);
 
+    /** Grace window added to the scheduled slot duration when capping measured check-out minutes. */
+    private static final long CHECKOUT_GRACE_MINUTES = 15;
+
     private final CleaningConfigRepository configRepository;
     private final CleaningSlotRepository slotRepository;
     private final CleaningRegistrationRepository registrationRepository;
@@ -486,14 +489,24 @@ public class CleaningService implements CleaningModuleApi {
         reg.setCheckedOut(true);
         reg.setCheckOutAt(java.time.Instant.now());
 
-        // Calculate actual minutes from check-in to check-out
-        int actualMinutes = (int) Duration.between(reg.getCheckInAt(), reg.getCheckOutAt()).toMinutes();
-        reg.setActualMinutes(actualMinutes);
-        registrationRepository.save(reg);
-
-        // Get hours credit from config
+        // Get hours credit + scheduled duration from config
         CleaningConfig config = configRepository.findById(slot.getConfigId()).orElse(null);
         BigDecimal hoursCredit = config != null ? config.getHoursCredit() : BigDecimal.ZERO;
+
+        // Calculate actual minutes from check-in to check-out, capped against the scheduled
+        // slot duration (+ grace window). Prevents a forgotten check-out from crediting the
+        // family with hundreds/thousands of minutes toward billing.
+        long rawMinutes = Duration.between(reg.getCheckInAt(), reg.getCheckOutAt()).toMinutes();
+        long capMinutes = rawMinutes;
+        if (config != null && config.getStartTime() != null && config.getEndTime() != null) {
+            long scheduledMinutes = Duration.between(config.getStartTime(), config.getEndTime()).toMinutes();
+            if (scheduledMinutes > 0) {
+                capMinutes = Math.min(rawMinutes, scheduledMinutes + CHECKOUT_GRACE_MINUTES);
+            }
+        }
+        int actualMinutes = (int) Math.max(0, capMinutes);
+        reg.setActualMinutes(actualMinutes);
+        registrationRepository.save(reg);
 
         // Check if all checked-in users have checked out -> complete slot
         List<CleaningRegistration> allRegs = registrationRepository.findBySlotId(slotId);

--- a/backend/src/main/java/com/monteweb/family/internal/controller/FamilyController.java
+++ b/backend/src/main/java/com/monteweb/family/internal/controller/FamilyController.java
@@ -75,7 +75,7 @@ public class FamilyController {
     }
 
     @PutMapping("/{id}/active")
-    @PreAuthorize("hasAnyRole('SUPERADMIN', 'SECTION_ADMIN')")
+    @PreAuthorize("hasRole('SUPERADMIN')")
     public ResponseEntity<ApiResponse<FamilyInfo>> setActive(
             @PathVariable UUID id,
             @RequestBody Map<String, Boolean> body) {
@@ -86,7 +86,7 @@ public class FamilyController {
     }
 
     @PutMapping("/{id}/hours-exempt")
-    @PreAuthorize("hasAnyRole('SUPERADMIN', 'SECTION_ADMIN')")
+    @PreAuthorize("hasRole('SUPERADMIN')")
     public ResponseEntity<ApiResponse<FamilyInfo>> setHoursExempt(
             @PathVariable UUID id,
             @RequestBody Map<String, Boolean> body) {

--- a/backend/src/main/java/com/monteweb/family/internal/service/FamilyService.java
+++ b/backend/src/main/java/com/monteweb/family/internal/service/FamilyService.java
@@ -125,6 +125,10 @@ public class FamilyService implements FamilyModuleApi {
             throw new BusinessException("Already a member of this family");
         }
 
+        // US-333: a parent may belong to only one Familienverbund. Joining via
+        // invite code always adds the user as a PARENT, so enforce the invariant here.
+        assertParentNotAlreadyInAnotherFamily(userId, family.getId());
+
         var member = new FamilyMember(family, userId, FamilyMemberRole.PARENT);
         family.getMembers().add(member);
         familyRepository.save(family);
@@ -265,7 +269,8 @@ public class FamilyService implements FamilyModuleApi {
 
     @Transactional
     public FamilyInfo setActive(UUID familyId, boolean active, UUID requestingUserId) {
-        assertAdminOrSectionAdmin(requestingUserId);
+        // US-337: only SUPERADMIN may toggle a family's active state.
+        assertSuperAdmin(requestingUserId);
         var family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new ResourceNotFoundException("Family", familyId));
         family.setActive(active);
@@ -332,6 +337,12 @@ public class FamilyService implements FamilyModuleApi {
             throw new BusinessException("Invitation is not pending");
         }
 
+        // US-333: a parent may belong to only one Familienverbund. Block accepting a
+        // PARENT-role invitation while the user is already a member of another family.
+        if (invitation.getRole() == FamilyMemberRole.PARENT) {
+            assertParentNotAlreadyInAnotherFamily(userId, invitation.getFamilyId());
+        }
+
         invitation.setStatus(FamilyInvitationStatus.ACCEPTED);
         invitation.setResolvedAt(Instant.now());
         invitationRepository.save(invitation);
@@ -383,6 +394,21 @@ public class FamilyService implements FamilyModuleApi {
         }
     }
 
+    /**
+     * US-333: A parent can belong to only one Familienverbund. This invariant is
+     * enforced on create() and must equally hold when a user joins another family
+     * as a PARENT (via invite code or by accepting a PARENT-role invitation).
+     * The target family is excluded so that the caller's own "already a member of
+     * this family" check remains the authority for re-joins.
+     */
+    private void assertParentNotAlreadyInAnotherFamily(UUID userId, UUID targetFamilyId) {
+        boolean inOtherFamily = familyRepository.findByMemberUserId(userId).stream()
+                .anyMatch(f -> !f.getId().equals(targetFamilyId));
+        if (inOtherFamily) {
+            throw new BusinessException("A parent can only belong to one family");
+        }
+    }
+
     private FamilyInvitationInfo toInvitationInfo(FamilyInvitation invitation) {
         String familyName = familyRepository.findById(invitation.getFamilyId())
                 .map(Family::getName).orElse("Unknown");
@@ -400,7 +426,8 @@ public class FamilyService implements FamilyModuleApi {
 
     @Transactional
     public FamilyInfo setHoursExempt(UUID familyId, boolean exempt, UUID requestingUserId) {
-        assertAdminOrSectionAdmin(requestingUserId);
+        // US-337: only SUPERADMIN may toggle a family's hours-exempt flag.
+        assertSuperAdmin(requestingUserId);
         var family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new ResourceNotFoundException("Family", familyId));
         family.setHoursExempt(exempt);
@@ -414,6 +441,17 @@ public class FamilyService implements FamilyModuleApi {
         if (user.role() != com.monteweb.user.UserRole.SUPERADMIN
                 && user.role() != com.monteweb.user.UserRole.SECTION_ADMIN) {
             throw new BusinessException("Only SUPERADMIN or SECTION_ADMIN can manage families");
+        }
+    }
+
+    /**
+     * US-337: hours-exempt and active toggles are reserved for SUPERADMIN only.
+     */
+    private void assertSuperAdmin(UUID userId) {
+        var user = userModuleApi.findById(userId)
+                .orElseThrow(() -> new BusinessException("User not found"));
+        if (user.role() != com.monteweb.user.UserRole.SUPERADMIN) {
+            throw new BusinessException("Only SUPERADMIN can perform this action");
         }
     }
 

--- a/backend/src/main/java/com/monteweb/family/internal/service/FamilyService.java
+++ b/backend/src/main/java/com/monteweb/family/internal/service/FamilyService.java
@@ -100,9 +100,7 @@ public class FamilyService implements FamilyModuleApi {
         var family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new ResourceNotFoundException("Family", familyId));
 
-        if (!familyRepository.isMember(requestingUserId, familyId)) {
-            throw new BusinessException("Not a member of this family");
-        }
+        assertParentMember(requestingUserId, family);
 
         String code = inviteCodeService.generateCode();
         family.setInviteCode(code);
@@ -139,9 +137,7 @@ public class FamilyService implements FamilyModuleApi {
         var family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new ResourceNotFoundException("Family", familyId));
 
-        if (!familyRepository.isMember(requestingUserId, familyId)) {
-            throw new BusinessException("Not a member of this family");
-        }
+        assertParentMember(requestingUserId, family);
 
         if (familyRepository.isMember(childUserId, familyId)) {
             throw new BusinessException("User is already a member of this family");
@@ -159,8 +155,26 @@ public class FamilyService implements FamilyModuleApi {
         var family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new ResourceNotFoundException("Family", familyId));
 
-        if (!familyRepository.isMember(requestingUserId, familyId)) {
-            throw new BusinessException("Not a member of this family");
+        // Only a PARENT member (or SUPERADMIN) may remove members — a CHILD must not be
+        // able to remove a PARENT and thereby orphan the Familienverbund.
+        assertParentMember(requestingUserId, family);
+
+        // Enforce the same last-parent-with-children invariant as leaveFamily():
+        // a family of children must always retain at least one responsible parent.
+        var target = family.getMembers().stream()
+                .filter(m -> m.getUserId().equals(memberUserId))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException("Member not found"));
+
+        if (target.getRole() == FamilyMemberRole.PARENT) {
+            long parentCount = family.getMembers().stream()
+                    .filter(m -> m.getRole() == FamilyMemberRole.PARENT)
+                    .count();
+            boolean hasChildren = family.getMembers().stream()
+                    .anyMatch(m -> m.getRole() == FamilyMemberRole.CHILD);
+            if (parentCount <= 1 && hasChildren) {
+                throw new BusinessException("Cannot remove the last parent while children exist in this family");
+            }
         }
 
         family.getMembers().removeIf(m -> m.getUserId().equals(memberUserId));
@@ -274,9 +288,8 @@ public class FamilyService implements FamilyModuleApi {
         var family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new ResourceNotFoundException("Family", familyId));
 
-        if (!familyRepository.isMember(inviterId, familyId)) {
-            throw new BusinessException("Not a member of this family");
-        }
+        assertParentMember(inviterId, family);
+
         if (familyRepository.isMember(inviteeId, familyId)) {
             throw new BusinessException("User is already a member of this family");
         }
@@ -402,6 +415,25 @@ public class FamilyService implements FamilyModuleApi {
                 && user.role() != com.monteweb.user.UserRole.SECTION_ADMIN) {
             throw new BusinessException("Only SUPERADMIN or SECTION_ADMIN can manage families");
         }
+    }
+
+    /**
+     * Ensures the requesting user is a PARENT member of the family (or a SUPERADMIN).
+     * CHILD members (typically STUDENT accounts) must not be able to manage the
+     * Familienverbund — generate invite codes, add children, invite or remove members.
+     */
+    private void assertParentMember(UUID userId, Family family) {
+        boolean isSuperAdmin = userModuleApi.findById(userId)
+                .map(u -> u.role() == com.monteweb.user.UserRole.SUPERADMIN)
+                .orElse(false);
+        if (isSuperAdmin) {
+            return;
+        }
+        family.getMembers().stream()
+                .filter(m -> m.getUserId().equals(userId))
+                .findFirst()
+                .filter(m -> m.getRole() == FamilyMemberRole.PARENT)
+                .orElseThrow(() -> new BusinessException("Only family parents can manage members"));
     }
 
     private FamilyInfo toFamilyInfo(Family family) {

--- a/backend/src/main/java/com/monteweb/feed/FeedModuleApi.java
+++ b/backend/src/main/java/com/monteweb/feed/FeedModuleApi.java
@@ -24,6 +24,15 @@ public interface FeedModuleApi {
      */
     FeedPostInfo createTargetedSystemPost(String title, String content, SourceType sourceType, UUID sourceId, List<UUID> targetUserIds);
 
+    /**
+     * Creates a pinned SYSTEM banner that may carry an optional click-through link,
+     * a banner type (INFO/WARNING/ACTION_REQUIRED) and an expiry. When {@code targetUserIds}
+     * is non-empty the banner is only shown to those users (e.g. context-dependent Putz-Banner
+     * for affected parents — US-081). Surfaced via GET /api/v1/feed/banners.
+     */
+    FeedPostInfo createSystemBanner(String title, String content, String link, String bannerType,
+                                    java.time.Instant expiresAt, List<UUID> targetUserIds);
+
     Optional<FeedPostInfo> findPostById(UUID postId);
 
     /**

--- a/backend/src/main/java/com/monteweb/feed/internal/controller/FeedController.java
+++ b/backend/src/main/java/com/monteweb/feed/internal/controller/FeedController.java
@@ -68,6 +68,7 @@ public class FeedController {
         UUID userId = SecurityUtils.requireCurrentUserId();
         var post = feedService.findPostById(id)
                 .orElseThrow(() -> new com.monteweb.shared.exception.ResourceNotFoundException("FeedPost", id));
+        feedService.verifyPostReadAccess(id, userId);
         return ResponseEntity.ok(ApiResponse.ok(enrichPost(post, userId)));
     }
 
@@ -99,6 +100,7 @@ public class FeedController {
             @PathVariable UUID id,
             @PageableDefault(size = 20) Pageable pageable) {
         UUID userId = SecurityUtils.requireCurrentUserId();
+        feedService.verifyPostReadAccess(id, userId);
         var page = feedService.getComments(id, pageable);
         var enriched = page.map(c -> enrichComment(c, userId));
         return ResponseEntity.ok(ApiResponse.ok(PageResponse.from(enriched)));
@@ -109,6 +111,7 @@ public class FeedController {
             @PathVariable UUID id,
             @Valid @RequestBody CreateCommentRequest request) {
         UUID userId = SecurityUtils.requireCurrentUserId();
+        feedService.verifyPostReadAccess(id, userId);
         var comment = feedService.addComment(id, userId, request.content());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(comment));
     }
@@ -203,6 +206,7 @@ public class FeedController {
             @PathVariable UUID roomId,
             @PageableDefault(size = 20) Pageable pageable) {
         UUID userId = SecurityUtils.requireCurrentUserId();
+        feedService.verifyRoomReadAccess(roomId, userId);
         var page = feedService.getPostsBySource(SourceType.ROOM, roomId, pageable);
         return ResponseEntity.ok(ApiResponse.ok(PageResponse.from(enrichPage(page, userId))));
     }

--- a/backend/src/main/java/com/monteweb/feed/internal/controller/FeedController.java
+++ b/backend/src/main/java/com/monteweb/feed/internal/controller/FeedController.java
@@ -48,8 +48,9 @@ public class FeedController {
     }
 
     @GetMapping("/banners")
-    public ResponseEntity<ApiResponse<List<FeedPostInfo>>> getActiveBanners() {
-        return ResponseEntity.ok(ApiResponse.ok(feedService.getActiveSystemBanners()));
+    public ResponseEntity<ApiResponse<List<SystemBannerResponse>>> getActiveBanners() {
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.ok(feedService.getActiveSystemBanners(userId)));
     }
 
     @PostMapping("/posts")
@@ -58,7 +59,7 @@ public class FeedController {
         var post = feedService.createPost(
                 userId, request.title(), request.content(),
                 request.sourceType(), request.sourceId(), request.parentOnly(),
-                request.poll()
+                request.poll(), request.targetUserIds()
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(post));
     }

--- a/backend/src/main/java/com/monteweb/feed/internal/dto/CreatePostRequest.java
+++ b/backend/src/main/java/com/monteweb/feed/internal/dto/CreatePostRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
 import java.util.UUID;
 
 public record CreatePostRequest(
@@ -13,6 +14,11 @@ public record CreatePostRequest(
         @NotNull SourceType sourceType,
         UUID sourceId,
         boolean parentOnly,
-        @Valid CreatePollRequest poll
+        @Valid CreatePollRequest poll,
+        /**
+         * Optional: restrict this post to the given users only (US-080).
+         * When non-empty, only the listed users (plus the author/admins) can read it.
+         */
+        @Size(max = 500) List<UUID> targetUserIds
 ) {
 }

--- a/backend/src/main/java/com/monteweb/feed/internal/model/FeedPost.java
+++ b/backend/src/main/java/com/monteweb/feed/internal/model/FeedPost.java
@@ -56,6 +56,14 @@ public class FeedPost {
     @Column(name = "expires_at")
     private Instant expiresAt;
 
+    /** Optional click-through link for SYSTEM banners (US-081). */
+    @Column(length = 1000)
+    private String link;
+
+    /** Banner severity/type for SYSTEM banners: INFO, WARNING, ACTION_REQUIRED. */
+    @Column(name = "banner_type", length = 30)
+    private String bannerType;
+
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("sortOrder ASC")
     private List<FeedPostAttachment> attachments = new ArrayList<>();

--- a/backend/src/main/java/com/monteweb/feed/internal/service/CalendarFeedListener.java
+++ b/backend/src/main/java/com/monteweb/feed/internal/service/CalendarFeedListener.java
@@ -4,8 +4,7 @@ import com.monteweb.calendar.EventCancelledEvent;
 import com.monteweb.calendar.EventDeletedEvent;
 import com.monteweb.feed.FeedModuleApi;
 import com.monteweb.feed.SourceType;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
 /**
@@ -22,8 +21,7 @@ public class CalendarFeedListener {
         this.feedModule = feedModule;
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onEventCancelled(EventCancelledEvent event) {
         String title = "Termin abgesagt: " + event.eventTitle();
         String content = event.cancellerName() + " hat den Termin \"" + event.eventTitle() + "\" abgesagt.";
@@ -31,8 +29,7 @@ public class CalendarFeedListener {
         feedModule.createSystemPost(title, content, SourceType.SCHOOL, null);
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onEventDeleted(EventDeletedEvent event) {
         if (event.attendingUserIds() == null || event.attendingUserIds().isEmpty()) {
             return;

--- a/backend/src/main/java/com/monteweb/feed/internal/service/FeedService.java
+++ b/backend/src/main/java/com/monteweb/feed/internal/service/FeedService.java
@@ -67,6 +67,79 @@ public class FeedService implements FeedModuleApi {
         this.eventPublisher = eventPublisher;
     }
 
+    // --- Helpers ---
+
+    /**
+     * Treats both SUPERADMIN and SECTION_ADMIN as administrators, matching the
+     * convention used across the codebase (e.g. RoomChatService, DiscussionThreadService).
+     */
+    private boolean hasAdminRole(UserInfo user) {
+        return user != null && (user.role() == UserRole.SUPERADMIN || user.role() == UserRole.SECTION_ADMIN);
+    }
+
+    private boolean hasAdminRole(UUID userId) {
+        return userModuleApi.findById(userId).map(this::hasAdminRole).orElse(false);
+    }
+
+    /**
+     * Verifies that the given user may read the given post.
+     * Mirrors the personal-feed visibility rules: targetUserIds, parentOnly (students blocked),
+     * and room membership. Author and admins always have access.
+     */
+    public void verifyPostReadAccess(FeedPost post, UUID userId) {
+        var user = userModuleApi.findById(userId).orElse(null);
+
+        // Author and admins always have access
+        if (post.getAuthorId().equals(userId) || hasAdminRole(user)) {
+            return;
+        }
+
+        // targetUserIds — if set, only listed users (besides author/admin) can access
+        if (post.getTargetUserIds() != null && post.getTargetUserIds().length > 0) {
+            boolean isTarget = false;
+            for (UUID targetId : post.getTargetUserIds()) {
+                if (targetId.equals(userId)) {
+                    isTarget = true;
+                    break;
+                }
+            }
+            if (!isTarget) {
+                throw new ForbiddenException("You do not have access to this post");
+            }
+        }
+
+        // parentOnly — students cannot access parent-only posts
+        if (post.isParentOnly() && user != null && user.role() == UserRole.STUDENT) {
+            throw new ForbiddenException("You do not have access to this post");
+        }
+
+        // Room membership if post is room-scoped
+        if (post.getSourceType() == com.monteweb.feed.SourceType.ROOM && post.getSourceId() != null) {
+            if (!roomModuleApi.isUserInRoom(userId, post.getSourceId())) {
+                throw new ForbiddenException("You do not have access to this post");
+            }
+        }
+    }
+
+    /**
+     * Loads the post by id and verifies the given user may read it.
+     * Throws ResourceNotFoundException if the post does not exist, ForbiddenException if access is denied.
+     */
+    public void verifyPostReadAccess(UUID postId, UUID userId) {
+        var post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("FeedPost", postId));
+        verifyPostReadAccess(post, userId);
+    }
+
+    /**
+     * Verifies the given user may read posts of the given room (membership or admin).
+     */
+    public void verifyRoomReadAccess(UUID roomId, UUID userId) {
+        if (!hasAdminRole(userId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
+            throw new ForbiddenException("Not a member of this room");
+        }
+    }
+
     // --- Public API (FeedModuleApi) ---
 
     @Override
@@ -189,9 +262,11 @@ public class FeedService implements FeedModuleApi {
         }
 
         String authorName = userModuleApi.findById(authorId).map(UserInfo::displayName).orElse("Unknown");
+        // Covers all three valid post shapes (content, poll, title-only) without NPE
+        String eventBody = content != null ? content : (pollRequest != null ? pollRequest.question() : title);
         eventPublisher.publishEvent(new FeedPostCreatedEvent(
                 post.getId(), authorId, authorName, title,
-                content != null ? content : pollRequest.question(),
+                eventBody,
                 sourceType, sourceId
         ));
 
@@ -262,7 +337,7 @@ public class FeedService implements FeedModuleApi {
         // Only author or admin can close
         var user = userModuleApi.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User", userId));
-        if (!post.getAuthorId().equals(userId) && user.role() != UserRole.SUPERADMIN) {
+        if (!post.getAuthorId().equals(userId) && !hasAdminRole(user)) {
             throw new ForbiddenException("Only the author or admin can close this poll");
         }
 
@@ -295,7 +370,7 @@ public class FeedService implements FeedModuleApi {
         var user = userModuleApi.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User", userId));
 
-        if (!post.getAuthorId().equals(userId) && user.role() != UserRole.SUPERADMIN) {
+        if (!post.getAuthorId().equals(userId) && !hasAdminRole(user)) {
             throw new ForbiddenException("Only the author or admin can delete this post");
         }
         // Clean up attachment files from storage
@@ -314,7 +389,7 @@ public class FeedService implements FeedModuleApi {
         if (!post.getAuthorId().equals(userId)) {
             var user = userModuleApi.findById(userId)
                     .orElseThrow(() -> new ResourceNotFoundException("User", userId));
-            if (user.role() != UserRole.SUPERADMIN) {
+            if (!hasAdminRole(user)) {
                 throw new ForbiddenException("Only the author or admin can add attachments");
             }
         }
@@ -368,9 +443,9 @@ public class FeedService implements FeedModuleApi {
                 }
             }
             if (!isTarget) {
-                // Allow author and SUPERADMIN
+                // Allow author and admins
                 var user = userModuleApi.findById(userId).orElse(null);
-                if (!post.getAuthorId().equals(userId) && (user == null || user.role() != UserRole.SUPERADMIN)) {
+                if (!post.getAuthorId().equals(userId) && !hasAdminRole(user)) {
                     throw new ForbiddenException("You do not have access to this attachment");
                 }
             }
@@ -387,9 +462,9 @@ public class FeedService implements FeedModuleApi {
         // Check room membership if post is room-scoped
         if (post.getSourceType() == com.monteweb.feed.SourceType.ROOM && post.getSourceId() != null) {
             if (!roomModuleApi.isUserInRoom(userId, post.getSourceId())) {
-                // Allow SUPERADMIN
+                // Allow admins
                 var user = userModuleApi.findById(userId).orElse(null);
-                if (user == null || user.role() != UserRole.SUPERADMIN) {
+                if (!hasAdminRole(user)) {
                     throw new ForbiddenException("You do not have access to this attachment");
                 }
             }
@@ -408,7 +483,7 @@ public class FeedService implements FeedModuleApi {
         if (!post.getAuthorId().equals(userId)) {
             var user = userModuleApi.findById(userId)
                     .orElseThrow(() -> new ResourceNotFoundException("User", userId));
-            if (user.role() != UserRole.SUPERADMIN) {
+            if (!hasAdminRole(user)) {
                 throw new ForbiddenException("Only the author or admin can delete attachments");
             }
         }
@@ -421,7 +496,18 @@ public class FeedService implements FeedModuleApi {
     public FeedPostInfo togglePin(UUID postId, UUID userId) {
         var post = postRepository.findById(postId)
                 .orElseThrow(() -> new ResourceNotFoundException("FeedPost", postId));
+
         // Only room leaders or admins can pin
+        boolean allowed = hasAdminRole(userId);
+        if (!allowed && post.getSourceType() == com.monteweb.feed.SourceType.ROOM && post.getSourceId() != null) {
+            allowed = roomModuleApi.getUserRoleInRoom(userId, post.getSourceId())
+                    .map(role -> role == com.monteweb.room.RoomRole.LEADER)
+                    .orElse(false);
+        }
+        if (!allowed) {
+            throw new ForbiddenException("Only room leaders or admins can pin posts");
+        }
+
         post.setPinned(!post.isPinned());
         return toPostInfo(postRepository.save(post));
     }

--- a/backend/src/main/java/com/monteweb/feed/internal/service/FeedService.java
+++ b/backend/src/main/java/com/monteweb/feed/internal/service/FeedService.java
@@ -86,6 +86,22 @@ public class FeedService implements FeedModuleApi {
     }
 
     /**
+     * Staff = teaching/administrative roles. Parents and students are NOT staff.
+     * Used to gate feed-post creation (US-070/US-071: PARENT/STUDENT cannot author posts).
+     */
+    private boolean isStaff(UserInfo user) {
+        return user != null && (user.role() == UserRole.SUPERADMIN
+                || user.role() == UserRole.SECTION_ADMIN
+                || user.role() == UserRole.TEACHER);
+    }
+
+    private boolean isRoomLeader(UUID userId, UUID roomId) {
+        return roomModuleApi.getUserRoleInRoom(userId, roomId)
+                .map(role -> role == com.monteweb.room.RoomRole.LEADER)
+                .orElse(false);
+    }
+
+    /**
      * Verifies that the given user may read the given post.
      * Mirrors the personal-feed visibility rules: targetUserIds, parentOnly (students blocked),
      * and room membership. Author and admins always have access.
@@ -176,6 +192,26 @@ public class FeedService implements FeedModuleApi {
     }
 
     @Override
+    @Transactional
+    public FeedPostInfo createSystemBanner(String title, String content, String link, String bannerType,
+                                           Instant expiresAt, List<UUID> targetUserIds) {
+        var post = new FeedPost();
+        post.setAuthorId(UUID.fromString("00000000-0000-0000-0000-000000000000")); // system user
+        post.setTitle(title);
+        // Banners always carry a message; fall back to the title for content-less banners.
+        post.setContent(content != null && !content.isBlank() ? content : title);
+        post.setSourceType(SourceType.SYSTEM);
+        post.setPinned(true);
+        post.setLink(link);
+        post.setBannerType(bannerType != null ? bannerType : "INFO");
+        post.setExpiresAt(expiresAt);
+        if (targetUserIds != null && !targetUserIds.isEmpty()) {
+            post.setTargetUserIds(targetUserIds.toArray(new UUID[0]));
+        }
+        return toPostInfo(postRepository.save(post));
+    }
+
+    @Override
     public Optional<FeedPostInfo> findPostById(UUID postId) {
         return postRepository.findById(postId).map(this::toPostInfo);
     }
@@ -221,32 +257,57 @@ public class FeedService implements FeedModuleApi {
     @Transactional
     public FeedPostInfo createPost(UUID authorId, String title, String content,
                                    SourceType sourceType, UUID sourceId, boolean parentOnly) {
-        return createPost(authorId, title, content, sourceType, sourceId, parentOnly, null);
+        return createPost(authorId, title, content, sourceType, sourceId, parentOnly, null, null);
     }
 
     @Transactional
     public FeedPostInfo createPost(UUID authorId, String title, String content,
                                    SourceType sourceType, UUID sourceId, boolean parentOnly,
                                    CreatePollRequest pollRequest) {
-        // Validate: must have content, poll, or title (for attachment-only posts)
-        if ((content == null || content.isBlank()) && pollRequest == null && (title == null || title.isBlank())) {
-            throw new BusinessException("Post must have content, title, or a poll");
+        return createPost(authorId, title, content, sourceType, sourceId, parentOnly, pollRequest, null);
+    }
+
+    @Transactional
+    public FeedPostInfo createPost(UUID authorId, String title, String content,
+                                   SourceType sourceType, UUID sourceId, boolean parentOnly,
+                                   CreatePollRequest pollRequest, List<UUID> targetUserIds) {
+        // Validate: must have content or a poll. A title alone is NOT sufficient
+        // (US-086: "Titel allein reicht nicht aus"). Attachments are added after
+        // creation, so a content/poll requirement here does not block attachment-only
+        // posts — those are created with content and then enriched with files.
+        if ((content == null || content.isBlank()) && pollRequest == null) {
+            throw new BusinessException("Post must have content or a poll");
         }
+
+        var author = userModuleApi.findById(authorId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", authorId));
 
         // Validate author can post to this source
         if (sourceType == SourceType.ROOM && sourceId != null) {
             if (!roomModuleApi.isUserInRoom(authorId, sourceId)) {
                 throw new ForbiddenException("Not a member of this room");
             }
+            // US-070/US-071: only staff (TEACHER/SECTION_ADMIN/SUPERADMIN) or the
+            // room's LEADER may author room feed posts. Plain PARENT/STUDENT members
+            // can read but not create posts.
+            if (!isStaff(author) && !isRoomLeader(authorId, sourceId)) {
+                throw new ForbiddenException("Only teachers, admins or room leaders can create room posts");
+            }
         }
-        if (sourceType == SourceType.SCHOOL || sourceType == SourceType.SECTION) {
-            var user = userModuleApi.findById(authorId)
-                    .orElseThrow(() -> new ResourceNotFoundException("User", authorId));
-            boolean isStaff = user.role() == UserRole.SUPERADMIN || user.role() == UserRole.SECTION_ADMIN || user.role() == UserRole.TEACHER;
-            boolean isElternbeirat = user.specialRoles() != null && (user.specialRoles().contains("ELTERNBEIRAT")
-                    || (sourceId != null && user.specialRoles().contains("ELTERNBEIRAT:" + sourceId)));
-            if (!isStaff && !isElternbeirat) {
-                throw new ForbiddenException("Only staff or Elternbeirat can create school-wide or section posts");
+        if (sourceType == SourceType.SCHOOL) {
+            // US-087: school-wide posts are restricted to admins (SUPERADMIN/SECTION_ADMIN).
+            // Elternbeirat keeps its dedicated school-wide posting capability.
+            boolean isElternbeirat = author.specialRoles() != null && author.specialRoles().contains("ELTERNBEIRAT");
+            if (!hasAdminRole(author) && !isElternbeirat) {
+                throw new ForbiddenException("Only admins or Elternbeirat can create school-wide posts");
+            }
+        }
+        if (sourceType == SourceType.SECTION) {
+            // Section posts: staff or the section's Elternbeirat (mirrors calendar SECTION rule).
+            boolean isElternbeirat = author.specialRoles() != null && (author.specialRoles().contains("ELTERNBEIRAT")
+                    || (sourceId != null && author.specialRoles().contains("ELTERNBEIRAT:" + sourceId)));
+            if (!isStaff(author) && !isElternbeirat) {
+                throw new ForbiddenException("Only staff or Elternbeirat can create section posts");
             }
         }
 
@@ -257,6 +318,12 @@ public class FeedService implements FeedModuleApi {
         post.setSourceType(sourceType);
         post.setSourceId(sourceId);
         post.setParentOnly(parentOnly);
+        // US-080: optional per-user targeting. Only the listed users (plus author/admins)
+        // can read the post; visibility is enforced by the personal-feed query and
+        // verifyPostReadAccess/verifyPostAccess.
+        if (targetUserIds != null && !targetUserIds.isEmpty()) {
+            post.setTargetUserIds(targetUserIds.toArray(new UUID[0]));
+        }
 
         post = postRepository.save(post);
 
@@ -265,9 +332,10 @@ public class FeedService implements FeedModuleApi {
             createFeedPoll(post.getId(), pollRequest);
         }
 
-        String authorName = userModuleApi.findById(authorId).map(UserInfo::displayName).orElse("Unknown");
-        // Covers all three valid post shapes (content, poll, title-only) without NPE
-        String eventBody = content != null ? content : (pollRequest != null ? pollRequest.question() : title);
+        String authorName = author.displayName();
+        // A post always has content or a poll at this point (title-only is rejected above).
+        String eventBody = content != null && !content.isBlank() ? content
+                : (pollRequest != null ? pollRequest.question() : title);
         eventPublisher.publishEvent(new FeedPostCreatedEvent(
                 post.getId(), authorId, authorName, title,
                 eventBody,
@@ -555,10 +623,39 @@ public class FeedService implements FeedModuleApi {
                 .map(this::toPostInfo);
     }
 
-    public List<FeedPostInfo> getActiveSystemBanners() {
+    /**
+     * Returns active (non-expired, pinned) SYSTEM banners as banner DTOs that carry
+     * the optional click-through link, banner type and expiry (US-081).
+     *
+     * <p>Targeted banners (target_user_ids set) are only returned to the listed users,
+     * so a context-dependent banner (e.g. Putz reminder for affected parents) does not
+     * leak to everyone.
+     */
+    public List<com.monteweb.feed.internal.dto.SystemBannerResponse> getActiveSystemBanners(UUID userId) {
         return postRepository.findActiveSystemBanners().stream()
-                .map(this::toPostInfo)
+                .filter(p -> isBannerVisibleTo(p, userId))
+                .map(p -> new com.monteweb.feed.internal.dto.SystemBannerResponse(
+                        p.getId(),
+                        p.getTitle(),
+                        p.getContent(),
+                        p.getBannerType() != null ? p.getBannerType() : "INFO",
+                        p.getLink(),
+                        p.getExpiresAt()
+                ))
                 .toList();
+    }
+
+    private boolean isBannerVisibleTo(FeedPost banner, UUID userId) {
+        UUID[] targets = banner.getTargetUserIds();
+        if (targets == null || targets.length == 0) {
+            return true; // global banner
+        }
+        for (UUID target : targets) {
+            if (target.equals(userId)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // --- Reactions ---

--- a/backend/src/main/java/com/monteweb/feed/internal/service/FeedService.java
+++ b/backend/src/main/java/com/monteweb/feed/internal/service/FeedService.java
@@ -9,6 +9,7 @@ import com.monteweb.room.RoomModuleApi;
 import com.monteweb.shared.exception.BusinessException;
 import com.monteweb.shared.exception.ForbiddenException;
 import com.monteweb.shared.exception.ResourceNotFoundException;
+import com.monteweb.shared.util.ClamAvService;
 import com.monteweb.shared.util.FileValidationUtils;
 import com.monteweb.user.UserInfo;
 import com.monteweb.user.UserModuleApi;
@@ -44,6 +45,7 @@ public class FeedService implements FeedModuleApi {
     private final UserModuleApi userModuleApi;
     private final RoomModuleApi roomModuleApi;
     private final ApplicationEventPublisher eventPublisher;
+    private final ClamAvService clamAvService;
 
     public FeedService(FeedPostRepository postRepository,
                        FeedPostCommentRepository commentRepository,
@@ -54,7 +56,8 @@ public class FeedService implements FeedModuleApi {
                        FeedStorageService storageService,
                        UserModuleApi userModuleApi,
                        RoomModuleApi roomModuleApi,
-                       ApplicationEventPublisher eventPublisher) {
+                       ApplicationEventPublisher eventPublisher,
+                       ClamAvService clamAvService) {
         this.postRepository = postRepository;
         this.commentRepository = commentRepository;
         this.attachmentRepository = attachmentRepository;
@@ -65,6 +68,7 @@ public class FeedService implements FeedModuleApi {
         this.userModuleApi = userModuleApi;
         this.roomModuleApi = roomModuleApi;
         this.eventPublisher = eventPublisher;
+        this.clamAvService = clamAvService;
     }
 
     // --- Helpers ---
@@ -404,6 +408,16 @@ public class FeedService implements FeedModuleApi {
             }
             // Detect actual content type via magic bytes instead of trusting client header
             String detectedContentType = FileValidationUtils.detectContentType(file);
+
+            // Virus scan before storing (no-op unless the 'clamav' module toggle is enabled).
+            try {
+                ClamAvService.ScanResult scan = clamAvService.scan(file.getBytes());
+                if (!scan.isClean()) {
+                    throw new BusinessException("File rejected: malware detected (" + scan.virusName() + ")");
+                }
+            } catch (java.io.IOException e) {
+                throw new BusinessException("Could not read the uploaded file for virus scanning");
+            }
 
             var attachment = new FeedPostAttachment();
             attachment.setPost(post);

--- a/backend/src/main/java/com/monteweb/feed/internal/service/LinkPreviewService.java
+++ b/backend/src/main/java/com/monteweb/feed/internal/service/LinkPreviewService.java
@@ -77,10 +77,15 @@ public class LinkPreviewService {
     private final HttpClient httpClient;
     private final ConcurrentHashMap<String, CachedPreview> cache = new ConcurrentHashMap<>();
 
+    private static final int MAX_REDIRECTS = 3;
+
     public LinkPreviewService() {
+        // NEVER: redirects are followed manually so each hop is re-validated against
+        // the SSRF allow-list. HttpClient.Redirect.NORMAL would follow 30x to internal
+        // hosts (cloud metadata, postgres/redis/minio/...) without re-validation.
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(FETCH_TIMEOUT)
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build();
     }
 
@@ -96,33 +101,54 @@ public class LinkPreviewService {
         }
 
         try {
-            // SSRF protection: block private/internal IPs and non-HTTP schemes
-            SsrfProtectionUtils.validateUrl(url);
+            String currentUrl = url;
+            for (int redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+                // SSRF protection: re-validate EVERY hop (initial URL + each redirect target)
+                // to block private/internal IPs, cloud metadata and non-HTTP schemes.
+                SsrfProtectionUtils.validateUrl(currentUrl);
 
-            var uri = URI.create(url);
+                var uri = URI.create(currentUrl);
+                if (!isAllowedHost(uri)) {
+                    log.debug("Blocked link preview for internal/private host: {}", uri.getHost());
+                    return null;
+                }
 
-            if (!isAllowedHost(uri)) {
-                log.debug("Blocked link preview for internal/private host: {}", uri.getHost());
+                var request = HttpRequest.newBuilder()
+                        .uri(uri)
+                        .timeout(FETCH_TIMEOUT)
+                        .header("User-Agent", "MonteWeb/1.0 LinkPreview")
+                        .header("Accept", "text/html")
+                        .GET()
+                        .build();
+
+                var response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+                int status = response.statusCode();
+
+                // Handle redirects manually so the target is re-validated above
+                if (status >= 300 && status < 400) {
+                    var location = response.headers().firstValue("Location").orElse(null);
+                    if (location == null || location.isBlank()) {
+                        return null;
+                    }
+                    // Resolve relative redirects against the current URI
+                    URI nextUri = uri.resolve(location);
+                    currentUrl = nextUri.toString();
+                    continue;
+                }
+
+                if (status >= 200 && status < 300) {
+                    // Limit response body to prevent OOM
+                    var html = SsrfProtectionUtils.readLimited(response.body(), MAX_RESPONSE_BYTES);
+                    // Cache/return under the originally requested url
+                    var preview = parseOpenGraph(url, html);
+                    putCache(url, preview);
+                    return preview;
+                }
+
+                // Non-redirect, non-success status: give up
                 return null;
             }
-
-            var request = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .timeout(FETCH_TIMEOUT)
-                    .header("User-Agent", "MonteWeb/1.0 LinkPreview")
-                    .header("Accept", "text/html")
-                    .GET()
-                    .build();
-
-            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
-
-            if (response.statusCode() >= 200 && response.statusCode() < 400) {
-                // Limit response body to prevent OOM
-                var html = SsrfProtectionUtils.readLimited(response.body(), MAX_RESPONSE_BYTES);
-                var preview = parseOpenGraph(url, html);
-                putCache(url, preview);
-                return preview;
-            }
+            log.debug("Too many redirects fetching link preview for {}", url);
         } catch (IllegalArgumentException e) {
             log.debug("URL blocked by SSRF protection: {}: {}", url, e.getMessage());
         } catch (Exception e) {

--- a/backend/src/main/java/com/monteweb/files/internal/service/FileService.java
+++ b/backend/src/main/java/com/monteweb/files/internal/service/FileService.java
@@ -282,14 +282,14 @@ public class FileService implements FilesModuleApi {
 
     // ---- Helpers ----
 
-    private boolean isSuperAdmin(UUID userId) {
+    private boolean hasAdminRole(UUID userId) {
         return userModuleApi.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN)
+                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
                 .orElse(false);
     }
 
     private void requireRoomMembership(UUID userId, UUID roomId) {
-        if (!isSuperAdmin(userId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRole(userId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("You are not a member of this room");
         }
     }

--- a/backend/src/main/java/com/monteweb/files/internal/service/FileService.java
+++ b/backend/src/main/java/com/monteweb/files/internal/service/FileService.java
@@ -196,8 +196,8 @@ public class FileService implements FilesModuleApi {
                 .filter(f -> f.getRoomId().equals(roomId))
                 .orElseThrow(() -> new ResourceNotFoundException("File", fileId));
 
-        // Only uploader or room leaders can delete
-        if (!roomFile.getUploadedBy().equals(userId)) {
+        // Only uploader, room leaders, or admins (SUPERADMIN/SECTION_ADMIN) can delete
+        if (!roomFile.getUploadedBy().equals(userId) && !hasAdminRole(userId)) {
             var role = roomModuleApi.getUserRoleInRoom(userId, roomId);
             if (role.isEmpty() || !"LEADER".equals(role.get().name())) {
                 throw new ForbiddenException("Only the uploader or room leaders can delete files");

--- a/backend/src/main/java/com/monteweb/files/internal/service/FileService.java
+++ b/backend/src/main/java/com/monteweb/files/internal/service/FileService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.monteweb.shared.util.ClamAvService;
 import com.monteweb.shared.util.FileValidationUtils;
 
 import java.io.InputStream;
@@ -41,19 +42,22 @@ public class FileService implements FilesModuleApi {
     private final RoomModuleApi roomModuleApi;
     private final UserModuleApi userModuleApi;
     private final ApplicationEventPublisher eventPublisher;
+    private final ClamAvService clamAvService;
 
     public FileService(RoomFileRepository fileRepository,
                        RoomFolderRepository folderRepository,
                        FileStorageService storageService,
                        RoomModuleApi roomModuleApi,
                        UserModuleApi userModuleApi,
-                       ApplicationEventPublisher eventPublisher) {
+                       ApplicationEventPublisher eventPublisher,
+                       ClamAvService clamAvService) {
         this.fileRepository = fileRepository;
         this.folderRepository = folderRepository;
         this.storageService = storageService;
         this.roomModuleApi = roomModuleApi;
         this.userModuleApi = userModuleApi;
         this.eventPublisher = eventPublisher;
+        this.clamAvService = clamAvService;
     }
 
     // ---- Public API (FilesModuleApi) ----
@@ -146,6 +150,16 @@ public class FileService implements FilesModuleApi {
 
         // Detect actual content type via magic bytes instead of trusting client header
         String detectedContentType = FileValidationUtils.detectContentType(file);
+
+        // Virus scan before storing (no-op unless the 'clamav' module toggle is enabled).
+        try {
+            ClamAvService.ScanResult scan = clamAvService.scan(file.getBytes());
+            if (!scan.isClean()) {
+                throw new BusinessException("File rejected: malware detected (" + scan.virusName() + ")");
+            }
+        } catch (java.io.IOException e) {
+            throw new BusinessException("Could not read the uploaded file for virus scanning");
+        }
 
         String storedName = UUID.randomUUID() + "_" + sanitizeFileName(file.getOriginalFilename());
         String storagePath = storageService.upload(roomId, folderId, storedName, file, detectedContentType);

--- a/backend/src/main/java/com/monteweb/files/internal/service/FileService.java
+++ b/backend/src/main/java/com/monteweb/files/internal/service/FileService.java
@@ -107,16 +107,24 @@ public class FileService implements FilesModuleApi {
         requireRoomMembership(userId, roomId);
 
         List<RoomFile> files;
+        String folderAudience = null;
         if (folderId == null) {
             files = fileRepository.findByRoomIdAndFolderIdIsNullOrderByCreatedAtDesc(roomId);
         } else {
             files = fileRepository.findByRoomIdAndFolderIdOrderByCreatedAtDesc(roomId, folderId);
+            folderAudience = folderRepository.findById(folderId)
+                    .filter(f -> f.getRoomId().equals(roomId))
+                    .map(RoomFolder::getAudience)
+                    .orElse(null);
         }
 
-        // Filter files by audience based on user's role
+        // Filter files by their EFFECTIVE audience (own audience inheriting the folder's
+        // visibility, US-143) so a broad file inside a restrictive folder is hidden from
+        // users who may not see the folder.
         Set<String> allowedAudiences = getAllowedAudiences(userId, roomId);
+        final String inheritedAudience = folderAudience;
         return files.stream()
-                .filter(f -> allowedAudiences.contains(f.getAudience()))
+                .filter(f -> allowedAudiences.contains(effectiveAudience(inheritedAudience, f.getAudience())))
                 .map(this::toFileInfo)
                 .toList();
     }
@@ -133,10 +141,12 @@ public class FileService implements FilesModuleApi {
             throw new BusinessException("File too large. Maximum size is 100 MB.");
         }
 
+        String folderAudience = null;
         if (folderId != null) {
-            folderRepository.findById(folderId)
+            var parentFolder = folderRepository.findById(folderId)
                     .filter(f -> f.getRoomId().equals(roomId))
                     .orElseThrow(() -> new ResourceNotFoundException("Folder", folderId));
+            folderAudience = parentFolder.getAudience();
         }
 
         // Validate audience value
@@ -147,6 +157,12 @@ public class FileService implements FilesModuleApi {
             }
             resolvedAudience = audience.toUpperCase();
         }
+
+        // Files inherit the visibility of their containing folder (US-143): a file may
+        // never be broader than the folder it lives in. A restrictive (non-ALL) folder
+        // forces its audience onto the file, so e.g. an "ALL" file placed inside a
+        // PARENTS_ONLY folder is stored — and later served — as PARENTS_ONLY.
+        resolvedAudience = effectiveAudience(folderAudience, resolvedAudience);
 
         // Detect actual content type via magic bytes instead of trusting client header
         String detectedContentType = FileValidationUtils.detectContentType(file);
@@ -191,7 +207,7 @@ public class FileService implements FilesModuleApi {
                 .filter(f -> f.getRoomId().equals(roomId))
                 .orElseThrow(() -> new ResourceNotFoundException("File", fileId));
 
-        requireAudienceAccess(userId, roomId, roomFile.getAudience());
+        requireAudienceAccess(userId, roomId, effectiveAudienceForFile(roomFile));
         return storageService.download(roomFile.getStoragePath());
     }
 
@@ -201,7 +217,7 @@ public class FileService implements FilesModuleApi {
         var roomFile = fileRepository.findById(fileId)
                 .filter(f -> f.getRoomId().equals(roomId))
                 .orElseThrow(() -> new ResourceNotFoundException("File", fileId));
-        requireAudienceAccess(userId, roomId, roomFile.getAudience());
+        requireAudienceAccess(userId, roomId, effectiveAudienceForFile(roomFile));
         return roomFile;
     }
 
@@ -210,8 +226,8 @@ public class FileService implements FilesModuleApi {
                 .filter(f -> f.getRoomId().equals(roomId))
                 .orElseThrow(() -> new ResourceNotFoundException("File", fileId));
 
-        // Only uploader, room leaders, or admins (SUPERADMIN/SECTION_ADMIN) can delete
-        if (!roomFile.getUploadedBy().equals(userId) && !hasAdminRole(userId)) {
+        // Only uploader, room leaders, or admins (SUPERADMIN / section-scoped SECTION_ADMIN) can delete
+        if (!roomFile.getUploadedBy().equals(userId) && !hasAdminRoleForRoom(userId, roomId)) {
             var role = roomModuleApi.getUserRoleInRoom(userId, roomId);
             if (role.isEmpty() || !"LEADER".equals(role.get().name())) {
                 throw new ForbiddenException("Only the uploader or room leaders can delete files");
@@ -278,17 +294,37 @@ public class FileService implements FilesModuleApi {
                 .filter(f -> f.getRoomId().equals(roomId))
                 .orElseThrow(() -> new ResourceNotFoundException("Folder", folderId));
 
+        // Only the folder creator, a room LEADER, or an admin (SUPERADMIN globally,
+        // SECTION_ADMIN scoped to this room's section) may delete a folder. Deletion
+        // cascades to all files and sub-folders, so this must not be open to any member.
+        boolean isCreator = userId.equals(folder.getCreatedBy());
+        boolean isLeader = roomModuleApi.getUserRoleInRoom(userId, roomId)
+                .map(r -> "LEADER".equals(r.name()))
+                .orElse(false);
+        if (!isCreator && !isLeader && !hasAdminRoleForRoom(userId, roomId)) {
+            throw new ForbiddenException("Only the folder creator, a room leader, or an admin can delete this folder");
+        }
+
+        deleteFolderRecursive(roomId, folder);
+    }
+
+    /**
+     * Recursively deletes a folder, its files (from MinIO + DB), and its sub-folders.
+     * Authorization is checked once by the public {@link #deleteFolder} entry point; the
+     * authorized actor's deletion cascades over the entire sub-tree.
+     */
+    private void deleteFolderRecursive(UUID roomId, RoomFolder folder) {
         // Delete all files in this folder from storage
-        var files = fileRepository.findByRoomIdAndFolderIdOrderByCreatedAtDesc(roomId, folderId);
+        var files = fileRepository.findByRoomIdAndFolderIdOrderByCreatedAtDesc(roomId, folder.getId());
         for (var file : files) {
             storageService.delete(file.getStoragePath());
         }
         fileRepository.deleteAll(files);
 
         // Delete sub-folders recursively
-        var subFolders = folderRepository.findByRoomIdAndParentIdOrderByNameAsc(roomId, folderId);
+        var subFolders = folderRepository.findByRoomIdAndParentIdOrderByNameAsc(roomId, folder.getId());
         for (var sub : subFolders) {
-            deleteFolder(roomId, sub.getId(), userId);
+            deleteFolderRecursive(roomId, sub);
         }
 
         folderRepository.delete(folder);
@@ -296,14 +332,30 @@ public class FileService implements FilesModuleApi {
 
     // ---- Helpers ----
 
-    private boolean hasAdminRole(UUID userId) {
-        return userModuleApi.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
-                .orElse(false);
+    /**
+     * Returns true if the user is a global SUPERADMIN, or a SECTION_ADMIN scoped to the
+     * section the given room belongs to. SECTION_ADMINs are NOT global admins: a section
+     * admin scoped to e.g. Krippe must not gain access to an Oberstufe room.
+     * Mirrors {@code DiscussionThreadService.hasAdminRoleForRoom} / {@code RoomController.isAdminForSection}.
+     */
+    private boolean hasAdminRoleForRoom(UUID userId, UUID roomId) {
+        var user = userModuleApi.findById(userId).orElse(null);
+        if (user == null) {
+            return false;
+        }
+        if (user.role() == UserRole.SUPERADMIN) {
+            return true;
+        }
+        if (user.role() == UserRole.SECTION_ADMIN) {
+            var sectionId = roomModuleApi.findById(roomId).map(r -> r.sectionId()).orElse(null);
+            return sectionId != null && user.specialRoles() != null
+                    && user.specialRoles().contains("SECTION_ADMIN:" + sectionId);
+        }
+        return false;
     }
 
     private void requireRoomMembership(UUID userId, UUID roomId) {
-        if (!hasAdminRole(userId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRoleForRoom(userId, roomId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("You are not a member of this room");
         }
     }
@@ -314,6 +366,34 @@ public class FileService implements FilesModuleApi {
         if (!allowed.contains(audience)) {
             throw new ForbiddenException("You do not have access to this file");
         }
+    }
+
+    /**
+     * Resolves the EFFECTIVE audience of a file given its containing folder's audience
+     * (US-143 inheritance). A restrictive (non-ALL) folder forces its audience onto the
+     * file so the file can never be broader than the folder it lives in. When the folder
+     * is ALL (or the file is at the room root with no folder) the file keeps its own audience.
+     */
+    private String effectiveAudience(String folderAudience, String fileAudience) {
+        if (folderAudience != null && !"ALL".equals(folderAudience)) {
+            return folderAudience;
+        }
+        return fileAudience != null ? fileAudience : "ALL";
+    }
+
+    /**
+     * Looks up a file's containing folder (if any) and returns the file's effective,
+     * folder-inherited audience. Used by single-file access checks (download / metadata)
+     * so they cannot bypass the folder-level visibility restriction.
+     */
+    private String effectiveAudienceForFile(RoomFile roomFile) {
+        String folderAudience = null;
+        if (roomFile.getFolderId() != null) {
+            folderAudience = folderRepository.findById(roomFile.getFolderId())
+                    .map(RoomFolder::getAudience)
+                    .orElse(null);
+        }
+        return effectiveAudience(folderAudience, roomFile.getAudience());
     }
 
     /**
@@ -328,11 +408,11 @@ public class FileService implements FilesModuleApi {
         var userInfo = userModuleApi.findById(userId).orElse(null);
         var userRole = userInfo != null ? userInfo.role() : null;
 
-        // Leaders, teachers, superadmins, section admins see everything
+        // Leaders, teachers, and admins (SUPERADMIN globally, SECTION_ADMIN only for
+        // rooms in their own section) see everything.
         if (roomRole == RoomRole.LEADER
                 || userRole == UserRole.TEACHER
-                || userRole == UserRole.SUPERADMIN
-                || userRole == UserRole.SECTION_ADMIN) {
+                || hasAdminRoleForRoom(userId, roomId)) {
             return Set.of("ALL", "PARENTS_ONLY", "STUDENTS_ONLY");
         }
 

--- a/backend/src/main/java/com/monteweb/forms/internal/service/FormsService.java
+++ b/backend/src/main/java/com/monteweb/forms/internal/service/FormsService.java
@@ -632,6 +632,7 @@ public class FormsService implements FormsModuleApi {
         var saved = new ArrayList<FormQuestion>();
         for (int i = 0; i < requests.size(); i++) {
             var req = requests.get(i);
+            validateQuestion(req);
             var question = new FormQuestion();
             question.setFormId(formId);
             question.setType(req.type());
@@ -655,6 +656,28 @@ public class FormsService implements FormsModuleApi {
             saved.add(questionRepository.save(question));
         }
         return saved;
+    }
+
+    /**
+     * US-160 / US-181: Single-/multiple-choice questions require options.
+     * At least two distinct, non-blank options are mandatory so that the
+     * respondent actually has a choice to make. A choice question with zero
+     * or one option can be neither saved nor published.
+     */
+    private void validateQuestion(QuestionRequest req) {
+        if (req.type() == QuestionType.SINGLE_CHOICE || req.type() == QuestionType.MULTIPLE_CHOICE) {
+            var options = req.options();
+            long distinctNonBlank = options == null ? 0 : options.stream()
+                    .filter(Objects::nonNull)
+                    .map(String::trim)
+                    .filter(o -> !o.isEmpty())
+                    .distinct()
+                    .count();
+            if (distinctNonBlank < 2) {
+                throw new IllegalArgumentException(
+                        "Choice questions require at least two distinct options: " + req.label());
+            }
+        }
     }
 
     private void checkCreatePermission(FormScope scope, UUID scopeId, UUID userId) {
@@ -721,10 +744,38 @@ public class FormsService implements FormsModuleApi {
     }
 
     private int calculateTargetCount(Form form) {
-        if (form.getScope() == FormScope.ROOM && form.getScopeId() != null) {
-            return roomModule.getMemberUserIds(form.getScopeId()).size();
+        return switch (form.getScope()) {
+            case ROOM -> form.getScopeId() != null
+                    ? roomModule.getMemberUserIds(form.getScopeId()).size()
+                    : 0;
+            case SECTION -> sectionTargetUserIds(form).size();
+            // US-172: A true school-wide target count is the total number of
+            // active users. The user module currently exposes no count API, so
+            // we cannot compute it without a cross-module API addition. Returning
+            // 0 keeps the response-rate denominator hidden rather than wrong.
+            // TODO(cross-module): add UserModuleApi.countActiveUsers() and use it here.
+            case SCHOOL -> 0;
+        };
+    }
+
+    /**
+     * US-167: The target group of a section-scoped form is the union of all
+     * members across every (non-archived) room belonging to the targeted
+     * sections. Counted distinctly so a user in two rooms of the same section
+     * is not double-counted.
+     */
+    private Set<UUID> sectionTargetUserIds(Form form) {
+        List<UUID> sectionIds = form.getSectionIds() != null && form.getSectionIds().length > 0
+                ? List.of(form.getSectionIds())
+                : (form.getScopeId() != null ? List.of(form.getScopeId()) : List.of());
+
+        var userIds = new HashSet<UUID>();
+        for (var sectionId : sectionIds) {
+            for (var room : roomModule.findBySectionId(sectionId)) {
+                userIds.addAll(roomModule.getMemberUserIds(room.id()));
+            }
         }
-        return 0;
+        return userIds;
     }
 
     private FormInfo toFormInfo(Form form, UUID currentUserId) {

--- a/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxPermissionService.java
+++ b/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxPermissionService.java
@@ -28,15 +28,15 @@ public class FotoboxPermissionService {
     private final FotoboxImageRepository imageRepo;
 
     public FotoboxPermissionLevel getPermission(UUID userId, UUID roomId) {
-        boolean isSuperAdmin = isSuperAdmin(userId);
-        if (!isSuperAdmin && !roomModule.isUserInRoom(userId, roomId)) {
+        boolean hasAdminRole = hasAdminRole(userId);
+        if (!hasAdminRole && !roomModule.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
         }
         var settings = settingsRepo.findByRoomId(roomId).orElse(null);
         if (settings == null || !settings.isEnabled()) {
             throw new ForbiddenException("Fotobox not enabled for this room");
         }
-        if (isSuperAdmin) {
+        if (hasAdminRole) {
             return FotoboxPermissionLevel.CREATE_THREADS;
         }
         var role = roomModule.getUserRoleInRoom(userId, roomId).orElse(null);
@@ -54,20 +54,20 @@ public class FotoboxPermissionService {
     }
 
     public void requireRoomMember(UUID userId, UUID roomId) {
-        if (!isSuperAdmin(userId) && !roomModule.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRole(userId) && !roomModule.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
         }
     }
 
     public boolean isLeaderOrAdmin(UUID userId, UUID roomId) {
-        if (isSuperAdmin(userId)) {
+        if (hasAdminRole(userId)) {
             return true;
         }
         var role = roomModule.getUserRoleInRoom(userId, roomId).orElse(null);
         return role == RoomRole.LEADER;
     }
 
-    private boolean isSuperAdmin(UUID userId) {
+    private boolean hasAdminRole(UUID userId) {
         return userModule.findById(userId)
                 .map(u -> u.role() == UserRole.SUPERADMIN)
                 .orElse(false);

--- a/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxPermissionService.java
+++ b/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxPermissionService.java
@@ -69,7 +69,7 @@ public class FotoboxPermissionService {
 
     private boolean hasAdminRole(UUID userId) {
         return userModule.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN)
+                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
                 .orElse(false);
     }
 

--- a/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxPermissionService.java
+++ b/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxPermissionService.java
@@ -5,6 +5,7 @@ import com.monteweb.fotobox.internal.model.FotoboxRoomSettings;
 import com.monteweb.fotobox.internal.repository.FotoboxImageRepository;
 import com.monteweb.fotobox.internal.repository.FotoboxRoomSettingsRepository;
 import com.monteweb.fotobox.internal.repository.FotoboxThreadRepository;
+import com.monteweb.room.RoomInfo;
 import com.monteweb.room.RoomModuleApi;
 import com.monteweb.room.RoomRole;
 import com.monteweb.shared.exception.ForbiddenException;
@@ -28,7 +29,7 @@ public class FotoboxPermissionService {
     private final FotoboxImageRepository imageRepo;
 
     public FotoboxPermissionLevel getPermission(UUID userId, UUID roomId) {
-        boolean hasAdminRole = hasAdminRole(userId);
+        boolean hasAdminRole = hasAdminRole(userId, roomId);
         if (!hasAdminRole && !roomModule.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
         }
@@ -54,23 +55,39 @@ public class FotoboxPermissionService {
     }
 
     public void requireRoomMember(UUID userId, UUID roomId) {
-        if (!hasAdminRole(userId) && !roomModule.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRole(userId, roomId) && !roomModule.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
         }
     }
 
     public boolean isLeaderOrAdmin(UUID userId, UUID roomId) {
-        if (hasAdminRole(userId)) {
+        if (hasAdminRole(userId, roomId)) {
             return true;
         }
         var role = roomModule.getUserRoleInRoom(userId, roomId).orElse(null);
         return role == RoomRole.LEADER;
     }
 
-    private boolean hasAdminRole(UUID userId) {
-        return userModule.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
-                .orElse(false);
+    /**
+     * Returns true if the user is a global SUPERADMIN, or a SECTION_ADMIN scoped to the
+     * section the given room belongs to. SECTION_ADMINs are NOT global admins: a section
+     * admin scoped to e.g. Krippe must not gain access to an Oberstufe room.
+     * Mirrors {@code DiscussionThreadService.hasAdminRoleForRoom} / {@code RoomController.isAdminForSection}.
+     */
+    public boolean hasAdminRole(UUID userId, UUID roomId) {
+        var user = userModule.findById(userId).orElse(null);
+        if (user == null) {
+            return false;
+        }
+        if (user.role() == UserRole.SUPERADMIN) {
+            return true;
+        }
+        if (user.role() == UserRole.SECTION_ADMIN) {
+            var sectionId = roomModule.findById(roomId).map(RoomInfo::sectionId).orElse(null);
+            return sectionId != null && user.specialRoles() != null
+                    && user.specialRoles().contains("SECTION_ADMIN:" + sectionId);
+        }
+        return false;
     }
 
     public boolean isThreadOwnerOrLeader(UUID userId, UUID threadId) {

--- a/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxService.java
+++ b/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxService.java
@@ -8,8 +8,6 @@ import com.monteweb.fotobox.internal.model.FotoboxThread;
 import com.monteweb.fotobox.internal.repository.FotoboxImageRepository;
 import com.monteweb.fotobox.internal.repository.FotoboxRoomSettingsRepository;
 import com.monteweb.fotobox.internal.repository.FotoboxThreadRepository;
-import com.monteweb.room.RoomModuleApi;
-import com.monteweb.room.RoomRole;
 import com.monteweb.shared.exception.BadRequestException;
 import com.monteweb.shared.exception.ForbiddenException;
 import com.monteweb.shared.exception.ResourceNotFoundException;
@@ -40,7 +38,6 @@ public class FotoboxService implements FotoboxModuleApi {
     private final FotoboxRoomSettingsRepository settingsRepo;
     private final FotoboxPermissionService permissionService;
     private final FotoboxStorageService storageService;
-    private final RoomModuleApi roomModule;
     private final UserModuleApi userModule;
     private final ApplicationEventPublisher eventPublisher;
     private final ClamAvService clamAvService;
@@ -389,15 +386,13 @@ public class FotoboxService implements FotoboxModuleApi {
      * Same logic as FileService.getAllowedAudiences.
      */
     private Set<String> getAllowedAudiences(UUID userId, UUID roomId) {
-        var roomRole = roomModule.getUserRoleInRoom(userId, roomId).orElse(null);
         var userInfo = userModule.findById(userId).orElse(null);
         var userRole = userInfo != null ? userInfo.role() : null;
 
-        // Leaders, teachers, superadmins, section admins see everything
-        if (roomRole == RoomRole.LEADER
-                || userRole == UserRole.TEACHER
-                || userRole == UserRole.SUPERADMIN
-                || userRole == UserRole.SECTION_ADMIN) {
+        // Teachers see everything. Leaders, superadmins, and SECTION_ADMINs scoped to this
+        // room's section also see everything (section-scoping handled by isLeaderOrAdmin).
+        if (userRole == UserRole.TEACHER
+                || permissionService.isLeaderOrAdmin(userId, roomId)) {
             return Set.of("ALL", "PARENTS_ONLY", "STUDENTS_ONLY");
         }
 

--- a/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxService.java
+++ b/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxService.java
@@ -110,6 +110,10 @@ public class FotoboxService implements FotoboxModuleApi {
         if (!thread.getRoomId().equals(roomId)) {
             throw new ResourceNotFoundException("FotoboxThread", threadId);
         }
+        // Enforce audience visibility (mirrors the filter in getThreads)
+        if (!getAllowedAudiences(userId, thread.getRoomId()).contains(thread.getAudience())) {
+            throw new ResourceNotFoundException("FotoboxThread", threadId);
+        }
         return toThreadInfo(thread);
     }
 
@@ -118,6 +122,10 @@ public class FotoboxService implements FotoboxModuleApi {
         var thread = threadRepo.findById(threadId)
                 .orElseThrow(() -> new ResourceNotFoundException("FotoboxThread", threadId));
         if (!thread.getRoomId().equals(roomId)) {
+            throw new ResourceNotFoundException("FotoboxThread", threadId);
+        }
+        // Enforce audience visibility (mirrors the filter in getThreads)
+        if (!getAllowedAudiences(userId, thread.getRoomId()).contains(thread.getAudience())) {
             throw new ResourceNotFoundException("FotoboxThread", threadId);
         }
         var images = imageRepo.findByThreadIdOrderBySortOrderAscCreatedAtAsc(threadId);
@@ -289,6 +297,11 @@ public class FotoboxService implements FotoboxModuleApi {
         var thread = threadRepo.findById(image.getThreadId())
                 .orElseThrow(() -> new ResourceNotFoundException("FotoboxThread", image.getThreadId()));
         permissionService.requirePermission(userId, thread.getRoomId(), FotoboxPermissionLevel.VIEW_ONLY);
+        // Enforce audience visibility (mirrors the filter in getThreads) — return 404 to avoid
+        // confirming existence of images in an audience the user may not see.
+        if (!getAllowedAudiences(userId, thread.getRoomId()).contains(thread.getAudience())) {
+            throw new ResourceNotFoundException("FotoboxThread", thread.getId());
+        }
         return image;
     }
 

--- a/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxService.java
+++ b/backend/src/main/java/com/monteweb/fotobox/internal/service/FotoboxService.java
@@ -13,6 +13,7 @@ import com.monteweb.room.RoomRole;
 import com.monteweb.shared.exception.BadRequestException;
 import com.monteweb.shared.exception.ForbiddenException;
 import com.monteweb.shared.exception.ResourceNotFoundException;
+import com.monteweb.shared.util.ClamAvService;
 import com.monteweb.user.UserModuleApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -42,6 +43,7 @@ public class FotoboxService implements FotoboxModuleApi {
     private final RoomModuleApi roomModule;
     private final UserModuleApi userModule;
     private final ApplicationEventPublisher eventPublisher;
+    private final ClamAvService clamAvService;
 
     // --- Settings ---
 
@@ -222,6 +224,17 @@ public class FotoboxService implements FotoboxModuleApi {
             }
 
             String contentType = storageService.validateAndDetectContentType(file);
+
+            // Virus scan before storing (no-op unless the 'clamav' module toggle is enabled).
+            try {
+                ClamAvService.ScanResult scan = clamAvService.scan(file.getBytes());
+                if (!scan.isClean()) {
+                    throw new BadRequestException("File rejected: malware detected (" + scan.virusName() + ")");
+                }
+            } catch (java.io.IOException e) {
+                throw new BadRequestException("Could not read the uploaded file for virus scanning");
+            }
+
             String extension = FotoboxStorageService.extensionFromContentType(contentType);
             UUID imageId = UUID.randomUUID();
 

--- a/backend/src/main/java/com/monteweb/fundgrube/internal/controller/FundgrubeController.java
+++ b/backend/src/main/java/com/monteweb/fundgrube/internal/controller/FundgrubeController.java
@@ -35,9 +35,10 @@ public class FundgrubeController {
 
     @GetMapping("/items")
     public ApiResponse<List<FundgrubeItemInfo>> listItems(
-            @RequestParam(required = false) UUID sectionId) {
+            @RequestParam(required = false) UUID sectionId,
+            @RequestParam(required = false) Boolean claimed) {
         SecurityUtils.requireCurrentUserId();
-        return ApiResponse.ok(fundgrubeService.listItems(sectionId));
+        return ApiResponse.ok(fundgrubeService.listItems(sectionId, claimed));
     }
 
     @GetMapping("/items/{itemId}")

--- a/backend/src/main/java/com/monteweb/fundgrube/internal/repository/FundgrubeItemRepository.java
+++ b/backend/src/main/java/com/monteweb/fundgrube/internal/repository/FundgrubeItemRepository.java
@@ -15,7 +15,11 @@ public interface FundgrubeItemRepository extends JpaRepository<FundgrubeItem, UU
     @Query("SELECT i FROM FundgrubeItem i WHERE (i.expiresAt IS NULL OR i.expiresAt > :now) ORDER BY i.createdAt DESC")
     List<FundgrubeItem> findAllActive(@Param("now") Instant now);
 
-    @Query("SELECT i FROM FundgrubeItem i WHERE i.sectionId = :sectionId AND (i.expiresAt IS NULL OR i.expiresAt > :now) ORDER BY i.createdAt DESC")
+    /**
+     * Items belonging to the given section PLUS school-wide items (sectionId IS NULL),
+     * which are visible under every section filter.
+     */
+    @Query("SELECT i FROM FundgrubeItem i WHERE (i.sectionId = :sectionId OR i.sectionId IS NULL) AND (i.expiresAt IS NULL OR i.expiresAt > :now) ORDER BY i.createdAt DESC")
     List<FundgrubeItem> findActiveBySectionId(@Param("sectionId") UUID sectionId, @Param("now") Instant now);
 
     @Query("SELECT i FROM FundgrubeItem i WHERE i.expiresAt IS NOT NULL AND i.expiresAt < :now")

--- a/backend/src/main/java/com/monteweb/fundgrube/internal/service/FundgrubeService.java
+++ b/backend/src/main/java/com/monteweb/fundgrube/internal/service/FundgrubeService.java
@@ -123,6 +123,8 @@ public class FundgrubeService implements FundgrubeModuleApi {
 
     // ---- Images ----
 
+    private static final long MAX_IMAGE_BYTES = 20L * 1024 * 1024; // 20 MB per image
+
     @Transactional
     public List<FundgrubeImageInfo> uploadImages(UUID userId, UUID itemId, List<MultipartFile> files) {
         var item = requireItem(itemId);
@@ -131,6 +133,11 @@ public class FundgrubeService implements FundgrubeModuleApi {
 
         List<FundgrubeImageInfo> result = new ArrayList<>();
         for (MultipartFile file : files) {
+            // Explicit per-file bound (the global multipart limit is now 100MB).
+            if (file.getSize() > MAX_IMAGE_BYTES) {
+                throw new BadRequestException("Image too large: " + file.getOriginalFilename()
+                        + " (max " + (MAX_IMAGE_BYTES / (1024 * 1024)) + " MB)");
+            }
             String contentType = storageService.validateAndDetectContentType(file);
             String extension = FundgrubeStorageService.extensionFromContentType(contentType);
             UUID imageId = UUID.randomUUID();

--- a/backend/src/main/java/com/monteweb/fundgrube/internal/service/FundgrubeService.java
+++ b/backend/src/main/java/com/monteweb/fundgrube/internal/service/FundgrubeService.java
@@ -40,12 +40,24 @@ public class FundgrubeService implements FundgrubeModuleApi {
 
     // ---- List ----
 
-    public List<FundgrubeItemInfo> listItems(UUID sectionId) {
+    /**
+     * Lists active fundgrube items.
+     *
+     * @param sectionId optional section filter; when set, items of that section AND
+     *                  school-wide items (sectionId == null) are returned.
+     * @param claimed   optional claim filter: {@code true} returns only already-claimed
+     *                  items, {@code false} returns only available (unclaimed) items,
+     *                  {@code null} returns all active items.
+     */
+    public List<FundgrubeItemInfo> listItems(UUID sectionId, Boolean claimed) {
         var now = Instant.now();
         List<FundgrubeItem> items = sectionId != null
                 ? itemRepo.findActiveBySectionId(sectionId, now)
                 : itemRepo.findAllActive(now);
-        return items.stream().map(this::toInfo).toList();
+        return items.stream()
+                .filter(item -> claimed == null || item.isClaimed() == claimed)
+                .map(this::toInfo)
+                .toList();
     }
 
     // ---- Get ----

--- a/backend/src/main/java/com/monteweb/jobboard/internal/controller/JobboardController.java
+++ b/backend/src/main/java/com/monteweb/jobboard/internal/controller/JobboardController.java
@@ -183,6 +183,13 @@ public class JobboardController {
     public ResponseEntity<ApiResponse<JobAssignmentInfo>> confirmAssignment(
             @PathVariable UUID assignmentId) {
         UUID userId = SecurityUtils.requireCurrentUserId();
+        var user = userModuleApi.findById(userId)
+                .orElseThrow(() -> new ForbiddenException("User not found"));
+        if (user.role() != UserRole.TEACHER
+                && user.role() != UserRole.SECTION_ADMIN
+                && user.role() != UserRole.SUPERADMIN) {
+            throw new ForbiddenException("Not authorized");
+        }
         return ResponseEntity.ok(ApiResponse.ok(jobboardService.confirmAssignment(assignmentId, userId)));
     }
 

--- a/backend/src/main/java/com/monteweb/jobboard/internal/controller/JobboardController.java
+++ b/backend/src/main/java/com/monteweb/jobboard/internal/controller/JobboardController.java
@@ -12,6 +12,7 @@ import com.monteweb.shared.util.FileValidationUtils;
 import com.monteweb.shared.util.SecurityUtils;
 import com.monteweb.user.UserModuleApi;
 import com.monteweb.user.UserRole;
+import jakarta.validation.Valid;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.data.domain.Pageable;
@@ -172,7 +173,7 @@ public class JobboardController {
     @PutMapping("/assignments/{assignmentId}/complete")
     public ResponseEntity<ApiResponse<JobAssignmentInfo>> completeAssignment(
             @PathVariable UUID assignmentId,
-            @RequestBody CompleteAssignmentRequest request) {
+            @Valid @RequestBody CompleteAssignmentRequest request) {
         UUID userId = SecurityUtils.requireCurrentUserId();
         return ResponseEntity.ok(ApiResponse.ok(
                 jobboardService.completeAssignment(assignmentId, userId, request.actualHours(), request.notes())));

--- a/backend/src/main/java/com/monteweb/jobboard/internal/controller/JobboardExportController.java
+++ b/backend/src/main/java/com/monteweb/jobboard/internal/controller/JobboardExportController.java
@@ -3,7 +3,11 @@ package com.monteweb.jobboard.internal.controller;
 import com.monteweb.admin.AdminModuleApi;
 import com.monteweb.jobboard.FamilyHoursInfo;
 import com.monteweb.jobboard.internal.service.JobboardService;
+import com.monteweb.shared.exception.ForbiddenException;
 import com.monteweb.shared.util.PdfService;
+import com.monteweb.shared.util.SecurityUtils;
+import com.monteweb.user.UserModuleApi;
+import com.monteweb.user.UserRole;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/jobs/report")
@@ -23,17 +28,21 @@ public class JobboardExportController {
     private final JobboardService jobboardService;
     private final PdfService pdfService;
     private final AdminModuleApi adminModuleApi;
+    private final UserModuleApi userModuleApi;
 
     public JobboardExportController(JobboardService jobboardService,
                                     PdfService pdfService,
-                                    AdminModuleApi adminModuleApi) {
+                                    AdminModuleApi adminModuleApi,
+                                    UserModuleApi userModuleApi) {
         this.jobboardService = jobboardService;
         this.pdfService = pdfService;
         this.adminModuleApi = adminModuleApi;
+        this.userModuleApi = userModuleApi;
     }
 
     @GetMapping(value = "/export", produces = "text/csv")
     public ResponseEntity<byte[]> exportCsv() {
+        requireAdminRole(SecurityUtils.requireCurrentUserId());
         List<FamilyHoursInfo> report = jobboardService.getAllFamilyHoursReport();
 
         StringBuilder csv = new StringBuilder();
@@ -65,6 +74,7 @@ public class JobboardExportController {
 
     @GetMapping(value = "/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
     public ResponseEntity<byte[]> exportPdf() {
+        requireAdminRole(SecurityUtils.requireCurrentUserId());
         List<FamilyHoursInfo> report = jobboardService.getAllFamilyHoursReport();
         String schoolName = adminModuleApi.getTenantConfig().schoolName();
 
@@ -85,6 +95,15 @@ public class JobboardExportController {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"familien-stundenbericht.pdf\"")
                 .contentType(MediaType.APPLICATION_PDF)
                 .body(pdf);
+    }
+
+    private void requireAdminRole(UUID userId) {
+        var user = userModuleApi.findById(userId)
+                .orElseThrow(() -> new ForbiddenException("User not found"));
+        if (user.role() != UserRole.SUPERADMIN && user.role() != UserRole.SECTION_ADMIN
+                && user.role() != UserRole.TEACHER) {
+            throw new ForbiddenException("Only administrators and teachers can access reports");
+        }
     }
 
     private String escapeCsv(String value) {

--- a/backend/src/main/java/com/monteweb/jobboard/internal/service/JobboardService.java
+++ b/backend/src/main/java/com/monteweb/jobboard/internal/service/JobboardService.java
@@ -31,6 +31,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.monteweb.shared.util.FileValidationUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
@@ -970,6 +974,9 @@ public class JobboardService implements JobboardModuleApi {
     }
 
     public record CompleteAssignmentRequest(
+            @NotNull(message = "actualHours is required")
+            @DecimalMin(value = "0.0", message = "actualHours must be >= 0")
+            @DecimalMax(value = "24.0", message = "actualHours must be <= 24")
             BigDecimal actualHours,
             String notes
     ) {

--- a/backend/src/main/java/com/monteweb/messaging/internal/controller/MessagingController.java
+++ b/backend/src/main/java/com/monteweb/messaging/internal/controller/MessagingController.java
@@ -45,11 +45,14 @@ public class MessagingController {
     public ResponseEntity<ApiResponse<ConversationInfo>> startConversation(
             @RequestBody StartConversationRequest request) {
         UUID userId = SecurityUtils.requireCurrentUserId();
+        if (request.participantIds() == null || request.participantIds().isEmpty()) {
+            throw new BadRequestException("At least one participant is required");
+        }
         ConversationInfo conversation;
         if (request.participantIds().size() == 1 && !request.isGroup()) {
             conversation = messagingService.startDirectConversation(userId, request.participantIds().get(0));
         } else {
-            conversation = messagingService.startGroupConversation(userId, request.title(), request.participantIds());
+            conversation = messagingService.startUserGroupConversation(userId, request.title(), request.participantIds());
         }
         return ResponseEntity.ok(ApiResponse.ok(conversation));
     }

--- a/backend/src/main/java/com/monteweb/messaging/internal/service/MessagingService.java
+++ b/backend/src/main/java/com/monteweb/messaging/internal/service/MessagingService.java
@@ -138,6 +138,34 @@ public class MessagingService implements MessagingModuleApi {
         return toConversationInfo(conversation, userId);
     }
 
+    /**
+     * User-initiated group conversation creation (via REST controller).
+     * <p>Unlike {@link #startGroupConversation} (used internally / cross-module for room chats),
+     * this entry point enforces the minimum-participant rule and communication rules so that
+     * parent-to-parent / student-to-student restrictions cannot be bypassed via group chats.
+     */
+    public ConversationInfo startUserGroupConversation(UUID userId, String title, List<UUID> participantIds) {
+        // Distinct participants excluding the creator
+        var otherParticipantIds = participantIds == null ? List.<UUID>of() : participantIds.stream()
+                .filter(Objects::nonNull)
+                .filter(id -> !id.equals(userId))
+                .distinct()
+                .toList();
+
+        // A group conversation requires at least 2 other participants (besides the creator)
+        if (otherParticipantIds.size() < 2) {
+            throw new BusinessException("A group conversation requires at least 2 other participants");
+        }
+
+        // Enforce communication rules between the creator and every other participant
+        // (prevents bypassing parent-to-parent / student-to-student rules via group conversations)
+        for (UUID participantId : otherParticipantIds) {
+            enforceCommRules(userId, participantId);
+        }
+
+        return startGroupConversation(userId, title, otherParticipantIds);
+    }
+
     public ConversationInfo startGroupConversation(UUID userId, String title, List<UUID> participantIds) {
         var conversation = new Conversation();
         conversation.setTitle(title);
@@ -171,6 +199,13 @@ public class MessagingService implements MessagingModuleApi {
         var attachmentsByMessageId = allAttachments.stream()
                 .collect(java.util.stream.Collectors.groupingBy(MessageAttachment::getMessageId));
 
+        // Batch-load reactions so pre-existing reactions are returned on load (not only after toggle)
+        var allReactions = messageIds.isEmpty()
+                ? List.<MessageReaction>of()
+                : messageReactionRepository.findByMessageIdIn(messageIds);
+        var reactionsByMessageId = allReactions.stream()
+                .collect(java.util.stream.Collectors.groupingBy(MessageReaction::getMessageId));
+
         // Collect reply-to IDs
         var replyToIds = page.getContent().stream()
                 .map(Message::getReplyToId)
@@ -195,7 +230,8 @@ public class MessagingService implements MessagingModuleApi {
         return page.map(m -> toMessageInfo(m,
                 imagesByMessageId.getOrDefault(m.getId(), List.of()),
                 attachmentsByMessageId.getOrDefault(m.getId(), List.of()),
-                replyMessages, replyImagesByMsgId, replyAttachmentsByMsgId, userId));
+                replyMessages, replyImagesByMsgId, replyAttachmentsByMsgId,
+                reactionsByMessageId.getOrDefault(m.getId(), List.of()), userId));
     }
 
     public MessageInfo sendPollMessage(UUID conversationId, UUID senderId, CreateMessagePollRequest pollRequest) {
@@ -621,13 +657,15 @@ public class MessagingService implements MessagingModuleApi {
                                        Map<UUID, Message> replyMessages,
                                        Map<UUID, List<MessageImage>> replyImagesByMsgId,
                                        Map<UUID, List<MessageAttachment>> replyAttachmentsByMsgId) {
-        return toMessageInfo(m, images, attachments, replyMessages, replyImagesByMsgId, replyAttachmentsByMsgId, null);
+        return toMessageInfo(m, images, attachments, replyMessages, replyImagesByMsgId, replyAttachmentsByMsgId,
+                List.of(), null);
     }
 
     private MessageInfo toMessageInfo(Message m, List<MessageImage> images, List<MessageAttachment> attachments,
                                        Map<UUID, Message> replyMessages,
                                        Map<UUID, List<MessageImage>> replyImagesByMsgId,
                                        Map<UUID, List<MessageAttachment>> replyAttachmentsByMsgId,
+                                       List<MessageReaction> reactions,
                                        UUID currentUserId) {
         String senderName = m.getSenderId() != null
                 ? userModuleApi.findById(m.getSenderId())
@@ -677,6 +715,8 @@ public class MessagingService implements MessagingModuleApi {
                 .map(poll -> toMessagePollInfo(poll, currentUserId))
                 .orElse(null);
 
+        List<MessageInfo.ReactionSummary> reactionSummaries = summarizeReactions(reactions, currentUserId);
+
         return new MessageInfo(
                 m.getId(),
                 m.getConversationId(),
@@ -687,9 +727,25 @@ public class MessagingService implements MessagingModuleApi {
                 imageInfos,
                 attachmentInfos,
                 replyInfo,
-                List.of(),
+                reactionSummaries,
                 pollInfo
         );
+    }
+
+    /**
+     * Aggregate raw reactions into per-emoji summaries (count + whether the current user reacted).
+     */
+    private List<MessageInfo.ReactionSummary> summarizeReactions(List<MessageReaction> reactions, UUID currentUserId) {
+        return reactions.stream()
+                .collect(Collectors.groupingBy(MessageReaction::getEmoji))
+                .entrySet().stream()
+                .map(e -> new MessageInfo.ReactionSummary(
+                        e.getKey(),
+                        e.getValue().size(),
+                        currentUserId != null && e.getValue().stream().anyMatch(r -> r.getUserId().equals(currentUserId))
+                ))
+                .sorted(Comparator.comparingLong(MessageInfo.ReactionSummary::count).reversed())
+                .toList();
     }
 
     private PollInfo toMessagePollInfo(MessagePoll poll, UUID currentUserId) {
@@ -812,16 +868,7 @@ public class MessagingService implements MessagingModuleApi {
                 .orElseThrow(() -> new ResourceNotFoundException("Message", messageId));
         requireParticipant(message.getConversationId(), currentUserId);
         var reactions = messageReactionRepository.findByMessageId(messageId);
-        return reactions.stream()
-                .collect(Collectors.groupingBy(MessageReaction::getEmoji))
-                .entrySet().stream()
-                .map(e -> new MessageInfo.ReactionSummary(
-                        e.getKey(),
-                        e.getValue().size(),
-                        e.getValue().stream().anyMatch(r -> r.getUserId().equals(currentUserId))
-                ))
-                .sorted(Comparator.comparingLong(MessageInfo.ReactionSummary::count).reversed())
-                .toList();
+        return summarizeReactions(reactions, currentUserId);
     }
 
     /**

--- a/backend/src/main/java/com/monteweb/messaging/internal/service/MessagingService.java
+++ b/backend/src/main/java/com/monteweb/messaging/internal/service/MessagingService.java
@@ -772,7 +772,7 @@ public class MessagingService implements MessagingModuleApi {
         if (!message.getSenderId().equals(userId)) {
             var user = userModuleApi.findById(userId)
                     .orElseThrow(() -> new ResourceNotFoundException("User", userId));
-            if (user.role() != com.monteweb.user.UserRole.SUPERADMIN) {
+            if (!isStaffRole(user.role())) {
                 throw new ForbiddenException("Only the poll creator or admin can close this poll");
             }
         }
@@ -792,8 +792,9 @@ public class MessagingService implements MessagingModuleApi {
         if (!ALLOWED_EMOJIS.contains(emoji)) {
             throw new BusinessException("Invalid emoji. Allowed: " + ALLOWED_EMOJIS);
         }
-        messageRepository.findById(messageId)
+        var message = messageRepository.findById(messageId)
                 .orElseThrow(() -> new ResourceNotFoundException("Message", messageId));
+        requireParticipant(message.getConversationId(), userId);
         var existing = messageReactionRepository.findByMessageIdAndUserIdAndEmoji(messageId, userId, emoji);
         if (existing.isPresent()) {
             messageReactionRepository.delete(existing.get());
@@ -807,6 +808,9 @@ public class MessagingService implements MessagingModuleApi {
     }
 
     public List<MessageInfo.ReactionSummary> getMessageReactions(UUID messageId, UUID currentUserId) {
+        var message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new ResourceNotFoundException("Message", messageId));
+        requireParticipant(message.getConversationId(), currentUserId);
         var reactions = messageReactionRepository.findByMessageId(messageId);
         return reactions.stream()
                 .collect(Collectors.groupingBy(MessageReaction::getEmoji))

--- a/backend/src/main/java/com/monteweb/notification/internal/service/CalendarNotificationListener.java
+++ b/backend/src/main/java/com/monteweb/notification/internal/service/CalendarNotificationListener.java
@@ -6,8 +6,7 @@ import com.monteweb.calendar.EventScope;
 import com.monteweb.notification.NotificationModuleApi;
 import com.monteweb.notification.NotificationType;
 import com.monteweb.room.RoomModuleApi;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -25,8 +24,7 @@ public class CalendarNotificationListener {
         this.roomModule = roomModule;
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onEventCreated(EventCreatedEvent event) {
         if (event.scope() != EventScope.ROOM || event.scopeId() == null) return;
 
@@ -38,8 +36,7 @@ public class CalendarNotificationListener {
                 title, message, link, event.eventId());
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onEventCancelled(EventCancelledEvent event) {
         if (event.scope() != EventScope.ROOM || event.scopeId() == null) return;
 

--- a/backend/src/main/java/com/monteweb/notification/internal/service/DiscussionNotificationListener.java
+++ b/backend/src/main/java/com/monteweb/notification/internal/service/DiscussionNotificationListener.java
@@ -4,8 +4,7 @@ import com.monteweb.notification.NotificationModuleApi;
 import com.monteweb.notification.NotificationType;
 import com.monteweb.room.DiscussionThreadCreatedEvent;
 import com.monteweb.room.RoomModuleApi;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,8 +19,7 @@ public class DiscussionNotificationListener {
         this.roomModule = roomModule;
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onDiscussionThreadCreated(DiscussionThreadCreatedEvent event) {
         var room = roomModule.findById(event.roomId()).orElse(null);
         if (room == null) return;

--- a/backend/src/main/java/com/monteweb/notification/internal/service/FamilyInvitationNotificationListener.java
+++ b/backend/src/main/java/com/monteweb/notification/internal/service/FamilyInvitationNotificationListener.java
@@ -3,8 +3,7 @@ package com.monteweb.notification.internal.service;
 import com.monteweb.family.FamilyInvitationEvent;
 import com.monteweb.notification.NotificationModuleApi;
 import com.monteweb.notification.NotificationType;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,8 +15,7 @@ public class FamilyInvitationNotificationListener {
         this.notificationModule = notificationModule;
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onFamilyInvitation(FamilyInvitationEvent event) {
         if (event.accepted()) {
             // Notify inviter that invitation was accepted

--- a/backend/src/main/java/com/monteweb/notification/internal/service/FormsNotificationListener.java
+++ b/backend/src/main/java/com/monteweb/notification/internal/service/FormsNotificationListener.java
@@ -6,8 +6,7 @@ import com.monteweb.forms.FormType;
 import com.monteweb.notification.NotificationModuleApi;
 import com.monteweb.notification.NotificationType;
 import com.monteweb.room.RoomModuleApi;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -25,8 +24,7 @@ public class FormsNotificationListener {
         this.roomModule = roomModule;
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onFormPublished(FormPublishedEvent event) {
         if (event.scope() != FormScope.ROOM || event.scopeId() == null) return;
 

--- a/backend/src/main/java/com/monteweb/notification/internal/service/MentionNotificationListener.java
+++ b/backend/src/main/java/com/monteweb/notification/internal/service/MentionNotificationListener.java
@@ -1,7 +1,9 @@
 package com.monteweb.notification.internal.service;
 
 import com.monteweb.feed.FeedCommentCreatedEvent;
+import com.monteweb.feed.FeedModuleApi;
 import com.monteweb.feed.FeedPostCreatedEvent;
+import com.monteweb.feed.FeedPostInfo;
 import com.monteweb.messaging.MessageSentEvent;
 import com.monteweb.notification.NotificationType;
 import com.monteweb.shared.util.MentionParser;
@@ -14,14 +16,21 @@ import java.util.UUID;
 /**
  * Listens for content creation events (posts, comments, messages) and sends
  * MENTION notifications to users who are mentioned via the @[userId:displayName] syntax.
+ *
+ * <p>Additionally, when a comment is added to a post, the post's author receives a
+ * {@link NotificationType#COMMENT} notification (US-330), unless the commenter is the
+ * author themselves or the author was already notified via a mention in the same comment.
  */
 @Component
 public class MentionNotificationListener {
 
     private final NotificationService notificationService;
+    private final FeedModuleApi feedModuleApi;
 
-    public MentionNotificationListener(NotificationService notificationService) {
+    public MentionNotificationListener(NotificationService notificationService,
+                                       FeedModuleApi feedModuleApi) {
         this.notificationService = notificationService;
+        this.feedModuleApi = feedModuleApi;
     }
 
     @ApplicationModuleListener
@@ -49,7 +58,6 @@ public class MentionNotificationListener {
     @ApplicationModuleListener
     public void onFeedCommentCreated(FeedCommentCreatedEvent event) {
         Set<UUID> mentionedIds = MentionParser.extractMentionedUserIds(event.content());
-        if (mentionedIds.isEmpty()) return;
 
         String link = "/feed";
 
@@ -66,6 +74,26 @@ public class MentionNotificationListener {
                     event.commentId()
             );
         }
+
+        // Notify the post author about the new comment (US-330: COMMENT notification),
+        // unless they wrote the comment themselves or were already notified via a mention.
+        FeedPostInfo post = feedModuleApi.findPostById(event.postId()).orElse(null);
+        if (post == null) return;
+
+        UUID postAuthorId = post.authorId();
+        if (postAuthorId == null) return;
+        if (postAuthorId.equals(event.authorId())) return;
+        if (mentionedIds.contains(postAuthorId)) return;
+
+        notificationService.sendNotification(
+                postAuthorId,
+                NotificationType.COMMENT,
+                event.authorName() + " hat deinen Beitrag kommentiert",
+                truncate(event.content(), 100),
+                link,
+                "FEED_COMMENT",
+                event.commentId()
+        );
     }
 
     @ApplicationModuleListener

--- a/backend/src/main/java/com/monteweb/notification/internal/service/RoomJoinRequestNotificationListener.java
+++ b/backend/src/main/java/com/monteweb/notification/internal/service/RoomJoinRequestNotificationListener.java
@@ -6,8 +6,7 @@ import com.monteweb.room.RoomJoinRequestEvent;
 import com.monteweb.room.RoomJoinRequestResolvedEvent;
 import com.monteweb.room.RoomModuleApi;
 import com.monteweb.room.RoomRole;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,8 +21,7 @@ public class RoomJoinRequestNotificationListener {
         this.roomModule = roomModule;
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onRoomJoinRequest(RoomJoinRequestEvent event) {
         String title = "Beitrittsanfrage: " + event.roomName();
         String message = event.requesterName() + " möchte dem Raum " + event.roomName() + " beitreten";
@@ -46,8 +44,7 @@ public class RoomJoinRequestNotificationListener {
         }
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onRoomJoinRequestResolved(RoomJoinRequestResolvedEvent event) {
         String title;
         String message;

--- a/backend/src/main/java/com/monteweb/parentletter/ParentLetterAttachmentInfo.java
+++ b/backend/src/main/java/com/monteweb/parentletter/ParentLetterAttachmentInfo.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 public record ParentLetterAttachmentInfo(
     UUID id,
     String originalFilename,
-    String storagePath,
     long fileSize,
     String contentType,
     int sortOrder,

--- a/backend/src/main/java/com/monteweb/parentletter/internal/controller/ParentLetterController.java
+++ b/backend/src/main/java/com/monteweb/parentletter/internal/controller/ParentLetterController.java
@@ -206,7 +206,8 @@ public class ParentLetterController {
     @GetMapping("/{id}/attachments")
     public ResponseEntity<ApiResponse<List<ParentLetterAttachmentInfo>>> getAttachments(
             @PathVariable UUID id) {
-        var result = parentLetterService.getAttachments(id);
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        var result = parentLetterService.getAttachments(id, userId);
         return ResponseEntity.ok(ApiResponse.ok(result));
     }
 
@@ -215,8 +216,8 @@ public class ParentLetterController {
             @PathVariable UUID id,
             @PathVariable UUID attachmentId) {
         UUID userId = SecurityUtils.requireCurrentUserId();
-        var info = parentLetterService.getAttachmentInfo(attachmentId);
-        var stream = parentLetterService.downloadAttachment(attachmentId, userId);
+        var info = parentLetterService.getAttachmentInfo(id, attachmentId, userId);
+        var stream = parentLetterService.downloadAttachment(id, attachmentId, userId);
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_TYPE, info.contentType())
                 .header(HttpHeaders.CONTENT_DISPOSITION,

--- a/backend/src/main/java/com/monteweb/parentletter/internal/repository/ParentLetterRecipientRepository.java
+++ b/backend/src/main/java/com/monteweb/parentletter/internal/repository/ParentLetterRecipientRepository.java
@@ -22,6 +22,8 @@ public interface ParentLetterRecipientRepository extends JpaRepository<ParentLet
     Optional<ParentLetterRecipient> findByLetterIdAndParentIdAndStudentId(
             UUID letterId, UUID parentId, UUID studentId);
 
+    boolean existsByLetterIdAndParentId(UUID letterId, UUID parentId);
+
     List<ParentLetterRecipient> findByParentIdAndStatus(UUID parentId, RecipientStatus status);
 
     long countByLetterIdAndStatus(UUID letterId, RecipientStatus status);

--- a/backend/src/main/java/com/monteweb/parentletter/internal/service/ParentLetterService.java
+++ b/backend/src/main/java/com/monteweb/parentletter/internal/service/ParentLetterService.java
@@ -401,21 +401,36 @@ public class ParentLetterService implements ParentLetterModuleApi {
     }
 
     @Transactional(readOnly = true)
-    public List<ParentLetterAttachmentInfo> getAttachments(UUID letterId) {
+    public List<ParentLetterAttachmentInfo> getAttachments(UUID letterId, UUID userId) {
+        requireLetterAccess(letterId, userId);
         return attachmentRepository.findByLetterIdOrderBySortOrder(letterId).stream()
                 .map(this::toAttachmentInfo)
                 .toList();
     }
 
-    public InputStream downloadAttachment(UUID attachmentId, UUID userId) {
+    /**
+     * Load an attachment after verifying that it belongs to the given letter and that
+     * the caller is authorized to access that letter.
+     */
+    private ParentLetterAttachment loadAuthorizedAttachment(UUID letterId, UUID attachmentId, UUID userId) {
         var attachment = attachmentRepository.findById(attachmentId)
                 .orElseThrow(() -> new ResourceNotFoundException("Attachment", attachmentId));
+        if (!attachment.getLetter().getId().equals(letterId)) {
+            throw new ResourceNotFoundException("Attachment", attachmentId);
+        }
+        requireLetterAccess(letterId, userId);
+        return attachment;
+    }
+
+    @Transactional(readOnly = true)
+    public InputStream downloadAttachment(UUID letterId, UUID attachmentId, UUID userId) {
+        var attachment = loadAuthorizedAttachment(letterId, attachmentId, userId);
         return storageService.downloadAttachment(attachment.getStoragePath());
     }
 
-    public ParentLetterAttachmentInfo getAttachmentInfo(UUID attachmentId) {
-        var attachment = attachmentRepository.findById(attachmentId)
-                .orElseThrow(() -> new ResourceNotFoundException("Attachment", attachmentId));
+    @Transactional(readOnly = true)
+    public ParentLetterAttachmentInfo getAttachmentInfo(UUID letterId, UUID attachmentId, UUID userId) {
+        var attachment = loadAuthorizedAttachment(letterId, attachmentId, userId);
         return toAttachmentInfo(attachment);
     }
 
@@ -437,7 +452,6 @@ public class ParentLetterService implements ParentLetterModuleApi {
         return new ParentLetterAttachmentInfo(
                 attachment.getId(),
                 attachment.getOriginalFilename(),
-                attachment.getStoragePath(),
                 attachment.getFileSize(),
                 attachment.getContentType(),
                 attachment.getSortOrder(),
@@ -639,6 +653,31 @@ public class ParentLetterService implements ParentLetterModuleApi {
         var role = roomModuleApi.getUserRoleInRoom(userId, roomId);
         if (role.isEmpty() || role.get() != RoomRole.LEADER) {
             throw new ForbiddenException("Only LEADER or SUPERADMIN can manage parent letters");
+        }
+    }
+
+    /**
+     * Authorize read access to a letter (and its attachments).
+     * Allowed: SUPERADMIN, the letter's creator, a LEADER of the letter's room,
+     * or a parent recipient of the letter. Mirrors the checks in
+     * {@link #getLetterDetail} plus the recipient-parent check from {@link #getLetterForParent}.
+     */
+    private void requireLetterAccess(UUID letterId, UUID userId) {
+        var letter = letterRepository.findById(letterId)
+                .orElseThrow(() -> new ResourceNotFoundException("ParentLetter", letterId));
+
+        var user = userModuleApi.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+
+        boolean isSuperadmin = user.role() == UserRole.SUPERADMIN;
+        boolean isCreator = userId.equals(letter.getCreatedBy());
+        boolean isLeader = roomModuleApi.getUserRoleInRoom(userId, letter.getRoomId())
+                .map(role -> role == RoomRole.LEADER)
+                .orElse(false);
+        boolean isRecipientParent = recipientRepository.existsByLetterIdAndParentId(letterId, userId);
+
+        if (!isSuperadmin && !isCreator && !isLeader && !isRecipientParent) {
+            throw new ForbiddenException("You are not authorized to access this letter");
         }
     }
 

--- a/backend/src/main/java/com/monteweb/room/internal/controller/RoomController.java
+++ b/backend/src/main/java/com/monteweb/room/internal/controller/RoomController.java
@@ -135,7 +135,7 @@ public class RoomController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<RoomInfo>> create(@Valid @RequestBody CreateRoomRequest request) {
-        UUID userId = SecurityUtils.requireCurrentUserId();
+        UUID userId = requireRoomCreator();
         var room = roomService.create(
                 request.name(), request.description(), request.type(), request.sectionId(), userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(room));
@@ -324,6 +324,27 @@ public class RoomController {
         if (user.isEmpty() || user.get().role() != UserRole.SUPERADMIN) {
             throw new ForbiddenException("Only administrators can perform this action");
         }
+    }
+
+    /**
+     * Room creation (US-050) is restricted to staff: SUPERADMIN, SECTION_ADMIN and
+     * TEACHER may create KLASSE/GRUPPE/PROJEKT rooms. PARENT and STUDENT are rejected
+     * with 403 (they may only create interest rooms via {@code POST /rooms/interest}).
+     *
+     * @return the current user's id (already resolved) for reuse by the caller
+     */
+    private UUID requireRoomCreator() {
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        var user = userModuleApi.findById(userId);
+        if (user.isPresent()) {
+            var role = user.get().role();
+            if (role == UserRole.SUPERADMIN
+                    || role == UserRole.SECTION_ADMIN
+                    || role == UserRole.TEACHER) {
+                return userId;
+            }
+        }
+        throw new ForbiddenException("Only teachers or administrators can create rooms");
     }
 
     private void requireLeaderOrAdmin(UUID roomId) {

--- a/backend/src/main/java/com/monteweb/room/internal/service/DiscussionThreadService.java
+++ b/backend/src/main/java/com/monteweb/room/internal/service/DiscussionThreadService.java
@@ -46,7 +46,12 @@ public class DiscussionThreadService {
     }
 
     public Page<ThreadInfo> getThreads(UUID roomId, UUID userId, String statusFilter, Pageable pageable) {
-        requireRoomMember(roomId, userId);
+        // Fetch user role once (reused for membership check + audience filtering)
+        var userRole = userModuleApi.findById(userId).map(u -> u.role()).orElse(null);
+        boolean isAdmin = userRole == UserRole.SUPERADMIN || userRole == UserRole.SECTION_ADMIN;
+        if (!isAdmin && !roomModuleApi.isUserInRoom(userId, roomId)) {
+            throw new ForbiddenException("You are not a member of this room");
+        }
 
         var room = roomRepository.findById(roomId).orElse(null);
         var settings = room != null ? room.getSettings() : RoomSettings.defaults();
@@ -57,8 +62,6 @@ public class DiscussionThreadService {
         }
 
         // Determine which audiences the user can see
-        var user = userModuleApi.findById(userId);
-        var userRole = user.map(u -> u.role()).orElse(null);
         var roomRole = roomModuleApi.getUserRoleInRoom(userId, roomId).orElse(null);
 
         boolean canSeeAll = userRole == UserRole.TEACHER || userRole == UserRole.SUPERADMIN
@@ -201,14 +204,14 @@ public class DiscussionThreadService {
                 .orElseThrow(() -> new ResourceNotFoundException("Discussion thread", threadId));
     }
 
-    private boolean isSuperAdmin(UUID userId) {
+    private boolean hasAdminRole(UUID userId) {
         return userModuleApi.findById(userId)
                 .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
                 .orElse(false);
     }
 
     private void requireRoomMember(UUID roomId, UUID userId) {
-        if (!isSuperAdmin(userId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRole(userId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("You are not a member of this room");
         }
     }
@@ -243,7 +246,7 @@ public class DiscussionThreadService {
     }
 
     /**
-     * Check if user can manage (archive/delete) threads: LEADER, TEACHER, SUPERADMIN.
+     * Check if user can manage (archive/delete) threads: LEADER, TEACHER, SUPERADMIN, SECTION_ADMIN.
      */
     private void requireThreadManager(UUID roomId, UUID userId) {
         var userRole = userModuleApi.findById(userId).map(u -> u.role()).orElse(null);

--- a/backend/src/main/java/com/monteweb/room/internal/service/DiscussionThreadService.java
+++ b/backend/src/main/java/com/monteweb/room/internal/service/DiscussionThreadService.java
@@ -46,10 +46,9 @@ public class DiscussionThreadService {
     }
 
     public Page<ThreadInfo> getThreads(UUID roomId, UUID userId, String statusFilter, Pageable pageable) {
-        // Fetch user role once (reused for membership check + audience filtering)
-        var userRole = userModuleApi.findById(userId).map(u -> u.role()).orElse(null);
-        boolean isAdmin = userRole == UserRole.SUPERADMIN || userRole == UserRole.SECTION_ADMIN;
-        if (!isAdmin && !roomModuleApi.isUserInRoom(userId, roomId)) {
+        // Membership gate: global admins and section admins scoped to this room's section
+        // may always list; otherwise the user must be a member.
+        if (!hasAdminRoleForRoom(userId, roomId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("You are not a member of this room");
         }
 
@@ -61,14 +60,11 @@ public class DiscussionThreadService {
             return Page.empty(pageable);
         }
 
-        // Determine which audiences the user can see
-        var roomRole = roomModuleApi.getUserRoleInRoom(userId, roomId).orElse(null);
-
-        boolean canSeeAll = userRole == UserRole.TEACHER || userRole == UserRole.SUPERADMIN
-                || userRole == UserRole.SECTION_ADMIN || roomRole == RoomRole.LEADER;
+        // Determine which audiences the user can see (null => may see all audiences)
+        var allowedAudiences = allowedAudiencesFor(roomId, userId, settings);
 
         Page<DiscussionThread> threads;
-        if (canSeeAll) {
+        if (allowedAudiences == null) {
             if (statusFilter != null && !statusFilter.isBlank()) {
                 threads = threadRepository.findByRoomIdAndStatusOrderByCreatedAtDesc(
                         roomId, ThreadStatus.valueOf(statusFilter.toUpperCase()), pageable);
@@ -76,21 +72,6 @@ public class DiscussionThreadService {
                 threads = threadRepository.findByRoomIdOrderByCreatedAtDesc(roomId, pageable);
             }
         } else {
-            boolean isParent = roomRole == RoomRole.PARENT_MEMBER || userRole == UserRole.PARENT;
-            boolean isStudent = userRole == UserRole.STUDENT;
-
-            java.util.List<ThreadAudience> allowedAudiences;
-            if (isParent) {
-                allowedAudiences = java.util.List.of(ThreadAudience.ALLE, ThreadAudience.ELTERN);
-            } else if (isStudent && settings.childDiscussionEnabled()) {
-                allowedAudiences = java.util.List.of(ThreadAudience.ALLE, ThreadAudience.KINDER);
-            } else if (isStudent) {
-                // Child discussions not enabled: only see ALLE
-                allowedAudiences = java.util.List.of(ThreadAudience.ALLE);
-            } else {
-                allowedAudiences = java.util.List.of(ThreadAudience.ALLE);
-            }
-
             if (statusFilter != null && !statusFilter.isBlank()) {
                 threads = threadRepository.findByRoomIdAndStatusAndAudienceInOrderByCreatedAtDesc(
                         roomId, ThreadStatus.valueOf(statusFilter.toUpperCase()), allowedAudiences, pageable);
@@ -109,6 +90,7 @@ public class DiscussionThreadService {
         if (!thread.getRoomId().equals(roomId)) {
             throw new ResourceNotFoundException("Thread", threadId);
         }
+        requireCanViewThread(thread, userId);
         return toThreadInfo(thread);
     }
 
@@ -164,6 +146,7 @@ public class DiscussionThreadService {
         if (!thread.getRoomId().equals(roomId)) {
             throw new ResourceNotFoundException("Thread", threadId);
         }
+        requireCanViewThread(thread, userId);
         return replyRepository.findByThreadIdOrderByCreatedAtAsc(threadId, pageable)
                 .map(this::toReplyInfo);
     }
@@ -186,6 +169,7 @@ public class DiscussionThreadService {
         if (!thread.getRoomId().equals(roomId)) {
             throw new ResourceNotFoundException("Thread", threadId);
         }
+        requireCanViewThread(thread, userId);
         if (thread.getStatus() != ThreadStatus.ACTIVE) {
             throw new BusinessException("Cannot reply to an archived thread");
         }
@@ -204,14 +188,74 @@ public class DiscussionThreadService {
                 .orElseThrow(() -> new ResourceNotFoundException("Discussion thread", threadId));
     }
 
-    private boolean hasAdminRole(UUID userId) {
-        return userModuleApi.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
-                .orElse(false);
+    /**
+     * Computes which thread audiences a user may see in a room.
+     * Returns {@code null} when the user may see ALL audiences (TEACHER, SUPERADMIN,
+     * SECTION_ADMIN, or room LEADER). Otherwise returns the explicit list of allowed audiences.
+     * Mirrors the audience logic used by {@link #getThreads}.
+     */
+    private java.util.List<ThreadAudience> allowedAudiencesFor(UUID roomId, UUID userId, RoomSettings settings) {
+        var userRole = userModuleApi.findById(userId).map(u -> u.role()).orElse(null);
+        var roomRole = roomModuleApi.getUserRoleInRoom(userId, roomId).orElse(null);
+
+        boolean canSeeAll = userRole == UserRole.TEACHER || userRole == UserRole.SUPERADMIN
+                || userRole == UserRole.SECTION_ADMIN || roomRole == RoomRole.LEADER;
+        if (canSeeAll) {
+            return null;
+        }
+
+        boolean isParent = roomRole == RoomRole.PARENT_MEMBER || userRole == UserRole.PARENT;
+        boolean isStudent = userRole == UserRole.STUDENT;
+
+        if (isParent) {
+            return java.util.List.of(ThreadAudience.ALLE, ThreadAudience.ELTERN);
+        } else if (isStudent && settings.childDiscussionEnabled()) {
+            return java.util.List.of(ThreadAudience.ALLE, ThreadAudience.KINDER);
+        } else {
+            // Students without child discussions enabled, or any other member: only ALLE
+            return java.util.List.of(ThreadAudience.ALLE);
+        }
+    }
+
+    /**
+     * Ensures the caller is allowed to view a thread based on its audience.
+     * Applies the SAME audience filter as {@link #getThreads} so that single-thread reads
+     * (and replies) cannot bypass the list-level audience restriction. Throws
+     * {@link ResourceNotFoundException} to avoid revealing the existence of hidden threads.
+     */
+    private void requireCanViewThread(DiscussionThread thread, UUID userId) {
+        var room = roomRepository.findById(thread.getRoomId()).orElse(null);
+        var settings = room != null ? room.getSettings() : RoomSettings.defaults();
+        var allowed = allowedAudiencesFor(thread.getRoomId(), userId, settings);
+        if (allowed != null && !allowed.contains(thread.getAudience())) {
+            throw new ResourceNotFoundException("Discussion thread", thread.getId());
+        }
+    }
+
+    /**
+     * Returns true if the user is a global SUPERADMIN, or a SECTION_ADMIN scoped to the
+     * section the given room belongs to. SECTION_ADMINs are NOT global admins: a section
+     * admin scoped to e.g. Krippe must not gain access to an Oberstufe room.
+     * Mirrors {@code RoomController.requireLeaderOrAdmin} / {@code isAdminForSection}.
+     */
+    private boolean hasAdminRoleForRoom(UUID userId, UUID roomId) {
+        var user = userModuleApi.findById(userId).orElse(null);
+        if (user == null) {
+            return false;
+        }
+        if (user.role() == UserRole.SUPERADMIN) {
+            return true;
+        }
+        if (user.role() == UserRole.SECTION_ADMIN) {
+            var sectionId = roomModuleApi.findById(roomId).map(r -> r.sectionId()).orElse(null);
+            return sectionId != null && user.specialRoles() != null
+                    && user.specialRoles().contains("SECTION_ADMIN:" + sectionId);
+        }
+        return false;
     }
 
     private void requireRoomMember(UUID roomId, UUID userId) {
-        if (!hasAdminRole(userId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRoleForRoom(userId, roomId) && !roomModuleApi.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("You are not a member of this room");
         }
     }
@@ -222,8 +266,8 @@ public class DiscussionThreadService {
      */
     private void requireThreadCreator(UUID roomId, UUID userId) {
         var userRole = userModuleApi.findById(userId).map(u -> u.role()).orElse(null);
-        // SUPERADMIN / SECTION_ADMIN can always create
-        if (userRole == UserRole.SUPERADMIN || userRole == UserRole.SECTION_ADMIN) return;
+        // SUPERADMIN (global) and SECTION_ADMIN scoped to this room's section can always create
+        if (hasAdminRoleForRoom(userId, roomId)) return;
 
         var roomRole = roomModuleApi.getUserRoleInRoom(userId, roomId)
                 .orElseThrow(() -> new ForbiddenException("You are not a member of this room"));
@@ -250,7 +294,7 @@ public class DiscussionThreadService {
      */
     private void requireThreadManager(UUID roomId, UUID userId) {
         var userRole = userModuleApi.findById(userId).map(u -> u.role()).orElse(null);
-        if (userRole == UserRole.SUPERADMIN || userRole == UserRole.SECTION_ADMIN) return;
+        if (hasAdminRoleForRoom(userId, roomId)) return;
 
         var roomRole = roomModuleApi.getUserRoleInRoom(userId, roomId)
                 .orElseThrow(() -> new ForbiddenException("You are not a member of this room"));

--- a/backend/src/main/java/com/monteweb/room/internal/service/RoomChatService.java
+++ b/backend/src/main/java/com/monteweb/room/internal/service/RoomChatService.java
@@ -37,9 +37,9 @@ public class RoomChatService {
     private final MessagingModuleApi messagingModuleApi;
     private final UserModuleApi userModuleApi;
 
-    private boolean isSuperAdmin(UUID userId) {
+    private boolean hasAdminRole(UUID userId) {
         return userModuleApi.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN)
+                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
                 .orElse(false);
     }
 
@@ -48,7 +48,7 @@ public class RoomChatService {
      */
     @Transactional(readOnly = true)
     public List<RoomChatChannelInfo> getChannels(UUID roomId, UUID userId) {
-        boolean superAdmin = isSuperAdmin(userId);
+        boolean superAdmin = hasAdminRole(userId);
 
         if (!superAdmin && !roomService.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
@@ -82,7 +82,7 @@ public class RoomChatService {
      */
     @Transactional
     public RoomChatChannelInfo getOrCreateChannel(UUID roomId, UUID userId, ChannelType type) {
-        boolean superAdmin = isSuperAdmin(userId);
+        boolean superAdmin = hasAdminRole(userId);
 
         if (!superAdmin && !roomService.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");

--- a/backend/src/main/java/com/monteweb/room/internal/service/RoomChatService.java
+++ b/backend/src/main/java/com/monteweb/room/internal/service/RoomChatService.java
@@ -37,10 +37,26 @@ public class RoomChatService {
     private final MessagingModuleApi messagingModuleApi;
     private final UserModuleApi userModuleApi;
 
-    private boolean hasAdminRole(UUID userId) {
-        return userModuleApi.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
-                .orElse(false);
+    /**
+     * Returns true if the user is a global SUPERADMIN, or a SECTION_ADMIN scoped to the
+     * section the given room belongs to. SECTION_ADMINs are NOT global admins: a section
+     * admin scoped to e.g. Krippe must not gain access to an Oberstufe room's chat.
+     * Mirrors {@code RoomController.requireLeaderOrAdmin} / {@code isAdminForSection}.
+     */
+    private boolean hasAdminRoleForRoom(UUID userId, UUID roomId) {
+        var user = userModuleApi.findById(userId).orElse(null);
+        if (user == null) {
+            return false;
+        }
+        if (user.role() == UserRole.SUPERADMIN) {
+            return true;
+        }
+        if (user.role() == UserRole.SECTION_ADMIN) {
+            var sectionId = roomService.findById(roomId).map(r -> r.sectionId()).orElse(null);
+            return sectionId != null && user.specialRoles() != null
+                    && user.specialRoles().contains("SECTION_ADMIN:" + sectionId);
+        }
+        return false;
     }
 
     /**
@@ -48,7 +64,7 @@ public class RoomChatService {
      */
     @Transactional(readOnly = true)
     public List<RoomChatChannelInfo> getChannels(UUID roomId, UUID userId) {
-        boolean superAdmin = hasAdminRole(userId);
+        boolean superAdmin = hasAdminRoleForRoom(userId, roomId);
 
         if (!superAdmin && !roomService.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
@@ -82,7 +98,7 @@ public class RoomChatService {
      */
     @Transactional
     public RoomChatChannelInfo getOrCreateChannel(UUID roomId, UUID userId, ChannelType type) {
-        boolean superAdmin = hasAdminRole(userId);
+        boolean superAdmin = hasAdminRoleForRoom(userId, roomId);
 
         if (!superAdmin && !roomService.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");

--- a/backend/src/main/java/com/monteweb/search/internal/service/SearchService.java
+++ b/backend/src/main/java/com/monteweb/search/internal/service/SearchService.java
@@ -4,18 +4,25 @@ import com.monteweb.calendar.CalendarModuleApi;
 import com.monteweb.calendar.EventInfo;
 import com.monteweb.feed.FeedModuleApi;
 import com.monteweb.feed.FeedPostInfo;
+import com.monteweb.files.FileInfo;
+import com.monteweb.files.FilesModuleApi;
 import com.monteweb.room.RoomInfo;
 import com.monteweb.room.RoomModuleApi;
 import com.monteweb.search.SearchResult;
+import com.monteweb.tasks.TasksModuleApi;
 import com.monteweb.user.UserInfo;
 import com.monteweb.user.UserModuleApi;
+import com.monteweb.wiki.WikiModuleApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -25,17 +32,26 @@ public class SearchService {
     private final RoomModuleApi roomModuleApi;
     private final FeedModuleApi feedModuleApi;
     private final CalendarModuleApi calendarModuleApi;
+    private final FilesModuleApi filesModuleApi;
+    private final WikiModuleApi wikiModuleApi;
+    private final TasksModuleApi tasksModuleApi;
     private final SolrSearchService solrSearchService;
 
     public SearchService(UserModuleApi userModuleApi,
                          RoomModuleApi roomModuleApi,
                          @Autowired(required = false) FeedModuleApi feedModuleApi,
                          @Autowired(required = false) CalendarModuleApi calendarModuleApi,
+                         @Autowired(required = false) FilesModuleApi filesModuleApi,
+                         @Autowired(required = false) WikiModuleApi wikiModuleApi,
+                         @Autowired(required = false) TasksModuleApi tasksModuleApi,
                          @Autowired(required = false) SolrSearchService solrSearchService) {
         this.userModuleApi = userModuleApi;
         this.roomModuleApi = roomModuleApi;
         this.feedModuleApi = feedModuleApi;
         this.calendarModuleApi = calendarModuleApi;
+        this.filesModuleApi = filesModuleApi;
+        this.wikiModuleApi = wikiModuleApi;
+        this.tasksModuleApi = tasksModuleApi;
         this.solrSearchService = solrSearchService;
     }
 
@@ -67,6 +83,19 @@ public class SearchService {
         }
         if ("ALL".equals(type) || "EVENT".equals(type)) {
             results.addAll(searchEvents(q, limit));
+        }
+        // Room-scoped types: only resolve the user's accessible rooms when needed.
+        if (isRoomScopedRequested(type)) {
+            Set<UUID> accessibleRoomIds = resolveAccessibleRoomIds(userId);
+            if ("ALL".equals(type) || "FILE".equals(type)) {
+                results.addAll(searchFiles(q, limit, accessibleRoomIds));
+            }
+            if ("ALL".equals(type) || "WIKI".equals(type)) {
+                results.addAll(searchWiki(q, limit, accessibleRoomIds));
+            }
+            if ("ALL".equals(type) || "TASK".equals(type)) {
+                results.addAll(searchTasks(q, limit, accessibleRoomIds));
+            }
         }
 
         // Sort: exact title matches first, then by timestamp descending
@@ -127,6 +156,88 @@ public class SearchService {
         }
     }
 
+    private boolean isRoomScopedRequested(String type) {
+        return "ALL".equals(type) || "FILE".equals(type) || "WIKI".equals(type) || "TASK".equals(type);
+    }
+
+    /**
+     * Resolves the set of room IDs the user may see. Room-scoped fallback results
+     * (FILE, WIKI, TASK) must be constrained to these rooms — mirroring the Solr
+     * access filter in {@link SolrSearchService}. Fails closed (empty set) on error
+     * or when no user is given.
+     */
+    private Set<UUID> resolveAccessibleRoomIds(UUID userId) {
+        if (userId == null) return Set.of();
+        try {
+            return roomModuleApi.findByUserId(userId).stream()
+                    .map(RoomInfo::id)
+                    .collect(java.util.stream.Collectors.toCollection(HashSet::new));
+        } catch (Exception e) {
+            return Set.of();
+        }
+    }
+
+    private List<SearchResult> searchFiles(String query, int limit, Set<UUID> accessibleRoomIds) {
+        if (filesModuleApi == null || accessibleRoomIds.isEmpty()) return List.of();
+        String lowerQ = query.toLowerCase();
+        try {
+            return filesModuleApi.findAllFiles().stream()
+                    .filter(f -> f.roomId() != null && accessibleRoomIds.contains(f.roomId()))
+                    .filter(f -> f.originalName() != null
+                            && f.originalName().toLowerCase().contains(lowerQ))
+                    .limit(limit)
+                    .map(this::toFileResult)
+                    .toList();
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    private List<SearchResult> searchWiki(String query, int limit, Set<UUID> accessibleRoomIds) {
+        if (wikiModuleApi == null || accessibleRoomIds.isEmpty()) return List.of();
+        String lowerQ = query.toLowerCase();
+        try {
+            return wikiModuleApi.findAllPagesForIndexing().stream()
+                    .filter(p -> {
+                        UUID roomId = (UUID) p.get("roomId");
+                        return roomId != null && accessibleRoomIds.contains(roomId);
+                    })
+                    .filter(p -> matchesAny(lowerQ, (String) p.get("title"), (String) p.get("content")))
+                    .limit(limit)
+                    .map(this::toWikiResult)
+                    .toList();
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    private List<SearchResult> searchTasks(String query, int limit, Set<UUID> accessibleRoomIds) {
+        if (tasksModuleApi == null || accessibleRoomIds.isEmpty()) return List.of();
+        String lowerQ = query.toLowerCase();
+        try {
+            return tasksModuleApi.findAllTasksForIndexing().stream()
+                    .filter(t -> {
+                        UUID roomId = (UUID) t.get("roomId");
+                        return roomId != null && accessibleRoomIds.contains(roomId);
+                    })
+                    .filter(t -> matchesAny(lowerQ, (String) t.get("title"), (String) t.get("description")))
+                    .limit(limit)
+                    .map(this::toTaskResult)
+                    .toList();
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    private boolean matchesAny(String lowerQ, String... fields) {
+        for (String field : fields) {
+            if (field != null && field.toLowerCase().contains(lowerQ)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private SearchResult toUserResult(UserInfo user) {
         return new SearchResult(
                 user.id(),
@@ -176,6 +287,63 @@ public class SearchService {
                 "/calendar?event=" + event.id(),
                 event.createdAt()
         );
+    }
+
+    private SearchResult toFileResult(FileInfo file) {
+        String roomName = roomName(file.roomId());
+        return new SearchResult(
+                file.id(),
+                "FILE",
+                file.originalName(),
+                roomName,
+                file.contentType(),
+                "/rooms/" + file.roomId() + "/files",
+                file.createdAt()
+        );
+    }
+
+    private SearchResult toWikiResult(Map<String, Object> page) {
+        UUID pageId = (UUID) page.get("id");
+        UUID roomId = (UUID) page.get("roomId");
+        String title = (String) page.get("title");
+        String content = (String) page.get("content");
+        String slug = (String) page.get("slug");
+        String roomName = roomName(roomId);
+        return new SearchResult(
+                pageId,
+                "WIKI",
+                title,
+                roomName != null ? "Wiki - " + roomName : "Wiki",
+                truncate(content, 150),
+                "/rooms/" + roomId + "/wiki/" + slug,
+                null
+        );
+    }
+
+    private SearchResult toTaskResult(Map<String, Object> task) {
+        UUID taskId = (UUID) task.get("id");
+        UUID roomId = (UUID) task.get("roomId");
+        String title = (String) task.get("title");
+        String description = (String) task.get("description");
+        String roomName = roomName(roomId);
+        return new SearchResult(
+                taskId,
+                "TASK",
+                title,
+                roomName != null ? "Aufgabe - " + roomName : "Aufgabe",
+                truncate(description, 150),
+                "/rooms/" + roomId + "/tasks",
+                null
+        );
+    }
+
+    private String roomName(UUID roomId) {
+        if (roomId == null) return null;
+        try {
+            return roomModuleApi.findById(roomId).map(RoomInfo::name).orElse(null);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private String truncate(String text, int maxLength) {

--- a/backend/src/main/java/com/monteweb/search/internal/service/SearchService.java
+++ b/backend/src/main/java/com/monteweb/search/internal/service/SearchService.java
@@ -46,7 +46,7 @@ public class SearchService {
 
         // Delegate to Solr if available
         if (solrSearchService != null) {
-            return solrSearchService.search(query.trim(), type, limit);
+            return solrSearchService.search(query.trim(), type, limit, userId);
         }
 
         // Fallback: DB-based search

--- a/backend/src/main/java/com/monteweb/search/internal/service/SolrIndexingListener.java
+++ b/backend/src/main/java/com/monteweb/search/internal/service/SolrIndexingListener.java
@@ -14,8 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
 import java.io.InputStream;
@@ -53,8 +52,7 @@ public class SolrIndexingListener {
         this.indexingService = indexingService;
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onFeedPostCreated(FeedPostCreatedEvent event) {
         log.debug("Indexing feed post: {}", event.postId());
         if (feedModuleApi == null) return;
@@ -62,8 +60,7 @@ public class SolrIndexingListener {
                 .ifPresent(indexingService::indexFeedPost);
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onFileUploaded(FileUploadedEvent event) {
         log.debug("Indexing uploaded file: {}", event.fileId());
 
@@ -89,38 +86,33 @@ public class SolrIndexingListener {
                 event.originalName(), event.contentType(), event.fileSize());
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onFileDeleted(FileDeletedEvent event) {
         log.debug("Removing file from index: {}", event.fileId());
         indexingService.deleteDocument("FILE", event.fileId());
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onWikiPageSaved(WikiPageSavedEvent event) {
         log.debug("Indexing wiki page: {}", event.pageId());
         indexingService.indexWikiPage(event.pageId(), event.roomId(),
                 event.title(), event.content(), event.slug());
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onWikiPageDeleted(WikiPageDeletedEvent event) {
         log.debug("Removing wiki page from index: {}", event.pageId());
         indexingService.deleteDocument("WIKI", event.pageId());
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onTaskSaved(TaskSavedEvent event) {
         log.debug("Indexing task: {}", event.taskId());
         indexingService.indexTask(event.taskId(), event.roomId(),
                 event.title(), event.description(), event.assigneeName());
     }
 
-    @Async
-    @EventListener
+    @ApplicationModuleListener
     public void onTaskDeleted(TaskDeletedEvent event) {
         log.debug("Removing task from index: {}", event.taskId());
         indexingService.deleteDocument("TASK", event.taskId());

--- a/backend/src/main/java/com/monteweb/search/internal/service/SolrIndexingListener.java
+++ b/backend/src/main/java/com/monteweb/search/internal/service/SolrIndexingListener.java
@@ -1,13 +1,19 @@
 package com.monteweb.search.internal.service;
 
-import com.monteweb.feed.FeedCommentCreatedEvent;
+import com.monteweb.calendar.CalendarModuleApi;
+import com.monteweb.calendar.EventCreatedEvent;
+import com.monteweb.calendar.EventDeletedEvent;
 import com.monteweb.feed.FeedModuleApi;
 import com.monteweb.feed.FeedPostCreatedEvent;
 import com.monteweb.files.FileDeletedEvent;
 import com.monteweb.files.FileUploadedEvent;
 import com.monteweb.files.FilesModuleApi;
+import com.monteweb.room.RoomCreatedEvent;
+import com.monteweb.room.RoomModuleApi;
 import com.monteweb.tasks.TaskDeletedEvent;
 import com.monteweb.tasks.TaskSavedEvent;
+import com.monteweb.user.UserModuleApi;
+import com.monteweb.user.UserRegisteredEvent;
 import com.monteweb.wiki.WikiPageDeletedEvent;
 import com.monteweb.wiki.WikiPageSavedEvent;
 import org.slf4j.Logger;
@@ -17,7 +23,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
-import java.io.InputStream;
 import java.util.Set;
 
 @Component
@@ -41,6 +46,8 @@ public class SolrIndexingListener {
     );
 
     private final SolrIndexingService indexingService;
+    private final UserModuleApi userModuleApi;
+    private final RoomModuleApi roomModuleApi;
 
     @Autowired(required = false)
     private FeedModuleApi feedModuleApi;
@@ -48,8 +55,15 @@ public class SolrIndexingListener {
     @Autowired(required = false)
     private FilesModuleApi filesModuleApi;
 
-    public SolrIndexingListener(SolrIndexingService indexingService) {
+    @Autowired(required = false)
+    private CalendarModuleApi calendarModuleApi;
+
+    public SolrIndexingListener(SolrIndexingService indexingService,
+                                UserModuleApi userModuleApi,
+                                RoomModuleApi roomModuleApi) {
         this.indexingService = indexingService;
+        this.userModuleApi = userModuleApi;
+        this.roomModuleApi = roomModuleApi;
     }
 
     @ApplicationModuleListener
@@ -61,27 +75,49 @@ public class SolrIndexingListener {
     }
 
     @ApplicationModuleListener
+    public void onUserRegistered(UserRegisteredEvent event) {
+        log.debug("Indexing user: {}", event.userId());
+        userModuleApi.findById(event.userId())
+                .ifPresent(indexingService::indexUser);
+    }
+
+    @ApplicationModuleListener
+    public void onRoomCreated(RoomCreatedEvent event) {
+        log.debug("Indexing room: {}", event.roomId());
+        roomModuleApi.findById(event.roomId())
+                .ifPresent(indexingService::indexRoom);
+    }
+
+    @ApplicationModuleListener
+    public void onEventCreated(EventCreatedEvent event) {
+        log.debug("Indexing calendar event: {}", event.eventId());
+        if (calendarModuleApi == null) return;
+        calendarModuleApi.findById(event.eventId())
+                .ifPresent(indexingService::indexEvent);
+    }
+
+    @ApplicationModuleListener
+    public void onEventDeleted(EventDeletedEvent event) {
+        log.debug("Removing calendar event from index: {}", event.eventId());
+        indexingService.deleteDocument("EVENT", event.eventId());
+    }
+
+    @ApplicationModuleListener
     public void onFileUploaded(FileUploadedEvent event) {
         log.debug("Indexing uploaded file: {}", event.fileId());
 
-        // Try content extraction for supported types
+        // Tika full-text extraction (indexFileWithContent) requires streaming the
+        // file's bytes to Solr's /update/extract handler. The files module currently
+        // only exposes getStoragePath(fileId) via FilesModuleApi, not an InputStream,
+        // and the search module has no MinIO client of its own — so we cannot obtain
+        // the content here. We index metadata only until FilesModuleApi exposes a
+        // content-stream accessor (see FLAG in the audit changelog).
         if (filesModuleApi != null && event.contentType() != null && isExtractable(event.contentType())) {
-            String storagePath = filesModuleApi.getStoragePath(event.fileId());
-            if (storagePath != null) {
-                try {
-                    // Download from MinIO for extraction
-                    // We'll index with metadata only — content extraction happens in Solr
-                    // File is streamed directly to Solr's ExtractingRequestHandler
-                    indexingService.indexFile(event.fileId(), event.roomId(),
-                            event.originalName(), event.contentType(), event.fileSize());
-                    return;
-                } catch (Exception e) {
-                    log.warn("Could not extract file content for {}: {}", event.fileId(), e.getMessage());
-                }
-            }
+            log.debug("File {} is an extractable type ({}); indexing metadata only "
+                    + "(Tika extraction needs a content stream from the files module)",
+                    event.fileId(), event.contentType());
         }
 
-        // Fallback: index metadata only
         indexingService.indexFile(event.fileId(), event.roomId(),
                 event.originalName(), event.contentType(), event.fileSize());
     }

--- a/backend/src/main/java/com/monteweb/search/internal/service/SolrIndexingService.java
+++ b/backend/src/main/java/com/monteweb/search/internal/service/SolrIndexingService.java
@@ -81,6 +81,55 @@ public class SolrIndexingService {
         }
     }
 
+    public void indexUser(UserInfo user) {
+        try {
+            SolrInputDocument doc = new SolrInputDocument();
+            doc.addField("id", "USER:" + user.id());
+            doc.addField("doc_type", "USER");
+            doc.addField("entity_id", user.id().toString());
+            doc.addField("title", user.displayName());
+            doc.addField("content", user.email());
+            doc.addField("url", "/users/" + user.id());
+            solrClient.add(doc);
+            solrClient.commit();
+        } catch (SolrServerException | IOException e) {
+            log.error("Failed to index user {}: {}", user.id(), e.getMessage());
+        }
+    }
+
+    public void indexRoom(RoomInfo room) {
+        try {
+            SolrInputDocument doc = new SolrInputDocument();
+            doc.addField("id", "ROOM:" + room.id());
+            doc.addField("doc_type", "ROOM");
+            doc.addField("entity_id", room.id().toString());
+            doc.addField("title", room.name());
+            doc.addField("content", room.description());
+            doc.addField("url", "/rooms/" + room.id());
+            solrClient.add(doc);
+            solrClient.commit();
+        } catch (SolrServerException | IOException e) {
+            log.error("Failed to index room {}: {}", room.id(), e.getMessage());
+        }
+    }
+
+    public void indexEvent(EventInfo event) {
+        try {
+            SolrInputDocument doc = new SolrInputDocument();
+            doc.addField("id", "EVENT:" + event.id());
+            doc.addField("doc_type", "EVENT");
+            doc.addField("entity_id", event.id().toString());
+            doc.addField("title", event.title());
+            doc.addField("content", event.description());
+            doc.addField("url", "/calendar?event=" + event.id());
+            doc.addField("created_at", toDate(event.createdAt()));
+            solrClient.add(doc);
+            solrClient.commit();
+        } catch (SolrServerException | IOException e) {
+            log.error("Failed to index event {}: {}", event.id(), e.getMessage());
+        }
+    }
+
     public void indexWikiPage(UUID pageId, UUID roomId, String title, String content, String slug) {
         try {
             String roomName = roomModuleApi.findById(roomId).map(RoomInfo::name).orElse(null);

--- a/backend/src/main/java/com/monteweb/search/internal/service/SolrSearchService.java
+++ b/backend/src/main/java/com/monteweb/search/internal/service/SolrSearchService.java
@@ -1,5 +1,7 @@
 package com.monteweb.search.internal.service;
 
+import com.monteweb.room.RoomInfo;
+import com.monteweb.room.RoomModuleApi;
 import com.monteweb.search.SearchResult;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -24,12 +26,14 @@ public class SolrSearchService {
     );
 
     private final SolrClient solrClient;
+    private final RoomModuleApi roomModuleApi;
 
-    public SolrSearchService(SolrClient solrClient) {
+    public SolrSearchService(SolrClient solrClient, RoomModuleApi roomModuleApi) {
         this.solrClient = solrClient;
+        this.roomModuleApi = roomModuleApi;
     }
 
-    public List<SearchResult> search(String query, String type, int limit) {
+    public List<SearchResult> search(String query, String type, int limit, UUID userId) {
         try {
             SolrQuery solrQuery = new SolrQuery();
             solrQuery.setQuery(escapeQuery(query));
@@ -43,6 +47,11 @@ public class SolrSearchService {
                 }
                 solrQuery.addFilterQuery("doc_type:" + upperType);
             }
+
+            // Access control: room-scoped documents (FILE, WIKI, TASK) must be
+            // constrained to the rooms the requesting user is a member of.
+            // Documents without a room_id (USER, ROOM, POST, EVENT) always pass.
+            solrQuery.addFilterQuery(buildAccessFilter(userId));
 
             // Highlighting
             solrQuery.setHighlight(true);
@@ -99,6 +108,46 @@ public class SolrSearchService {
             log.error("Solr search failed for query '{}': {}", query, e.getMessage());
             return List.of();
         }
+    }
+
+    /**
+     * Builds a Solr filter query that restricts room-scoped documents to the
+     * rooms the user is a member of, while always allowing documents that have
+     * no room_id (USER, ROOM, POST, EVENT).
+     *
+     * <p>Resulting filter: {@code (*:* -room_id:[* TO *]) OR room_id:(id1 OR id2 ...)}.
+     * If the user is a member of no rooms, the filter collapses to
+     * {@code (*:* -room_id:[* TO *])}, hiding all room-scoped documents.</p>
+     */
+    private String buildAccessFilter(UUID userId) {
+        // Documents without a room_id are never room-scoped and always allowed.
+        String noRoomClause = "(*:* -room_id:[* TO *])";
+
+        if (userId == null) {
+            return noRoomClause;
+        }
+
+        List<UUID> accessibleRoomIds;
+        try {
+            accessibleRoomIds = roomModuleApi.findByUserId(userId).stream()
+                    .map(RoomInfo::id)
+                    .toList();
+        } catch (Exception e) {
+            log.error("Failed to resolve accessible rooms for user {}: {}", userId, e.getMessage());
+            // Fail closed: only non-room-scoped documents are returned.
+            return noRoomClause;
+        }
+
+        if (accessibleRoomIds.isEmpty()) {
+            return noRoomClause;
+        }
+
+        String roomIdsOr = accessibleRoomIds.stream()
+                .map(id -> "\"" + id + "\"")
+                .reduce((a, b) -> a + " OR " + b)
+                .orElse("");
+
+        return noRoomClause + " OR room_id:(" + roomIdsOr + ")";
     }
 
     private String buildSubtitle(String docType, String roomName, String contentType, SolrDocument doc) {

--- a/backend/src/main/java/com/monteweb/shared/config/SecretValidationConfig.java
+++ b/backend/src/main/java/com/monteweb/shared/config/SecretValidationConfig.java
@@ -10,8 +10,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 
-import java.util.Arrays;
-
 /**
  * Validates that critical secrets are properly configured in non-dev/test environments.
  * Logs errors for every weak/default secret found, counts problems, and in production
@@ -52,8 +50,8 @@ public class SecretValidationConfig {
     public void validateSecrets() {
         int problems = 0;
 
-        if (jwtSecret.isBlank() || jwtSecret.contains("dev-only")) {
-            log.error("SECURITY: JWT_SECRET is not configured or uses the insecure default. Set JWT_SECRET environment variable.");
+        if (jwtSecret.isBlank() || jwtSecret.contains("dev-only") || jwtSecret.startsWith("change-this-to-a-secure")) {
+            log.error("SECURITY: JWT_SECRET is not configured or uses the insecure example placeholder. Set JWT_SECRET environment variable.");
             problems++;
         } else if (jwtSecret.length() < 64) {
             log.error("SECURITY: JWT_SECRET is too short ({}). Must be at least 64 characters.", jwtSecret.length());
@@ -81,8 +79,8 @@ public class SecretValidationConfig {
         }
 
         if (encryptionSecret.isBlank()) {
+            // Falls back to JWT_SECRET (documented behaviour) — warn but do not abort startup.
             log.warn("SECURITY: ENCRYPTION_SECRET is not set. AES key falls back to JWT_SECRET — set a separate ENCRYPTION_SECRET (64+ chars).");
-            problems++;
         } else if (encryptionSecret.length() < 64) {
             log.warn("SECURITY: ENCRYPTION_SECRET is too short ({} chars). Use at least 64 characters.", encryptionSecret.length());
             problems++;
@@ -92,14 +90,13 @@ public class SecretValidationConfig {
         }
 
         if (problems > 0) {
-            String profiles = String.join(",", Arrays.asList(environment.getActiveProfiles()));
-            boolean isProd = profiles.contains("prod") || profiles.contains("production");
-            if (isProd) {
-                throw new IllegalStateException(
-                        "SECURITY: " + problems + " secret validation failure(s) detected in production! Fix configuration before starting.");
-            } else {
-                log.warn("SECURITY WARNING: {} secret validation failure(s) detected. These MUST be fixed before production deployment!", problems);
-            }
+            // This bean is @Profile("!dev & !test"), so it only runs in real
+            // (non-dev/non-test) environments. Fail closed: never boot a real
+            // deployment with weak/default secrets. For local development with
+            // relaxed validation, activate the 'dev' profile (SPRING_PROFILES_ACTIVE=dev).
+            throw new IllegalStateException(
+                    "SECURITY: " + problems + " secret validation failure(s) detected. "
+                            + "Fix the configuration before starting, or set SPRING_PROFILES_ACTIVE=dev for local development.");
         } else {
             log.info("Secret validation passed: all critical secrets are configured.");
         }

--- a/backend/src/main/java/com/monteweb/shared/config/SecretValidationConfig.java
+++ b/backend/src/main/java/com/monteweb/shared/config/SecretValidationConfig.java
@@ -48,55 +48,67 @@ public class SecretValidationConfig {
 
     @EventListener(ApplicationReadyEvent.class)
     public void validateSecrets() {
-        int problems = 0;
+        // FATAL = cryptographic secrets whose compromise is catastrophic (token forgery,
+        // decryptable 2FA secrets, forgeable QR check-ins). These abort startup.
+        // WARN = internal-network infra credentials (DB/Redis/MinIO). These only warn, so
+        //        rolling out this guard does not unexpectedly take down an existing
+        //        deployment whose .env still carries the old defaults.
+        int fatal = 0;
+        int warnings = 0;
 
         if (jwtSecret.isBlank() || jwtSecret.contains("dev-only") || jwtSecret.startsWith("change-this-to-a-secure")) {
             log.error("SECURITY: JWT_SECRET is not configured or uses the insecure example placeholder. Set JWT_SECRET environment variable.");
-            problems++;
+            fatal++;
         } else if (jwtSecret.length() < 64) {
             log.error("SECURITY: JWT_SECRET is too short ({}). Must be at least 64 characters.", jwtSecret.length());
-            problems++;
-        }
-
-        if ("changeme".equals(dbPassword) || dbPassword.isBlank()) {
-            log.warn("SECURITY: Database password is not configured or uses the insecure default 'changeme'. Set DB_PASSWORD environment variable.");
-            problems++;
-        }
-
-        if ("changeme".equals(redisPassword) || redisPassword.isBlank()) {
-            log.warn("SECURITY: Redis password is not configured or uses the insecure default 'changeme'. Set REDIS_PASSWORD environment variable.");
-            problems++;
-        }
-
-        if ("minioadmin".equals(minioAccessKey) || "minioadmin".equals(minioSecretKey)) {
-            log.warn("SECURITY: MinIO credentials use the insecure defaults. Set MINIO_ACCESS_KEY and MINIO_SECRET_KEY environment variables.");
-            problems++;
+            fatal++;
         }
 
         if (qrSecret.isBlank() || "monteweb-cleaning-qr-default-secret".equals(qrSecret)) {
             log.error("SECURITY: monteweb.cleaning.qr-secret is not set or uses the insecure default value!");
-            problems++;
+            fatal++;
         }
 
         if (encryptionSecret.isBlank()) {
-            // Falls back to JWT_SECRET (documented behaviour) — warn but do not abort startup.
+            // Falls back to JWT_SECRET (documented behaviour) — warn, do not abort.
             log.warn("SECURITY: ENCRYPTION_SECRET is not set. AES key falls back to JWT_SECRET — set a separate ENCRYPTION_SECRET (64+ chars).");
+            warnings++;
         } else if (encryptionSecret.length() < 64) {
-            log.warn("SECURITY: ENCRYPTION_SECRET is too short ({} chars). Use at least 64 characters.", encryptionSecret.length());
-            problems++;
+            log.error("SECURITY: ENCRYPTION_SECRET is set but too short ({} chars). Use at least 64 characters.", encryptionSecret.length());
+            fatal++;
         } else if (encryptionSecret.equals(jwtSecret)) {
             log.error("SECURITY: ENCRYPTION_SECRET must differ from JWT_SECRET.");
-            problems++;
+            fatal++;
         }
 
-        if (problems > 0) {
+        if ("changeme".equals(dbPassword) || dbPassword.isBlank()) {
+            log.warn("SECURITY: Database password is not configured or uses the insecure default 'changeme'. Set DB_PASSWORD environment variable.");
+            warnings++;
+        }
+
+        if ("changeme".equals(redisPassword) || redisPassword.isBlank()) {
+            log.warn("SECURITY: Redis password is not configured or uses the insecure default 'changeme'. Set REDIS_PASSWORD environment variable.");
+            warnings++;
+        }
+
+        if ("minioadmin".equals(minioAccessKey) || "minioadmin".equals(minioSecretKey)) {
+            log.warn("SECURITY: MinIO credentials use the insecure defaults. Set MINIO_ACCESS_KEY and MINIO_SECRET_KEY environment variables.");
+            warnings++;
+        }
+
+        if (fatal > 0) {
             // This bean is @Profile("!dev & !test"), so it only runs in real
-            // (non-dev/non-test) environments. Fail closed: never boot a real
-            // deployment with weak/default secrets. For local development with
-            // relaxed validation, activate the 'dev' profile (SPRING_PROFILES_ACTIVE=dev).
+            // (non-dev/non-test) environments. Fail closed on catastrophic secrets:
+            // never boot a real deployment with a forgeable JWT/QR/encryption key.
+            // For local development, activate the 'dev' profile (SPRING_PROFILES_ACTIVE=dev).
             throw new IllegalStateException(
-                    "SECURITY: " + problems + " secret validation failure(s) detected. "
-                            + "Fix the configuration before starting, or set SPRING_PROFILES_ACTIVE=dev for local development.");
+                    "SECURITY: " + fatal + " critical secret validation failure(s) detected. "
+                            + "Fix JWT_SECRET / ENCRYPTION_SECRET / cleaning QR secret before starting, "
+                            + "or set SPRING_PROFILES_ACTIVE=dev for local development.");
+        }
+        if (warnings > 0) {
+            log.warn("SECURITY WARNING: {} infrastructure credential(s) use weak/default values. "
+                    + "These MUST be changed before production deployment.", warnings);
         } else {
             log.info("Secret validation passed: all critical secrets are configured.");
         }

--- a/backend/src/main/java/com/monteweb/shared/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/monteweb/shared/exception/GlobalExceptionHandler.java
@@ -14,6 +14,13 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+import jakarta.validation.ConstraintViolationException;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -93,6 +100,39 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of("BAD_REQUEST", ex.getMessage(), 400));
+    }
+
+    @ExceptionHandler({
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class,
+            ConstraintViolationException.class
+    })
+    public ResponseEntity<ErrorResponse> handleClientBadRequest(Exception ex) {
+        // Malformed/missing JSON body, wrong path-variable type (e.g. a non-UUID id),
+        // missing @RequestParam, or @Validated constraint violation. These are client
+        // errors (400), not server faults — return 400 WITHOUT publishing an
+        // UnhandledExceptionEvent (which would log.error + persist a bogus error report).
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of("BAD_REQUEST", "Malformed or invalid request", 400));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSize(MaxUploadSizeExceededException ex) {
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .body(ErrorResponse.of("PAYLOAD_TOO_LARGE", "File exceeds the maximum allowed size", 413));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(ErrorResponse.of("METHOD_NOT_ALLOWED", "HTTP method not supported for this endpoint", 405));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResource(NoResourceFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of("NOT_FOUND", "Resource not found", 404));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/monteweb/shared/util/SecurityUtils.java
+++ b/backend/src/main/java/com/monteweb/shared/util/SecurityUtils.java
@@ -1,12 +1,22 @@
 package com.monteweb.shared.util;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public final class SecurityUtils {
+
+    /**
+     * Request attribute set by the JWT authentication filter when the current
+     * request is performed under an active impersonation session. Holds the
+     * UUID (as String) of the administrator who started impersonation.
+     */
+    public static final String IMPERSONATED_BY_ATTRIBUTE = "impersonatedBy";
 
     private SecurityUtils() {
     }
@@ -22,5 +32,85 @@ public final class SecurityUtils {
     public static UUID requireCurrentUserId() {
         return getCurrentUserId()
                 .orElseThrow(() -> new IllegalStateException("No authenticated user"));
+    }
+
+    /**
+     * Returns the UUID of the administrator currently impersonating another user,
+     * if any. Reads the {@link #IMPERSONATED_BY_ATTRIBUTE} request attribute that is
+     * populated by the JWT authentication filter from a server-issued, signed token.
+     *
+     * <p>Use this for audit-log attribution: actions performed during impersonation
+     * must be attributed to the impersonating admin, not to the target (impersonated)
+     * user returned by {@link #requireCurrentUserId()}.
+     *
+     * @return the impersonating admin's id, or empty when not impersonating / no request
+     */
+    public static Optional<UUID> getImpersonatorId() {
+        return currentRequest()
+                .map(req -> req.getAttribute(IMPERSONATED_BY_ATTRIBUTE))
+                .filter(value -> value instanceof String)
+                .map(Object::toString)
+                .filter(value -> !value.isBlank())
+                .map(SecurityUtils::parseUuidOrNull)
+                .filter(Optional::isPresent)
+                .map(Optional::get);
+    }
+
+    /**
+     * Returns the effective actor for audit purposes: the impersonating admin when an
+     * impersonation session is active, otherwise the authenticated current user.
+     *
+     * <p>This guarantees that actions taken while impersonating are attributed to the
+     * admin who initiated the session rather than to the impersonated target user.
+     */
+    public static UUID requireAuditActorId() {
+        return getImpersonatorId().orElseGet(SecurityUtils::requireCurrentUserId);
+    }
+
+    /**
+     * Extracts the real client IP address from the current HTTP request, honouring the
+     * reverse-proxy forwarding headers used in front of the application (X-Forwarded-For,
+     * then X-Real-IP), and finally falling back to the socket remote address.
+     *
+     * <p>This MUST be used for security audit trails (e.g. terms acceptance) instead of
+     * trusting any client-supplied request-body field, which is spoofable.
+     *
+     * @return the resolved client IP, or {@code null} when no request context is available
+     */
+    public static String getClientIpAddress() {
+        return currentRequest().map(SecurityUtils::extractClientIp).orElse(null);
+    }
+
+    private static String extractClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            // X-Forwarded-For may contain a comma-separated list; the first entry is the originating client.
+            int comma = forwardedFor.indexOf(',');
+            String first = (comma >= 0 ? forwardedFor.substring(0, comma) : forwardedFor).trim();
+            if (!first.isBlank()) {
+                return first;
+            }
+        }
+        String realIp = request.getHeader("X-Real-IP");
+        if (realIp != null && !realIp.isBlank()) {
+            return realIp.trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private static Optional<HttpServletRequest> currentRequest() {
+        var attributes = RequestContextHolder.getRequestAttributes();
+        if (attributes instanceof ServletRequestAttributes servletAttributes) {
+            return Optional.of(servletAttributes.getRequest());
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<UUID> parseUuidOrNull(String value) {
+        try {
+            return Optional.of(UUID.fromString(value));
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
     }
 }

--- a/backend/src/main/java/com/monteweb/tasks/internal/controller/TaskController.java
+++ b/backend/src/main/java/com/monteweb/tasks/internal/controller/TaskController.java
@@ -21,8 +21,8 @@ public class TaskController {
 
     @GetMapping
     public ApiResponse<TaskBoardResponse> getBoard(@PathVariable UUID roomId) {
-        SecurityUtils.requireCurrentUserId();
-        return ApiResponse.ok(taskService.getBoard(roomId));
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        return ApiResponse.ok(taskService.getBoard(roomId, userId));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/monteweb/tasks/internal/dto/UpdateTaskRequest.java
+++ b/backend/src/main/java/com/monteweb/tasks/internal/dto/UpdateTaskRequest.java
@@ -11,6 +11,8 @@ public record UpdateTaskRequest(
         UUID assigneeId,
         LocalDate dueDate,
         UUID columnId,
-        Integer position
+        Integer position,
+        Boolean clearAssignee,
+        Boolean clearDueDate
 ) {
 }

--- a/backend/src/main/java/com/monteweb/tasks/internal/service/TaskService.java
+++ b/backend/src/main/java/com/monteweb/tasks/internal/service/TaskService.java
@@ -73,8 +73,12 @@ public class TaskService implements TasksModuleApi {
 
     /**
      * Returns the full board response with columns and tasks, resolving user names.
+     * Requires the caller to be a member of the room (or an admin) before any board
+     * is read or lazily created.
      */
-    public TaskBoardResponse getBoard(UUID roomId) {
+    @Transactional
+    public TaskBoardResponse getBoard(UUID roomId, UUID userId) {
+        requireRoomMembership(userId, roomId);
         var board = getOrCreateBoard(roomId);
         var columns = columnRepo.findByBoardIdOrderByPosition(board.getId());
         var tasks = taskRepo.findByBoardId(board.getId());
@@ -172,8 +176,10 @@ public class TaskService implements TasksModuleApi {
 
         if (request.title() != null && !request.title().isBlank()) task.setTitle(request.title());
         if (request.description() != null) task.setDescription(request.description());
-        if (request.assigneeId() != null) task.setAssigneeId(request.assigneeId());
-        if (request.dueDate() != null) task.setDueDate(request.dueDate());
+        if (Boolean.TRUE.equals(request.clearAssignee())) task.setAssigneeId(null);
+        else if (request.assigneeId() != null) task.setAssigneeId(request.assigneeId());
+        if (Boolean.TRUE.equals(request.clearDueDate())) task.setDueDate(null);
+        else if (request.dueDate() != null) task.setDueDate(request.dueDate());
         if (request.columnId() != null) {
             var column = columnRepo.findById(request.columnId())
                     .orElseThrow(() -> new ResourceNotFoundException("Column not found"));

--- a/backend/src/main/java/com/monteweb/tasks/internal/service/TaskService.java
+++ b/backend/src/main/java/com/monteweb/tasks/internal/service/TaskService.java
@@ -379,14 +379,14 @@ public class TaskService implements TasksModuleApi {
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found: " + taskId));
     }
 
-    private boolean isSuperAdmin(UUID userId) {
+    private boolean hasAdminRole(UUID userId) {
         return userModule.findById(userId)
                 .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
                 .orElse(false);
     }
 
     private void requireRoomMembership(UUID userId, UUID roomId) {
-        if (!isSuperAdmin(userId) && !roomModule.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRole(userId) && !roomModule.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
         }
     }

--- a/backend/src/main/java/com/monteweb/tasks/internal/service/TaskService.java
+++ b/backend/src/main/java/com/monteweb/tasks/internal/service/TaskService.java
@@ -385,14 +385,28 @@ public class TaskService implements TasksModuleApi {
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found: " + taskId));
     }
 
-    private boolean hasAdminRole(UUID userId) {
-        return userModule.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
-                .orElse(false);
+    /**
+     * SUPERADMIN is always a global admin. SECTION_ADMIN only counts as admin for a room
+     * whose section the user actually administers (special role {@code SECTION_ADMIN:<sectionId>}).
+     */
+    private boolean hasAdminRoleForRoom(UUID userId, UUID roomId) {
+        var user = userModule.findById(userId).orElse(null);
+        if (user == null) {
+            return false;
+        }
+        if (user.role() == UserRole.SUPERADMIN) {
+            return true;
+        }
+        if (user.role() == UserRole.SECTION_ADMIN) {
+            var sectionId = roomModule.findById(roomId).map(r -> r.sectionId()).orElse(null);
+            return sectionId != null && user.specialRoles() != null
+                    && user.specialRoles().contains("SECTION_ADMIN:" + sectionId);
+        }
+        return false;
     }
 
     private void requireRoomMembership(UUID userId, UUID roomId) {
-        if (!hasAdminRole(userId) && !roomModule.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRoleForRoom(userId, roomId) && !roomModule.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
         }
     }

--- a/backend/src/main/java/com/monteweb/user/internal/dto/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/monteweb/user/internal/dto/UpdateProfileRequest.java
@@ -1,10 +1,11 @@
 package com.monteweb.user.internal.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdateProfileRequest(
-        @Size(max = 100) String firstName,
-        @Size(max = 100) String lastName,
+        @NotBlank @Size(max = 100) String firstName,
+        @NotBlank @Size(max = 100) String lastName,
         @Size(max = 50) String phone
 ) {
 }

--- a/backend/src/main/java/com/monteweb/user/internal/service/UserService.java
+++ b/backend/src/main/java/com/monteweb/user/internal/service/UserService.java
@@ -230,10 +230,18 @@ public class UserService implements UserModuleApi {
     @Override
     @Transactional
     public UserInfo updateProfile(UUID userId, String firstName, String lastName, String phone) {
+        // First and last name are mandatory (US-025). Reject null/blank so the
+        // derived displayName can never become empty or " ".
+        if (firstName == null || firstName.isBlank()) {
+            throw new com.monteweb.shared.exception.BadRequestException("First name is required");
+        }
+        if (lastName == null || lastName.isBlank()) {
+            throw new com.monteweb.shared.exception.BadRequestException("Last name is required");
+        }
         var user = findEntityById(userId);
-        if (firstName != null) user.setFirstName(firstName);
-        if (lastName != null) user.setLastName(lastName);
-        if (phone != null) user.setPhone(phone);
+        user.setFirstName(firstName.trim());
+        user.setLastName(lastName.trim());
+        if (phone != null) user.setPhone(phone.trim());
         user.setDisplayName(user.getFirstName() + " " + user.getLastName());
         return toUserInfo(userRepository.save(user));
     }
@@ -306,9 +314,21 @@ public class UserService implements UserModuleApi {
             }
             user.setEmail(email.toLowerCase().trim());
         }
-        if (firstName != null) user.setFirstName(firstName);
-        if (lastName != null) user.setLastName(lastName);
-        if (phone != null) user.setPhone(phone);
+        // null = leave unchanged; an explicitly provided value must not be blank
+        // (US-025) so the derived displayName never becomes empty or " ".
+        if (firstName != null) {
+            if (firstName.isBlank()) {
+                throw new com.monteweb.shared.exception.BadRequestException("First name must not be blank");
+            }
+            user.setFirstName(firstName.trim());
+        }
+        if (lastName != null) {
+            if (lastName.isBlank()) {
+                throw new com.monteweb.shared.exception.BadRequestException("Last name must not be blank");
+            }
+            user.setLastName(lastName.trim());
+        }
+        if (phone != null) user.setPhone(phone.trim());
         user.setDisplayName(user.getFirstName() + " " + user.getLastName());
         return toUserInfo(userRepository.save(user));
     }

--- a/backend/src/main/java/com/monteweb/wiki/internal/controller/WikiController.java
+++ b/backend/src/main/java/com/monteweb/wiki/internal/controller/WikiController.java
@@ -22,16 +22,16 @@ public class WikiController {
 
     @GetMapping
     public ApiResponse<List<WikiPageSummary>> getPageTree(@PathVariable UUID roomId) {
-        SecurityUtils.requireCurrentUserId();
-        return ApiResponse.ok(wikiService.getPageTree(roomId));
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        return ApiResponse.ok(wikiService.getPageTree(userId, roomId));
     }
 
     @GetMapping("/pages/{slug}")
     public ApiResponse<WikiPageResponse> getPage(
             @PathVariable UUID roomId,
             @PathVariable String slug) {
-        SecurityUtils.requireCurrentUserId();
-        return ApiResponse.ok(wikiService.getPage(roomId, slug));
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        return ApiResponse.ok(wikiService.getPage(userId, roomId, slug));
     }
 
     @PostMapping("/pages")
@@ -64,23 +64,23 @@ public class WikiController {
     public ApiResponse<List<WikiPageVersionResponse>> getVersions(
             @PathVariable UUID roomId,
             @PathVariable UUID pageId) {
-        SecurityUtils.requireCurrentUserId();
-        return ApiResponse.ok(wikiService.getVersions(pageId));
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        return ApiResponse.ok(wikiService.getVersions(userId, pageId));
     }
 
     @GetMapping("/versions/{versionId}")
     public ApiResponse<WikiPageVersionResponse> getVersion(
             @PathVariable UUID roomId,
             @PathVariable UUID versionId) {
-        SecurityUtils.requireCurrentUserId();
-        return ApiResponse.ok(wikiService.getVersion(versionId));
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        return ApiResponse.ok(wikiService.getVersion(userId, roomId, versionId));
     }
 
     @GetMapping("/search")
     public ApiResponse<List<WikiPageSummary>> searchPages(
             @PathVariable UUID roomId,
             @RequestParam("q") String query) {
-        SecurityUtils.requireCurrentUserId();
-        return ApiResponse.ok(wikiService.searchPages(roomId, query));
+        UUID userId = SecurityUtils.requireCurrentUserId();
+        return ApiResponse.ok(wikiService.searchPages(userId, roomId, query));
     }
 }

--- a/backend/src/main/java/com/monteweb/wiki/internal/dto/UpdatePageRequest.java
+++ b/backend/src/main/java/com/monteweb/wiki/internal/dto/UpdatePageRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record UpdatePageRequest(
         @NotBlank @Size(max = 255) String title,
-        @NotBlank String content
+        @NotBlank String content,
+        @Size(max = 255) String slug
 ) {
 }

--- a/backend/src/main/java/com/monteweb/wiki/internal/repository/WikiPageRepository.java
+++ b/backend/src/main/java/com/monteweb/wiki/internal/repository/WikiPageRepository.java
@@ -24,6 +24,8 @@ public interface WikiPageRepository extends JpaRepository<WikiPage, UUID> {
 
     boolean existsByRoomIdAndSlug(UUID roomId, String slug);
 
+    boolean existsByRoomIdAndSlugAndIdNot(UUID roomId, String slug, UUID id);
+
     List<WikiPage> findByCreatedBy(UUID userId);
 
     List<WikiPage> findByLastEditedBy(UUID userId);

--- a/backend/src/main/java/com/monteweb/wiki/internal/service/WikiService.java
+++ b/backend/src/main/java/com/monteweb/wiki/internal/service/WikiService.java
@@ -43,7 +43,8 @@ public class WikiService implements WikiModuleApi {
 
     // ---- Page Tree ----
 
-    public List<WikiPageSummary> getPageTree(UUID roomId) {
+    public List<WikiPageSummary> getPageTree(UUID userId, UUID roomId) {
+        requireRoomMembership(userId, roomId);
         var pages = pageRepo.findByRoomIdOrderByTitleAsc(roomId);
         // Build set of IDs that have children
         Set<UUID> parentIds = new HashSet<>();
@@ -66,7 +67,8 @@ public class WikiService implements WikiModuleApi {
 
     // ---- Get Page ----
 
-    public WikiPageResponse getPage(UUID roomId, String slug) {
+    public WikiPageResponse getPage(UUID userId, UUID roomId, String slug) {
+        requireRoomMembership(userId, roomId);
         var page = pageRepo.findByRoomIdAndSlug(roomId, slug)
                 .orElseThrow(() -> new ResourceNotFoundException("Wiki page not found: " + slug));
 
@@ -193,7 +195,7 @@ public class WikiService implements WikiModuleApi {
         eventPublisher.publishEvent(new WikiPageSavedEvent(
                 page.getId(), page.getRoomId(), page.getTitle(), page.getContent(), page.getSlug()));
 
-        return getPage(page.getRoomId(), page.getSlug());
+        return getPage(userId, page.getRoomId(), page.getSlug());
     }
 
     // ---- Delete Page ----
@@ -211,7 +213,9 @@ public class WikiService implements WikiModuleApi {
 
     // ---- Version History ----
 
-    public List<WikiPageVersionResponse> getVersions(UUID pageId) {
+    public List<WikiPageVersionResponse> getVersions(UUID userId, UUID pageId) {
+        var page = requirePage(pageId);
+        requireRoomMembership(userId, page.getRoomId());
         var versions = versionRepo.findByPageIdOrderByCreatedAtDesc(pageId);
 
         Set<UUID> userIds = new HashSet<>();
@@ -232,9 +236,17 @@ public class WikiService implements WikiModuleApi {
                 .toList();
     }
 
-    public WikiPageVersionResponse getVersion(UUID versionId) {
+    public WikiPageVersionResponse getVersion(UUID userId, UUID roomId, UUID versionId) {
         var version = versionRepo.findById(versionId)
                 .orElseThrow(() -> new ResourceNotFoundException("Version not found: " + versionId));
+
+        // Resolve the owning page to determine the room, and ensure the version
+        // actually belongs to the room in the request path (prevents cross-room reads).
+        var page = requirePage(version.getPageId());
+        if (!page.getRoomId().equals(roomId)) {
+            throw new ResourceNotFoundException("Version not found: " + versionId);
+        }
+        requireRoomMembership(userId, page.getRoomId());
 
         String userName = userModule.findById(version.getEditedBy())
                 .map(UserInfo::displayName).orElse("Unbekannt");
@@ -251,7 +263,8 @@ public class WikiService implements WikiModuleApi {
 
     // ---- Search ----
 
-    public List<WikiPageSummary> searchPages(UUID roomId, String query) {
+    public List<WikiPageSummary> searchPages(UUID userId, UUID roomId, String query) {
+        requireRoomMembership(userId, roomId);
         if (query == null || query.trim().isEmpty()) {
             return List.of();
         }

--- a/backend/src/main/java/com/monteweb/wiki/internal/service/WikiService.java
+++ b/backend/src/main/java/com/monteweb/wiki/internal/service/WikiService.java
@@ -182,6 +182,15 @@ public class WikiService implements WikiModuleApi {
         page.setTitle(request.title().trim());
         page.setContent(request.content());
         page.setLastEditedBy(userId);
+
+        // Slug may optionally be changed. When the client supplies a (non-blank) slug
+        // it is sanitized and made unique within the room (ignoring this page's own
+        // current slug). When omitted, the existing slug is preserved.
+        if (request.slug() != null && !request.slug().isBlank()) {
+            String newSlug = uniqueSlug(page.getRoomId(), slugify(request.slug()), page.getId());
+            page.setSlug(newSlug);
+        }
+
         pageRepo.save(page);
 
         // Create new version
@@ -355,14 +364,29 @@ public class WikiService implements WikiModuleApi {
                 .orElseThrow(() -> new ResourceNotFoundException("Wiki page not found: " + pageId));
     }
 
-    private boolean hasAdminRole(UUID userId) {
-        return userModule.findById(userId)
-                .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
-                .orElse(false);
+    /**
+     * Room-scoped admin check: SUPERADMIN is a global admin for every room,
+     * SECTION_ADMIN only counts as admin for rooms whose section the user actually
+     * administers (special role "SECTION_ADMIN:&lt;sectionId&gt;").
+     */
+    private boolean hasAdminRoleForRoom(UUID userId, UUID roomId) {
+        var user = userModule.findById(userId).orElse(null);
+        if (user == null) {
+            return false;
+        }
+        if (user.role() == UserRole.SUPERADMIN) {
+            return true;
+        }
+        if (user.role() == UserRole.SECTION_ADMIN) {
+            var sectionId = roomModule.findById(roomId).map(r -> r.sectionId()).orElse(null);
+            return sectionId != null && user.specialRoles() != null
+                    && user.specialRoles().contains("SECTION_ADMIN:" + sectionId);
+        }
+        return false;
     }
 
     private void requireRoomMembership(UUID userId, UUID roomId) {
-        if (!hasAdminRole(userId) && !roomModule.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRoleForRoom(userId, roomId) && !roomModule.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
         }
     }
@@ -381,8 +405,16 @@ public class WikiService implements WikiModuleApi {
      * Generate a URL-safe slug from the title. Ensures uniqueness within the room.
      */
     String generateSlug(UUID roomId, String title) {
+        return uniqueSlug(roomId, slugify(title), null);
+    }
+
+    /**
+     * Normalize an arbitrary input into a URL-safe slug (lowercase, hyphenated,
+     * special chars stripped). Never returns an empty string ("page" fallback).
+     */
+    private String slugify(String input) {
         // Normalize unicode, lowercase, replace spaces with hyphens, remove special chars
-        String normalized = Normalizer.normalize(title.trim().toLowerCase(), Normalizer.Form.NFD);
+        String normalized = Normalizer.normalize(input.trim().toLowerCase(), Normalizer.Form.NFD);
         // Replace umlauts
         normalized = normalized
                 .replaceAll("\\p{M}", "")
@@ -399,15 +431,28 @@ public class WikiService implements WikiModuleApi {
         if (slug.isEmpty()) {
             slug = "page";
         }
+        return slug;
+    }
 
-        // Ensure uniqueness
-        String baseSlug = slug;
+    /**
+     * Ensure the slug is unique within the room, appending -1, -2, ... on collision.
+     * When {@code excludePageId} is non-null, a collision with that page is ignored
+     * (used when updating a page's own slug).
+     */
+    private String uniqueSlug(UUID roomId, String baseSlug, UUID excludePageId) {
+        String slug = baseSlug;
         int counter = 1;
-        while (pageRepo.existsByRoomIdAndSlug(roomId, slug)) {
+        while (slugTaken(roomId, slug, excludePageId)) {
             slug = baseSlug + "-" + counter;
             counter++;
         }
-
         return slug;
+    }
+
+    private boolean slugTaken(UUID roomId, String slug, UUID excludePageId) {
+        if (excludePageId == null) {
+            return pageRepo.existsByRoomIdAndSlug(roomId, slug);
+        }
+        return pageRepo.existsByRoomIdAndSlugAndIdNot(roomId, slug, excludePageId);
     }
 }

--- a/backend/src/main/java/com/monteweb/wiki/internal/service/WikiService.java
+++ b/backend/src/main/java/com/monteweb/wiki/internal/service/WikiService.java
@@ -342,14 +342,14 @@ public class WikiService implements WikiModuleApi {
                 .orElseThrow(() -> new ResourceNotFoundException("Wiki page not found: " + pageId));
     }
 
-    private boolean isSuperAdmin(UUID userId) {
+    private boolean hasAdminRole(UUID userId) {
         return userModule.findById(userId)
                 .map(u -> u.role() == UserRole.SUPERADMIN || u.role() == UserRole.SECTION_ADMIN)
                 .orElse(false);
     }
 
     private void requireRoomMembership(UUID userId, UUID roomId) {
-        if (!isSuperAdmin(userId) && !roomModule.isUserInRoom(userId, roomId)) {
+        if (!hasAdminRole(userId) && !roomModule.isUserInRoom(userId, roomId)) {
             throw new ForbiddenException("Not a member of this room");
         }
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -47,8 +47,11 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 50MB
+      # Must be >= the largest per-service limit (FileService 100MB) so the
+      # service-level size checks are reachable and authoritative instead of
+      # being pre-empted by a framework MaxUploadSizeExceededException at 10MB.
+      max-file-size: 100MB
+      max-request-size: 110MB
 
   jackson:
     datetime:

--- a/backend/src/main/resources/db/migration/V117__feed_banner_link.sql
+++ b/backend/src/main/resources/db/migration/V117__feed_banner_link.sql
@@ -1,0 +1,4 @@
+-- US-081: System banners may carry an optional click-through link and a banner type.
+-- These columns back the SystemBannerResponse DTO returned by GET /api/v1/feed/banners.
+ALTER TABLE feed_posts ADD COLUMN link VARCHAR(1000);
+ALTER TABLE feed_posts ADD COLUMN banner_type VARCHAR(30);

--- a/backend/src/test/java/com/monteweb/TestHelper.java
+++ b/backend/src/test/java/com/monteweb/TestHelper.java
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 /**
  * Helper methods for integration tests.
@@ -70,5 +71,75 @@ public class TestHelper {
      */
     public static JsonNode parseResponse(String responseBody) throws Exception {
         return objectMapper.readTree(responseBody);
+    }
+
+    /**
+     * Logs in with the given credentials and returns the access token.
+     * Use for the Flyway seed accounts (e.g. admin@monteweb.local / test1234 — see
+     * {@link #loginAsAdmin}, lehrer@monteweb.local / test1234).
+     */
+    public static String loginAndGetToken(MockMvc mockMvc, String email, String password) throws Exception {
+        var result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email": "%s", "password": "%s"}
+                                """.formatted(email, password)))
+                .andReturn();
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        return json.path("data").path("accessToken").asText();
+    }
+
+    /**
+     * Logs in as the seeded SUPERADMIN and returns the access token.
+     *
+     * <p>NOTE: although V032 seeds admin@monteweb.local with "admin123", a later
+     * migration (V111) resets that account's password to "test1234". In the test
+     * database (all Flyway migrations applied) the effective admin password is therefore
+     * "test1234", not "admin123".
+     */
+    public static String loginAsAdmin(MockMvc mockMvc) throws Exception {
+        return loginAndGetToken(mockMvc, "admin@monteweb.local", "test1234");
+    }
+
+    /**
+     * Registers a new user with a unique email, promotes them to TEACHER via the admin
+     * role endpoint, and returns their access token.
+     *
+     * <p>Room/post/form/thread creation is restricted to staff (TEACHER/SECTION_ADMIN/
+     * SUPERADMIN); the registration default is PARENT. Use this helper for test setup
+     * that needs to create such resources. The returned token still authenticates the
+     * user — the role gates read the role from the DB, not the JWT, so the promotion
+     * takes effect for the existing token.
+     */
+    public static String registerTeacherAndGetToken(MockMvc mockMvc) throws Exception {
+        return registerTeacherAndGetToken(mockMvc, "teacher" + (++counter) + "@example.com",
+                "Teacher", "User" + counter);
+    }
+
+    /**
+     * Registers a user with specific details, promotes them to TEACHER, and returns
+     * their access token. See {@link #registerTeacherAndGetToken(MockMvc)}.
+     */
+    public static String registerTeacherAndGetToken(MockMvc mockMvc, String email,
+                                                     String firstName, String lastName) throws Exception {
+        JsonNode response = registerAndGetResponse(mockMvc, email, firstName, lastName);
+        String token = response.path("data").path("accessToken").asText();
+        String userId = response.path("data").path("userId").asText();
+        promoteToTeacher(mockMvc, userId);
+        return token;
+    }
+
+    /**
+     * Promotes the given user to TEACHER using a fresh SUPERADMIN session.
+     */
+    public static void promoteToTeacher(MockMvc mockMvc, String userId) throws Exception {
+        String adminToken = loginAsAdmin(mockMvc);
+        mockMvc.perform(put("/api/v1/admin/users/" + userId + "/roles")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"role": "TEACHER"}
+                                """))
+                .andReturn();
     }
 }

--- a/backend/src/test/java/com/monteweb/admin/AdminModuleApiTest.java
+++ b/backend/src/test/java/com/monteweb/admin/AdminModuleApiTest.java
@@ -1,10 +1,20 @@
 package com.monteweb.admin;
 
 import com.monteweb.TestContainerConfig;
+import com.monteweb.admin.internal.model.AuditLogEntry;
+import com.monteweb.admin.internal.service.AuditService;
+import com.monteweb.user.UserModuleApi;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,6 +24,22 @@ class AdminModuleApiTest {
 
     @Autowired
     private AdminModuleApi adminModule;
+
+    @Autowired
+    private AuditService auditService;
+
+    @Autowired
+    private UserModuleApi userModule;
+
+    /**
+     * The audit_log.user_id column has a FK to users(id), so the actor must be a real
+     * user. We use the seeded SUPERADMIN (V032: admin@monteweb.local) as a stand-in actor.
+     */
+    private UUID seededActorId() {
+        return userModule.findByEmail("admin@monteweb.local")
+                .orElseThrow(() -> new IllegalStateException("Seeded admin user not found"))
+                .id();
+    }
 
     @Test
     void getTenantConfig_shouldReturnNonNullConfig() {
@@ -71,5 +97,60 @@ class AdminModuleApiTest {
         TenantConfigInfo config2 = adminModule.getTenantConfig();
         assertEquals(config.id(), config2.id());
         assertEquals(config.schoolName(), config2.schoolName());
+    }
+
+    // ── Audit log (US-348) ───────────────────────────────────────────
+
+    @Test
+    void recordAuditEvent_shouldPersistAndBeQueryable() {
+        UUID actor = seededActorId();
+        UUID target = UUID.randomUUID();
+        String action = "TEST_ACTION_" + UUID.randomUUID();
+
+        adminModule.recordAuditEvent(actor, action, "USER", target,
+                Map.of("note", "unit test"), "127.0.0.1");
+
+        Page<AuditLogEntry> result = auditService.find(action, null, null, PageRequest.of(0, 20));
+
+        assertEquals(1, result.getTotalElements());
+        AuditLogEntry entry = result.getContent().get(0);
+        assertEquals(actor, entry.getUserId());
+        assertEquals(action, entry.getAction());
+        assertEquals("USER", entry.getEntityType());
+        assertEquals(target, entry.getEntityId());
+        assertNotNull(entry.getCreatedAt());
+    }
+
+    @Test
+    void auditFind_filterByAction_shouldExcludeOtherActions() {
+        String actionA = "ACTION_A_" + UUID.randomUUID();
+        String actionB = "ACTION_B_" + UUID.randomUUID();
+        UUID actor = seededActorId();
+        adminModule.recordAuditEvent(actor, actionA, "USER", null, null, null);
+        adminModule.recordAuditEvent(actor, actionB, "USER", null, null, null);
+
+        Page<AuditLogEntry> onlyA = auditService.find(actionA, null, null, PageRequest.of(0, 20));
+
+        assertEquals(1, onlyA.getTotalElements());
+        assertEquals(actionA, onlyA.getContent().get(0).getAction());
+    }
+
+    @Test
+    void auditFind_filterByTimeRange_shouldRespectBounds() {
+        String action = "TIMED_" + UUID.randomUUID();
+        adminModule.recordAuditEvent(seededActorId(), action, "USER", null, null, null);
+
+        Instant from = Instant.now().minus(1, ChronoUnit.HOURS);
+        Instant to = Instant.now().plus(1, ChronoUnit.HOURS);
+
+        Page<AuditLogEntry> inRange = auditService.find(action, from, to, PageRequest.of(0, 20));
+        assertEquals(1, inRange.getTotalElements());
+
+        // Window entirely in the past must not match the just-created entry
+        Page<AuditLogEntry> outOfRange = auditService.find(action,
+                Instant.now().minus(2, ChronoUnit.HOURS),
+                Instant.now().minus(1, ChronoUnit.HOURS),
+                PageRequest.of(0, 20));
+        assertEquals(0, outOfRange.getTotalElements());
     }
 }

--- a/backend/src/test/java/com/monteweb/auth/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/auth/AuthControllerIntegrationTest.java
@@ -147,4 +147,44 @@ class AuthControllerIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
     }
+
+    // ── Self-service 2FA enrollment via temp token (MANDATORY mode) ───
+
+    @Test
+    void setup2faTemp_missingTempToken_shouldReturn400() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/2fa/setup-temp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void setup2faTemp_invalidTempToken_shouldFail() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/2fa/setup-temp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"tempToken": "not-a-valid-temp-token"}
+                                """))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    void confirm2faTemp_invalidTempToken_shouldFail() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/2fa/setup-temp/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"tempToken": "not-a-valid-temp-token", "code": "123456"}
+                                """))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    void confirm2faTemp_missingCode_shouldReturn400() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/2fa/setup-temp/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"tempToken": "some-token"}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/backend/src/test/java/com/monteweb/auth/ValidateAndExtractClaimsIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/auth/ValidateAndExtractClaimsIntegrationTest.java
@@ -1,0 +1,69 @@
+package com.monteweb.auth;
+
+import com.monteweb.TestContainerConfig;
+import com.monteweb.auth.internal.service.JwtService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Security tests for {@link AuthModuleApi#validateAndExtractClaims(String)} — the single
+ * entry point used by the WebSocket/STOMP authentication interceptor.
+ *
+ * Special-purpose tokens that carry a "type" claim (2FA temp tokens issued BEFORE the second
+ * factor is verified, and freely-mintable image tokens) must NOT authenticate a session.
+ * Only full access tokens (no "type" claim) may. See auth security review finding [1].
+ */
+@SpringBootTest
+@Import(TestContainerConfig.class)
+class ValidateAndExtractClaimsIntegrationTest {
+
+    @Autowired
+    private AuthModuleApi authModuleApi;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Test
+    void validateAndExtractClaims_rejects2faTempToken() {
+        UUID userId = UUID.randomUUID();
+        // A 2FA temp token is issued before the second factor is verified — it must never
+        // authenticate a realtime session, otherwise mandatory 2FA is bypassed.
+        String tempToken = jwtService.generateTempToken(userId, "user@example.com", "TEACHER");
+
+        assertThat(authModuleApi.validateAndExtractClaims(tempToken)).isEmpty();
+    }
+
+    @Test
+    void validateAndExtractClaims_rejectsImageToken() {
+        UUID userId = UUID.randomUUID();
+        // Image tokens are scoped to image endpoints only — they carry no role and must not
+        // authenticate a session they were never issued for.
+        String imageToken = authModuleApi.generateImageToken(userId);
+
+        assertThat(authModuleApi.validateAndExtractClaims(imageToken)).isEmpty();
+    }
+
+    @Test
+    void validateAndExtractClaims_acceptsRegularAccessToken() {
+        UUID userId = UUID.randomUUID();
+        // A normal access token (no "type" claim) must still authenticate and expose the role.
+        String accessToken = jwtService.generateAccessToken(userId, "user@example.com", "PARENT");
+
+        var claims = authModuleApi.validateAndExtractClaims(accessToken);
+        assertThat(claims).isPresent();
+        assertThat(claims.get().userId()).isEqualTo(userId.toString());
+        assertThat(claims.get().role()).isEqualTo("PARENT");
+    }
+
+    @Test
+    void validateAndExtractClaims_rejectsNullAndGarbage() {
+        assertThat(authModuleApi.validateAndExtractClaims(null)).isEmpty();
+        assertThat(authModuleApi.validateAndExtractClaims("not-a-jwt")).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/monteweb/calendar/CalendarControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/calendar/CalendarControllerIntegrationTest.java
@@ -86,7 +86,7 @@ class CalendarControllerIntegrationTest {
 
     @Test
     void createRoomEvent_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "cal-room@example.com", "Calendar", "Room");
 
         // Create a room first
@@ -180,7 +180,7 @@ class CalendarControllerIntegrationTest {
 
     @Test
     void getRoomEvents_shouldReturnList() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "cal-roomev@example.com", "Calendar", "RoomEv");
 
         var roomResult = mockMvc.perform(post("/api/v1/rooms")

--- a/backend/src/test/java/com/monteweb/calendar/CalendarServiceIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/calendar/CalendarServiceIntegrationTest.java
@@ -141,6 +141,94 @@ class CalendarServiceIntegrationTest {
                 .andExpect(status().is4xxClientError());
     }
 
+    @Test
+    void getEventById_asRoomMember_shouldSucceed() throws Exception {
+        String token = TestHelper.registerAndGetToken(mockMvc,
+                "cal-owner@example.com", "Calendar", "Owner");
+
+        // Create a room (creator becomes LEADER) and a ROOM-scoped event
+        var roomResult = mockMvc.perform(post("/api/v1/rooms")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name": "IDOR Room", "type": "GRUPPE"}
+                                """))
+                .andReturn();
+        String roomId = TestHelper.parseResponse(roomResult.getResponse().getContentAsString())
+                .path("data").path("id").asText();
+
+        var eventResult = mockMvc.perform(post("/api/v1/calendar/events")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "title": "Private Room Event",
+                                    "allDay": false,
+                                    "startDate": "2026-06-20",
+                                    "startTime": "10:00",
+                                    "endDate": "2026-06-20",
+                                    "endTime": "11:00",
+                                    "scope": "ROOM",
+                                    "scopeId": "%s",
+                                    "recurrence": "NONE"
+                                }
+                                """.formatted(roomId)))
+                .andReturn();
+        String eventId = TestHelper.parseResponse(eventResult.getResponse().getContentAsString())
+                .path("data").path("id").asText();
+
+        // Member (the creator/leader) may read the event by id
+        mockMvc.perform(get("/api/v1/calendar/events/" + eventId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("Private Room Event"));
+    }
+
+    @Test
+    void getEventById_asNonMember_shouldBeDenied() throws Exception {
+        String ownerToken = TestHelper.registerAndGetToken(mockMvc,
+                "cal-idor-owner@example.com", "Calendar", "IdorOwner");
+
+        // Owner creates a private room and a ROOM-scoped event
+        var roomResult = mockMvc.perform(post("/api/v1/rooms")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name": "Secret Room", "type": "GRUPPE"}
+                                """))
+                .andReturn();
+        String roomId = TestHelper.parseResponse(roomResult.getResponse().getContentAsString())
+                .path("data").path("id").asText();
+
+        var eventResult = mockMvc.perform(post("/api/v1/calendar/events")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "title": "Secret Event",
+                                    "allDay": false,
+                                    "startDate": "2026-06-20",
+                                    "startTime": "10:00",
+                                    "endDate": "2026-06-20",
+                                    "endTime": "11:00",
+                                    "scope": "ROOM",
+                                    "scopeId": "%s",
+                                    "recurrence": "NONE"
+                                }
+                                """.formatted(roomId)))
+                .andReturn();
+        String eventId = TestHelper.parseResponse(eventResult.getResponse().getContentAsString())
+                .path("data").path("id").asText();
+
+        // A different, non-member user must NOT be able to read the event by id (IDOR)
+        String outsiderToken = TestHelper.registerAndGetToken(mockMvc,
+                "cal-idor-outsider@example.com", "Calendar", "Outsider");
+
+        mockMvc.perform(get("/api/v1/calendar/events/" + eventId)
+                        .header("Authorization", "Bearer " + outsiderToken))
+                .andExpect(status().is4xxClientError());
+    }
+
     // ── RSVP ─────────────────────────────────────────────────────────
 
     @Test

--- a/backend/src/test/java/com/monteweb/calendar/CalendarServiceIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/calendar/CalendarServiceIntegrationTest.java
@@ -143,7 +143,7 @@ class CalendarServiceIntegrationTest {
 
     @Test
     void getEventById_asRoomMember_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "cal-owner@example.com", "Calendar", "Owner");
 
         // Create a room (creator becomes LEADER) and a ROOM-scoped event
@@ -186,7 +186,7 @@ class CalendarServiceIntegrationTest {
 
     @Test
     void getEventById_asNonMember_shouldBeDenied() throws Exception {
-        String ownerToken = TestHelper.registerAndGetToken(mockMvc,
+        String ownerToken = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "cal-idor-owner@example.com", "Calendar", "IdorOwner");
 
         // Owner creates a private room and a ROOM-scoped event
@@ -248,7 +248,7 @@ class CalendarServiceIntegrationTest {
 
     @Test
     void getRoomEvents_shouldWork() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create a room first
         var roomResult = mockMvc.perform(post("/api/v1/rooms")
@@ -269,9 +269,91 @@ class CalendarServiceIntegrationTest {
 
     // ── Create Room Event ────────────────────────────────────────────
 
+    // ── Manage permission: only creator or SUPERADMIN (US-105/106/107) ──
+
+    /**
+     * Helper: SUPERADMIN logs in and creates a SCHOOL-scoped event, returning its id.
+     * SCHOOL events are readable by every authenticated user, which lets us assert that
+     * a non-creator who CAN read the event still cannot manage it.
+     */
+    private String createSchoolEventAsAdmin() throws Exception {
+        String adminToken = TestHelper.loginAsAdmin(mockMvc);
+
+        var eventResult = mockMvc.perform(post("/api/v1/calendar/events")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "title": "Manage Permission Event",
+                                    "allDay": true,
+                                    "startDate": "2026-06-15",
+                                    "endDate": "2026-06-15",
+                                    "scope": "SCHOOL",
+                                    "recurrence": "NONE"
+                                }
+                                """))
+                .andReturn();
+        return TestHelper.parseResponse(eventResult.getResponse().getContentAsString())
+                .path("data").path("id").asText();
+    }
+
+    @Test
+    void deleteEvent_byNonCreator_shouldBeForbidden() throws Exception {
+        String eventId = createSchoolEventAsAdmin();
+
+        String otherToken = TestHelper.registerAndGetToken(mockMvc,
+                "cal-mng-del@example.com", "Calendar", "NonCreatorDel");
+
+        mockMvc.perform(delete("/api/v1/calendar/events/" + eventId)
+                        .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void cancelEvent_byNonCreator_shouldBeForbidden() throws Exception {
+        String eventId = createSchoolEventAsAdmin();
+
+        String otherToken = TestHelper.registerAndGetToken(mockMvc,
+                "cal-mng-cancel@example.com", "Calendar", "NonCreatorCancel");
+
+        mockMvc.perform(post("/api/v1/calendar/events/" + eventId + "/cancel")
+                        .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void updateEvent_byNonCreator_shouldBeForbidden() throws Exception {
+        String eventId = createSchoolEventAsAdmin();
+
+        String otherToken = TestHelper.registerAndGetToken(mockMvc,
+                "cal-mng-update@example.com", "Calendar", "NonCreatorUpdate");
+
+        mockMvc.perform(put("/api/v1/calendar/events/" + eventId)
+                        .header("Authorization", "Bearer " + otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "Hijacked Title"}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Jitsi: rejected when module disabled (US-114) ────────────────
+
+    @Test
+    void generateJitsiRoom_whenModuleDisabled_shouldBeForbidden() throws Exception {
+        // jitsi DB toggle defaults to false; even the SUPERADMIN creator must be rejected
+        String adminToken = TestHelper.loginAsAdmin(mockMvc);
+
+        String eventId = createSchoolEventAsAdmin();
+
+        mockMvc.perform(post("/api/v1/calendar/events/" + eventId + "/jitsi")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isForbidden());
+    }
+
     @Test
     void createRoomEvent_asLeader_shouldWork() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create a room (creator becomes LEADER)
         var roomResult = mockMvc.perform(post("/api/v1/rooms")

--- a/backend/src/test/java/com/monteweb/cleaning/CleaningServiceTest.java
+++ b/backend/src/test/java/com/monteweb/cleaning/CleaningServiceTest.java
@@ -481,6 +481,39 @@ class CleaningServiceTest {
         }
 
         @Test
+        @DisplayName("Forgotten check-out caps actualMinutes at scheduled duration + grace window")
+        void checkOut_forgottenCheckoutIsCapped() {
+            CleaningSlot slot = makeSlot(SLOT_ID, LocalDate.of(2026, 3, 6), "IN_PROGRESS");
+            // Config scheduled 14:00-16:00 => 120 scheduled minutes, +15 grace => cap at 135
+            CleaningConfig config = makeConfig(null, 5);
+
+            CleaningRegistration reg = makeRegistration(SLOT_ID, USER_ID, true, false);
+            // Checked in 25 hours ago (forgot to check out) -> raw 1500 minutes
+            reg.setCheckInAt(Instant.now().minusSeconds(25 * 3600));
+
+            when(slotRepository.findById(SLOT_ID)).thenReturn(Optional.of(slot));
+            when(registrationRepository.findBySlotIdAndUserId(SLOT_ID, USER_ID))
+                    .thenReturn(Optional.of(reg));
+            when(registrationRepository.save(any(CleaningRegistration.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+            when(slotRepository.save(any(CleaningSlot.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+            when(configRepository.findById(slot.getConfigId())).thenReturn(Optional.of(config));
+            when(registrationRepository.findBySlotId(SLOT_ID)).thenReturn(List.of(reg));
+            mockSectionLookup();
+
+            service.checkOut(SLOT_ID, USER_ID);
+
+            // Capped at scheduled (120) + grace (15) instead of the raw 1500 minutes
+            assertThat(reg.getActualMinutes()).isEqualTo(135);
+
+            ArgumentCaptor<CleaningCompletedEvent> eventCaptor =
+                    ArgumentCaptor.forClass(CleaningCompletedEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().actualMinutes()).isEqualTo(135);
+        }
+
+        @Test
         @DisplayName("Check-out without prior check-in throws BusinessException")
         void checkOut_notCheckedIn() {
             CleaningSlot slot = makeSlot(SLOT_ID, LocalDate.of(2026, 3, 6), "IN_PROGRESS");

--- a/backend/src/test/java/com/monteweb/cleaning/CleaningServiceTest.java
+++ b/backend/src/test/java/com/monteweb/cleaning/CleaningServiceTest.java
@@ -9,6 +9,8 @@ import com.monteweb.cleaning.internal.repository.CleaningRegistrationRepository;
 import com.monteweb.cleaning.internal.repository.CleaningSlotRepository;
 import com.monteweb.cleaning.internal.service.CleaningService;
 import com.monteweb.cleaning.internal.service.QrTokenService;
+import com.monteweb.notification.NotificationModuleApi;
+import com.monteweb.notification.NotificationType;
 import com.monteweb.room.RoomModuleApi;
 import com.monteweb.school.SchoolModuleApi;
 import com.monteweb.school.SchoolSectionInfo;
@@ -54,6 +56,7 @@ class CleaningServiceTest {
     @Mock private ApplicationEventPublisher eventPublisher;
     @Mock private CalendarModuleApi calendarModuleApi;
     @Mock private RoomModuleApi roomModuleApi;
+    @Mock private NotificationModuleApi notificationModuleApi;
 
     private CleaningService service;
 
@@ -71,7 +74,7 @@ class CleaningServiceTest {
         service = new CleaningService(
                 configRepository, slotRepository, registrationRepository,
                 qrTokenService, schoolModuleApi, eventPublisher,
-                calendarModuleApi, roomModuleApi
+                calendarModuleApi, roomModuleApi, notificationModuleApi
         );
     }
 
@@ -526,6 +529,129 @@ class CleaningServiceTest {
             assertThatThrownBy(() -> service.checkOut(SLOT_ID, USER_ID))
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining("Must check in before checking out");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Swap Take-Over (US-230)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Swap Take-Over")
+    class SwapTakeOver {
+
+        @Test
+        @DisplayName("Take-over transfers the offered registration to the new user and clears the offer")
+        void takeOverSwap_transfersRegistration() {
+            UUID newUser = UUID.randomUUID();
+            UUID newFamily = UUID.randomUUID();
+            CleaningSlot slot = makeSlot(SLOT_ID, LocalDate.of(2026, 3, 6), "OPEN");
+            CleaningRegistration offered = makeRegistration(SLOT_ID, USER_ID, false, false);
+            offered.setSwapOffered(true);
+
+            when(slotRepository.findById(SLOT_ID)).thenReturn(Optional.of(slot));
+            when(registrationRepository.existsBySlotIdAndUserId(SLOT_ID, newUser)).thenReturn(false);
+            when(configRepository.findById(CONFIG_ID)).thenReturn(Optional.of(makeConfig(null, 5)));
+            when(registrationRepository.findSwapOffersForSlot(SLOT_ID)).thenReturn(List.of(offered));
+            when(registrationRepository.save(any(CleaningRegistration.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+            mockSectionLookup();
+            when(registrationRepository.findBySlotId(SLOT_ID)).thenReturn(List.of(offered));
+
+            CleaningSlotInfo result = service.takeOverSwap(SLOT_ID, newUser, "Bea Bauer", newFamily);
+
+            assertThat(result).isNotNull();
+            assertThat(offered.getUserId()).isEqualTo(newUser);
+            assertThat(offered.getFamilyId()).isEqualTo(newFamily);
+            assertThat(offered.isSwapOffered()).isFalse();
+            // Original registrant should be notified
+            verify(notificationModuleApi).sendNotification(
+                    eq(USER_ID), eq(NotificationType.SYSTEM), any(), any(), any(), any(), eq(SLOT_ID));
+        }
+
+        @Test
+        @DisplayName("Take-over with no open offer throws BusinessException")
+        void takeOverSwap_noOffer() {
+            UUID newUser = UUID.randomUUID();
+            CleaningSlot slot = makeSlot(SLOT_ID, LocalDate.of(2026, 3, 6), "OPEN");
+
+            when(slotRepository.findById(SLOT_ID)).thenReturn(Optional.of(slot));
+            when(registrationRepository.existsBySlotIdAndUserId(SLOT_ID, newUser)).thenReturn(false);
+            when(configRepository.findById(CONFIG_ID)).thenReturn(Optional.of(makeConfig(null, 5)));
+            when(registrationRepository.findSwapOffersForSlot(SLOT_ID)).thenReturn(List.of());
+
+            assertThatThrownBy(() -> service.takeOverSwap(SLOT_ID, newUser, "Bea Bauer", UUID.randomUUID()))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("No open swap offer");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Admin Minutes Correction (US-232)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Update Registration Minutes")
+    class UpdateMinutes {
+
+        @Test
+        @DisplayName("Admin can correct minutes for any checked-out registration")
+        void updateMinutes_correctsAnyParticipant() {
+            UUID otherUser = UUID.randomUUID();
+            CleaningRegistration reg = makeRegistration(SLOT_ID, otherUser, true, true);
+            UUID regId = reg.getId();
+
+            when(registrationRepository.findById(regId)).thenReturn(Optional.of(reg));
+            when(registrationRepository.save(any(CleaningRegistration.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            var result = service.updateRegistrationMinutes(regId, 90);
+
+            assertThat(result).isNotNull();
+            assertThat(reg.getActualMinutes()).isEqualTo(90);
+            assertThat(reg.isDurationConfirmed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("Update minutes before checkout throws BusinessException")
+        void updateMinutes_notCheckedOut() {
+            CleaningRegistration reg = makeRegistration(SLOT_ID, USER_ID, true, false);
+            UUID regId = reg.getId();
+
+            when(registrationRepository.findById(regId)).thenReturn(Optional.of(reg));
+
+            assertThatThrownBy(() -> service.updateRegistrationMinutes(regId, 90))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("Must check out");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Cancel Slot (US-233)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Cancel Slot")
+    class CancelSlot {
+
+        @Test
+        @DisplayName("Cancel records reason and notifies registered participants")
+        void cancelSlot_recordsReasonAndNotifies() {
+            CleaningSlot slot = makeSlot(SLOT_ID, LocalDate.of(2026, 3, 6), "OPEN");
+            CleaningRegistration reg = makeRegistration(SLOT_ID, USER_ID, false, false);
+
+            when(slotRepository.findById(SLOT_ID)).thenReturn(Optional.of(slot));
+            when(slotRepository.save(any(CleaningSlot.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(configRepository.findById(CONFIG_ID)).thenReturn(Optional.of(makeConfig(null, 5)));
+            when(registrationRepository.findBySlotId(SLOT_ID)).thenReturn(List.of(reg));
+
+            service.cancelSlot(SLOT_ID, "Krankheit");
+
+            assertThat(slot.isCancelled()).isTrue();
+            assertThat(slot.getStatus()).isEqualTo("CANCELLED");
+            assertThat(slot.getCancelReason()).isEqualTo("Krankheit");
+            verify(notificationModuleApi).sendNotification(
+                    eq(USER_ID), eq(NotificationType.SYSTEM), any(), any(), any(), any(), eq(SLOT_ID));
         }
     }
 }

--- a/backend/src/test/java/com/monteweb/family/FamilyServiceTest.java
+++ b/backend/src/test/java/com/monteweb/family/FamilyServiceTest.java
@@ -245,6 +245,28 @@ class FamilyServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining("Already a member");
         }
+
+        @Test
+        @DisplayName("US-333: parent already in another family cannot join a second one")
+        void joinByInviteCode_parentAlreadyInAnotherFamily_blocked() {
+            var targetFamily = makeFamily(FAMILY_ID, "Target Family");
+            targetFamily.setInviteCode("VALID");
+            targetFamily.setInviteExpires(Instant.now().plus(1, ChronoUnit.DAYS));
+
+            var existingFamily = makeFamily(OTHER_USER_ID, "Existing Family");
+
+            stubUserLookup(USER_ID, UserRole.PARENT);
+            when(familyRepository.findByInviteCode("VALID")).thenReturn(Optional.of(targetFamily));
+            when(familyRepository.isMember(USER_ID, FAMILY_ID)).thenReturn(false);
+            when(familyRepository.findByMemberUserId(USER_ID)).thenReturn(List.of(existingFamily));
+
+            assertThatThrownBy(() -> service.joinByInviteCode("VALID", USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("only belong to one family");
+
+            assertThat(targetFamily.getMembers()).isEmpty();
+            verify(familyRepository, never()).save(any());
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -304,6 +326,30 @@ class FamilyServiceTest {
             assertThatThrownBy(() -> service.acceptInvitation(invitationId, USER_ID))
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining("not pending");
+        }
+
+        @Test
+        @DisplayName("US-333: PARENT invitation blocked when invitee already in another family")
+        void acceptInvitation_parentInvitationWhileInAnotherFamily_blocked() {
+            UUID invitationId = UUID.randomUUID();
+            UUID inviterId = UUID.randomUUID();
+
+            var invitation = new FamilyInvitation(FAMILY_ID, inviterId, USER_ID, FamilyMemberRole.PARENT);
+            invitation.setId(invitationId);
+            invitation.setStatus(FamilyInvitationStatus.PENDING);
+
+            var existingFamily = makeFamily(OTHER_USER_ID, "Existing Family");
+
+            stubUserLookup(USER_ID, UserRole.PARENT);
+            when(invitationRepository.findById(invitationId)).thenReturn(Optional.of(invitation));
+            when(familyRepository.findByMemberUserId(USER_ID)).thenReturn(List.of(existingFamily));
+
+            assertThatThrownBy(() -> service.acceptInvitation(invitationId, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("only belong to one family");
+
+            assertThat(invitation.getStatus()).isEqualTo(FamilyInvitationStatus.PENDING);
+            verify(invitationRepository, never()).save(any());
         }
 
         @Test
@@ -442,6 +488,71 @@ class FamilyServiceTest {
 
             assertThat(code).isEqualTo("NEWCODE");
             assertThat(family.getInviteCode()).isEqualTo("NEWCODE");
+            verify(familyRepository).save(family);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  US-337: SUPERADMIN-only toggles (active / hours-exempt)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("SUPERADMIN-only toggles")
+    class SuperAdminToggles {
+
+        @Test
+        @DisplayName("SECTION_ADMIN cannot set active state")
+        void setActive_sectionAdminBlocked() {
+            stubUserLookup(USER_ID, UserRole.SECTION_ADMIN);
+
+            assertThatThrownBy(() -> service.setActive(FAMILY_ID, false, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("Only SUPERADMIN");
+
+            verify(familyRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("SUPERADMIN can set active state")
+        void setActive_superAdminSuccess() {
+            var family = makeFamily(FAMILY_ID, "Test Family");
+
+            stubUserLookup(USER_ID, UserRole.SUPERADMIN);
+            when(familyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(family));
+            stubFamilySave();
+
+            var result = service.setActive(FAMILY_ID, false, USER_ID);
+
+            assertThat(result).isNotNull();
+            assertThat(family.isActive()).isFalse();
+            verify(familyRepository).save(family);
+        }
+
+        @Test
+        @DisplayName("SECTION_ADMIN cannot set hours-exempt flag")
+        void setHoursExempt_sectionAdminBlocked() {
+            stubUserLookup(USER_ID, UserRole.SECTION_ADMIN);
+
+            assertThatThrownBy(() -> service.setHoursExempt(FAMILY_ID, true, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("Only SUPERADMIN");
+
+            verify(familyRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("SUPERADMIN can set hours-exempt flag")
+        void setHoursExempt_superAdminSuccess() {
+            var family = makeFamily(FAMILY_ID, "Test Family");
+
+            stubUserLookup(USER_ID, UserRole.SUPERADMIN);
+            when(familyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(family));
+            stubFamilySave();
+
+            var result = service.setHoursExempt(FAMILY_ID, true, USER_ID);
+
+            assertThat(result).isNotNull();
+            assertThat(family.isHoursExempt()).isTrue();
             verify(familyRepository).save(family);
         }
     }

--- a/backend/src/test/java/com/monteweb/family/FamilyServiceTest.java
+++ b/backend/src/test/java/com/monteweb/family/FamilyServiceTest.java
@@ -324,4 +324,125 @@ class FamilyServiceTest {
                     .hasMessageContaining("Not your invitation");
         }
     }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Remove Member (parent-role + last-parent safeguards)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Remove Member")
+    class RemoveMember {
+
+        @Test
+        @DisplayName("CHILD member cannot remove another member")
+        void removeMember_childRequesterBlocked() {
+            var family = makeFamily(FAMILY_ID, "Test Family");
+            var parent = new FamilyMember(family, OTHER_USER_ID, FamilyMemberRole.PARENT);
+            var child = new FamilyMember(family, USER_ID, FamilyMemberRole.CHILD);
+            family.getMembers().add(parent);
+            family.getMembers().add(child);
+
+            when(familyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(family));
+            // requester (USER_ID) is a CHILD, not a SUPERADMIN
+            when(userModuleApi.findById(USER_ID))
+                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.STUDENT)));
+
+            assertThatThrownBy(() -> service.removeMember(FAMILY_ID, OTHER_USER_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("Only family parents");
+
+            assertThat(family.getMembers()).hasSize(2);
+            verify(familyRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("PARENT cannot remove the last parent while children exist")
+        void removeMember_lastParentWithChildrenBlocked() {
+            var family = makeFamily(FAMILY_ID, "Test Family");
+            var parent = new FamilyMember(family, USER_ID, FamilyMemberRole.PARENT);
+            var child = new FamilyMember(family, OTHER_USER_ID, FamilyMemberRole.CHILD);
+            family.getMembers().add(parent);
+            family.getMembers().add(child);
+
+            when(familyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(family));
+            when(userModuleApi.findById(USER_ID))
+                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.PARENT)));
+
+            // The sole parent tries to remove themselves while a child remains
+            assertThatThrownBy(() -> service.removeMember(FAMILY_ID, USER_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("last parent");
+
+            assertThat(family.getMembers()).hasSize(2);
+            verify(familyRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("PARENT removes a CHILD member successfully")
+        void removeMember_parentRemovesChild() {
+            var family = makeFamily(FAMILY_ID, "Test Family");
+            var parent = new FamilyMember(family, USER_ID, FamilyMemberRole.PARENT);
+            var child = new FamilyMember(family, OTHER_USER_ID, FamilyMemberRole.CHILD);
+            family.getMembers().add(parent);
+            family.getMembers().add(child);
+
+            when(familyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(family));
+            when(userModuleApi.findById(USER_ID))
+                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.PARENT)));
+            stubFamilySave();
+
+            service.removeMember(FAMILY_ID, OTHER_USER_ID, USER_ID);
+
+            assertThat(family.getMembers()).hasSize(1);
+            assertThat(family.getMembers().get(0).getUserId()).isEqualTo(USER_ID);
+            verify(familyRepository).save(family);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Generate Invite Code (parent-role guard)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Generate Invite Code")
+    class GenerateInviteCode {
+
+        @Test
+        @DisplayName("CHILD member cannot generate an invite code")
+        void generateInviteCode_childRequesterBlocked() {
+            var family = makeFamily(FAMILY_ID, "Test Family");
+            var child = new FamilyMember(family, USER_ID, FamilyMemberRole.CHILD);
+            family.getMembers().add(child);
+
+            when(familyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(family));
+            when(userModuleApi.findById(USER_ID))
+                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.STUDENT)));
+
+            assertThatThrownBy(() -> service.generateInviteCode(FAMILY_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("Only family parents");
+
+            verify(familyRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("PARENT member generates an invite code successfully")
+        void generateInviteCode_parentSuccess() {
+            var family = makeFamily(FAMILY_ID, "Test Family");
+            var parent = new FamilyMember(family, USER_ID, FamilyMemberRole.PARENT);
+            family.getMembers().add(parent);
+
+            when(familyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(family));
+            when(userModuleApi.findById(USER_ID))
+                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.PARENT)));
+            when(inviteCodeService.generateCode()).thenReturn("NEWCODE");
+            stubFamilySave();
+
+            String code = service.generateInviteCode(FAMILY_ID, USER_ID);
+
+            assertThat(code).isEqualTo("NEWCODE");
+            assertThat(family.getInviteCode()).isEqualTo("NEWCODE");
+            verify(familyRepository).save(family);
+        }
+    }
 }

--- a/backend/src/test/java/com/monteweb/feed/FeedControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/feed/FeedControllerIntegrationTest.java
@@ -41,7 +41,7 @@ class FeedControllerIntegrationTest {
 
     @Test
     void createPost_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "feed-post@example.com", "Feed", "Poster");
 
         // Create a room first to use as source
@@ -113,7 +113,7 @@ class FeedControllerIntegrationTest {
 
     @Test
     void addComment_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "feed-comment@example.com", "Feed", "Commenter");
 
         // Create room and post

--- a/backend/src/test/java/com/monteweb/feed/FeedServiceIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/feed/FeedServiceIntegrationTest.java
@@ -45,7 +45,7 @@ class FeedServiceIntegrationTest {
 
     @Test
     void createPost_shouldReturnCreatedPost() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room first
         String roomId = createRoom(token, "Feed Post Room");
@@ -89,6 +89,81 @@ class FeedServiceIntegrationTest {
                 .andExpect(status().isUnauthorized());
     }
 
+    @Test
+    void createPost_titleOnly_shouldBeRejected() throws Exception {
+        // US-086: a title alone is not enough — content or a poll is required.
+        // A title-only post is rejected by the business validation (422).
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
+        String roomId = createRoom(token, "Title Only Room");
+
+        mockMvc.perform(post("/api/v1/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "title": "Just a title",
+                                    "sourceType": "ROOM",
+                                    "sourceId": "%s",
+                                    "parentOnly": false
+                                }
+                                """.formatted(roomId)))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    void createRoomPost_byPlainParentMember_shouldReturn403() throws Exception {
+        // US-070/US-071: a PARENT who is only a member (not LEADER) of a room
+        // must not be able to create a room feed post.
+        String leaderToken = TestHelper.registerTeacherAndGetToken(mockMvc);
+        String roomId = createRoom(leaderToken, "Members Cannot Post Room");
+
+        // Register a second user (defaults to PARENT) and add them as a plain MEMBER.
+        var memberResponse = TestHelper.registerAndGetResponse(mockMvc,
+                "feed-member" + System.nanoTime() + "@example.com", "Plain", "Member");
+        String memberToken = memberResponse.path("data").path("accessToken").asText();
+        String memberUserId = memberResponse.path("data").path("userId").asText();
+
+        mockMvc.perform(post("/api/v1/rooms/" + roomId + "/members")
+                        .header("Authorization", "Bearer " + leaderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"userId": "%s", "role": "MEMBER"}
+                                """.formatted(memberUserId)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/feed/posts")
+                        .header("Authorization", "Bearer " + memberToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "content": "I should not be allowed to post here",
+                                    "sourceType": "ROOM",
+                                    "sourceId": "%s",
+                                    "parentOnly": false
+                                }
+                                """.formatted(roomId)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void createSchoolPost_byParent_shouldReturn403() throws Exception {
+        // US-087: school-wide posts are restricted to admins (or Elternbeirat).
+        // A plain PARENT must be rejected.
+        String token = TestHelper.registerAndGetToken(mockMvc);
+
+        mockMvc.perform(post("/api/v1/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "content": "School-wide announcement from a parent",
+                                    "sourceType": "SCHOOL",
+                                    "parentOnly": false
+                                }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
     // ── Post Detail ──────────────────────────────────────────────────
 
     @Test
@@ -102,7 +177,7 @@ class FeedServiceIntegrationTest {
 
     @Test
     void getPost_existing_shouldReturnPost() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room and post
         String roomId = createRoom(token, "Detail Room");
@@ -116,8 +191,8 @@ class FeedServiceIntegrationTest {
 
     @Test
     void getPost_nonMemberOfRoom_shouldReturn403() throws Exception {
-        // Author (PARENT) creates a room-scoped post
-        String authorToken = TestHelper.registerAndGetToken(mockMvc);
+        // Author (teacher/leader) creates a room-scoped post
+        String authorToken = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(authorToken, "Private Detail Room");
         String postId = createPost(authorToken, roomId, "Members only");
 
@@ -130,8 +205,8 @@ class FeedServiceIntegrationTest {
 
     @Test
     void getRoomPosts_nonMember_shouldReturn403() throws Exception {
-        // Author (PARENT) creates a room
-        String authorToken = TestHelper.registerAndGetToken(mockMvc);
+        // Author (teacher/leader) creates a room
+        String authorToken = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(authorToken, "Private Room Posts");
         createPost(authorToken, roomId, "Room content");
 
@@ -146,7 +221,7 @@ class FeedServiceIntegrationTest {
 
     @Test
     void updatePost_asAuthor_shouldWork() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room and post
         String roomId = createRoom(token, "Update Room");
@@ -167,7 +242,7 @@ class FeedServiceIntegrationTest {
 
     @Test
     void deletePost_asAuthor_shouldWork() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room and post
         String roomId = createRoom(token, "Delete Room");
@@ -191,7 +266,7 @@ class FeedServiceIntegrationTest {
 
     @Test
     void addComment_shouldWork() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room and post
         String roomId = createRoom(token, "Comment Room");

--- a/backend/src/test/java/com/monteweb/feed/FeedServiceIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/feed/FeedServiceIntegrationTest.java
@@ -114,6 +114,34 @@ class FeedServiceIntegrationTest {
                 .andExpect(jsonPath("$.data.content").value("Detail test post"));
     }
 
+    @Test
+    void getPost_nonMemberOfRoom_shouldReturn403() throws Exception {
+        // Author (PARENT) creates a room-scoped post
+        String authorToken = TestHelper.registerAndGetToken(mockMvc);
+        String roomId = createRoom(authorToken, "Private Detail Room");
+        String postId = createPost(authorToken, roomId, "Members only");
+
+        // A different user who is not a member of the room must be denied
+        String outsiderToken = TestHelper.registerAndGetToken(mockMvc);
+        mockMvc.perform(get("/api/v1/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + outsiderToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getRoomPosts_nonMember_shouldReturn403() throws Exception {
+        // Author (PARENT) creates a room
+        String authorToken = TestHelper.registerAndGetToken(mockMvc);
+        String roomId = createRoom(authorToken, "Private Room Posts");
+        createPost(authorToken, roomId, "Room content");
+
+        // A non-member must not be able to list the room's posts
+        String outsiderToken = TestHelper.registerAndGetToken(mockMvc);
+        mockMvc.perform(get("/api/v1/feed/rooms/" + roomId + "/posts")
+                        .header("Authorization", "Bearer " + outsiderToken))
+                .andExpect(status().isForbidden());
+    }
+
     // ── Update Post ──────────────────────────────────────────────────
 
     @Test

--- a/backend/src/test/java/com/monteweb/forms/FormsControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/forms/FormsControllerIntegrationTest.java
@@ -52,7 +52,7 @@ class FormsControllerIntegrationTest {
 
     @Test
     void createForm_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "forms-create@example.com", "Forms", "Creator");
 
         // Create a room first (user becomes LEADER, which grants create permission for ROOM scope)
@@ -101,7 +101,7 @@ class FormsControllerIntegrationTest {
 
     @Test
     void createAndGetForm_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "forms-getone@example.com", "Forms", "GetOne");
 
         // Create room first
@@ -138,7 +138,7 @@ class FormsControllerIntegrationTest {
 
     @Test
     void publishForm_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "forms-publish@example.com", "Forms", "Publisher");
 
         // Create room first

--- a/backend/src/test/java/com/monteweb/forms/FormsEnhancementIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/forms/FormsEnhancementIntegrationTest.java
@@ -32,7 +32,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void updateResponse_shouldSucceedForPublishedFormWithExistingResponse() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "Update Resp Room");
         String formId = createForm(token, roomId);
 
@@ -62,7 +62,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void updateResponse_shouldFailForAnonymousForm() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "Anon Resp Room");
         String formId = createAnonymousForm(token, roomId);
 
@@ -92,7 +92,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void updateResponse_shouldFailForClosedForm() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "Closed Resp Room");
         String formId = createForm(token, roomId);
 
@@ -130,7 +130,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void getMyResponse_shouldReturnAnswersForExistingResponse() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "MyResp Room");
         String formId = createForm(token, roomId);
 
@@ -160,7 +160,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void getMyResponse_shouldReturnNullForAnonymousForm() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "AnonMyResp Room");
         String formId = createAnonymousForm(token, roomId);
 
@@ -189,7 +189,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void archiveForm_shouldSucceedForClosedForm() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "Archive Room");
         String formId = createForm(token, roomId);
 
@@ -210,7 +210,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void archiveForm_shouldFailForPublishedForm() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "ArchiveFail Room");
         String formId = createForm(token, roomId);
 
@@ -229,7 +229,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void deleteForm_creatorCanDeletePublishedForm() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "Delete Pub Room");
         String formId = createForm(token, roomId);
 
@@ -246,7 +246,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void deleteForm_creatorCanDeleteClosedForm() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "Delete Closed Room");
         String formId = createForm(token, roomId);
 
@@ -268,7 +268,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void getResults_respondentCanSeeClosedFormResults() throws Exception {
-        String creatorToken = TestHelper.registerAndGetToken(mockMvc);
+        String creatorToken = TestHelper.registerTeacherAndGetToken(mockMvc);
         String respondentToken = TestHelper.registerAndGetToken(mockMvc);
         String roomId = createRoom(creatorToken, "Results Room");
 
@@ -308,7 +308,7 @@ class FormsEnhancementIntegrationTest {
 
     @Test
     void getAvailableForms_shouldIncludeClosedForms() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
         String roomId = createRoom(token, "AvailClosed Room");
         String formId = createForm(token, roomId);
 

--- a/backend/src/test/java/com/monteweb/forms/FormsServiceIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/forms/FormsServiceIntegrationTest.java
@@ -71,7 +71,7 @@ class FormsServiceIntegrationTest {
 
     @Test
     void createForm_shouldReturnCreatedForm() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create a room first (user becomes LEADER, which grants create permission for ROOM scope)
         String roomId = createRoom(token, "Forms Room");
@@ -133,7 +133,7 @@ class FormsServiceIntegrationTest {
 
     @Test
     void getForm_existing_shouldReturnDetails() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room and form
         String roomId = createRoom(token, "Detail Form Room");
@@ -149,7 +149,7 @@ class FormsServiceIntegrationTest {
 
     @Test
     void publishForm_shouldUpdateStatus() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room and form
         String roomId = createRoom(token, "Publish Form Room");

--- a/backend/src/test/java/com/monteweb/forms/FormsServiceTest.java
+++ b/backend/src/test/java/com/monteweb/forms/FormsServiceTest.java
@@ -3,6 +3,7 @@ package com.monteweb.forms;
 import com.monteweb.forms.internal.model.*;
 import com.monteweb.forms.internal.repository.*;
 import com.monteweb.forms.internal.service.FormsService;
+import com.monteweb.room.RoomInfo;
 import com.monteweb.room.RoomModuleApi;
 import com.monteweb.school.SchoolModuleApi;
 import com.monteweb.user.UserInfo;
@@ -106,6 +107,15 @@ class FormsServiceTest {
         return new SubmitResponseRequest(List.of(
                 new AnswerRequest(questionId, text, null, null)
         ));
+    }
+
+    private RoomInfo makeRoom(UUID id, UUID sectionId) {
+        return new RoomInfo(id, "Room", null, null, null, "GENERAL",
+                sectionId, false, 0, "OPEN", null, List.of(), null);
+    }
+
+    private QuestionRequest makeChoiceRequest(QuestionType type, List<String> options) {
+        return new QuestionRequest(type, "Pick one", null, false, options, null);
     }
 
     /**
@@ -426,6 +436,144 @@ class FormsServiceTest {
 
             assertThatCode(() -> service.getResults(FORM_ID, USER_ID))
                     .doesNotThrowAnyException();
+        }
+    }
+
+    // ── Question Validation (US-160 / US-181) ───────────────────────────
+
+    @Nested
+    @DisplayName("Question Validation")
+    class QuestionValidation {
+
+        private CreateFormRequest schoolFormWith(QuestionRequest question) {
+            return new CreateFormRequest(
+                    "Survey", null, FormType.SURVEY, FormScope.SCHOOL,
+                    null, null, false, null, List.of(question)
+            );
+        }
+
+        @BeforeEach
+        void allowSuperadminCreate() {
+            // SUPERADMIN passes checkCreatePermission for any scope
+            when(userModule.findById(USER_ID))
+                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.SUPERADMIN)));
+        }
+
+        @Test
+        @DisplayName("should reject single-choice question with no options")
+        void createForm_singleChoiceNoOptions() {
+            var request = schoolFormWith(makeChoiceRequest(QuestionType.SINGLE_CHOICE, null));
+            when(formRepository.save(any(Form.class))).thenAnswer(inv -> {
+                Form f = inv.getArgument(0);
+                f.setId(FORM_ID);
+                return f;
+            });
+
+            assertThatThrownBy(() -> service.createForm(request, USER_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("at least two distinct options");
+        }
+
+        @Test
+        @DisplayName("should reject multiple-choice question with a single option")
+        void createForm_multipleChoiceOneOption() {
+            var request = schoolFormWith(
+                    makeChoiceRequest(QuestionType.MULTIPLE_CHOICE, List.of("Only one")));
+            when(formRepository.save(any(Form.class))).thenAnswer(inv -> {
+                Form f = inv.getArgument(0);
+                f.setId(FORM_ID);
+                return f;
+            });
+
+            assertThatThrownBy(() -> service.createForm(request, USER_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("at least two distinct options");
+        }
+
+        @Test
+        @DisplayName("should reject choice question with duplicate/blank options collapsing below two")
+        void createForm_choiceDuplicateOptions() {
+            var request = schoolFormWith(
+                    makeChoiceRequest(QuestionType.SINGLE_CHOICE, Arrays.asList("A", " A ", "")));
+            when(formRepository.save(any(Form.class))).thenAnswer(inv -> {
+                Form f = inv.getArgument(0);
+                f.setId(FORM_ID);
+                return f;
+            });
+
+            assertThatThrownBy(() -> service.createForm(request, USER_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("at least two distinct options");
+        }
+
+        @Test
+        @DisplayName("should accept single-choice question with two options")
+        void createForm_singleChoiceTwoOptions() {
+            var request = schoolFormWith(
+                    makeChoiceRequest(QuestionType.SINGLE_CHOICE, List.of("Yes", "No")));
+            when(formRepository.save(any(Form.class))).thenAnswer(inv -> {
+                Form f = inv.getArgument(0);
+                if (f.getId() == null) f.setId(FORM_ID);
+                return f;
+            });
+            when(questionRepository.save(any(FormQuestion.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+            // toFormInfo internals (do NOT override the SUPERADMIN user stub)
+            when(questionRepository.countByFormId(FORM_ID)).thenReturn(1);
+            when(responseRepository.countByFormId(FORM_ID)).thenReturn(0);
+            lenient().when(responseRepository.existsByFormIdAndUserId(eq(FORM_ID), any())).thenReturn(false);
+            lenient().when(trackingRepository.existsByFormIdAndUserId(eq(FORM_ID), any())).thenReturn(false);
+
+            assertThatCode(() -> service.createForm(request, USER_ID))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    // ── Target Count (US-167 / US-172) ──────────────────────────────────
+
+    @Nested
+    @DisplayName("Target Count")
+    class TargetCount {
+
+        @Test
+        @DisplayName("should count distinct section members across rooms for SECTION forms")
+        void getResults_sectionTargetCount() {
+            var sectionId = UUID.randomUUID();
+            var room1 = UUID.randomUUID();
+            var room2 = UUID.randomUUID();
+            var userA = UUID.randomUUID();
+            var userB = UUID.randomUUID();
+            var userC = UUID.randomUUID();
+
+            var form = makeForm(FormStatus.PUBLISHED, false, null);
+            form.setScope(FormScope.SECTION);
+            form.setSectionIds(new UUID[]{sectionId});
+            form.setScopeId(sectionId);
+            when(formRepository.findById(FORM_ID)).thenReturn(Optional.of(form));
+
+            when(userModule.findById(USER_ID))
+                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.SUPERADMIN)));
+
+            // toFormInfo internals
+            when(questionRepository.countByFormId(FORM_ID)).thenReturn(1);
+            when(responseRepository.countByFormId(FORM_ID)).thenReturn(0);
+            lenient().when(responseRepository.existsByFormIdAndUserId(eq(FORM_ID), any())).thenReturn(false);
+            when(schoolModule.findById(sectionId))
+                    .thenReturn(Optional.of(new com.monteweb.school.SchoolSectionInfo(
+                            sectionId, "Section", "section", null, 0, true)));
+
+            when(roomModule.findBySectionId(sectionId))
+                    .thenReturn(List.of(makeRoom(room1, sectionId), makeRoom(room2, sectionId)));
+            // userB is in both rooms -> must be counted once
+            when(roomModule.getMemberUserIds(room1)).thenReturn(List.of(userA, userB));
+            when(roomModule.getMemberUserIds(room2)).thenReturn(List.of(userB, userC));
+
+            when(questionRepository.findByFormIdOrderBySortOrder(FORM_ID)).thenReturn(List.of());
+
+            var summary = service.getResults(FORM_ID, USER_ID);
+
+            // userA, userB, userC -> 3 distinct
+            assertThat(summary.form().targetCount()).isEqualTo(3);
         }
     }
 }

--- a/backend/src/test/java/com/monteweb/fotobox/FotoboxControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/fotobox/FotoboxControllerIntegrationTest.java
@@ -90,7 +90,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void getSettings_authenticated_shouldReturn() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-settings@example.com", "Foto", "Settings");
         String roomId = createRoomAndGetId(token);
 
@@ -102,7 +102,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void getSettings_defaultValues_shouldReturn() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-defaults@example.com", "Foto", "Defaults");
         String roomId = createRoomAndGetId(token);
 
@@ -116,7 +116,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void updateSettings_asLeader_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-update@example.com", "Foto", "Update");
         String roomId = createRoomAndGetId(token);
 
@@ -134,7 +134,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void updateSettings_partialUpdate_shouldPreserveOtherValues() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-partial@example.com", "Foto", "Partial");
         String roomId = createRoomAndGetId(token);
 
@@ -162,7 +162,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void updateSettings_maxImagesZero_shouldSetNull() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-maxi0@example.com", "Foto", "MaxI0");
         String roomId = createRoomAndGetId(token);
 
@@ -180,7 +180,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void getThreads_withFotoboxEnabled_shouldReturnList() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-threads@example.com", "Foto", "Threads");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -193,7 +193,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void getThreads_fotoboxNotEnabled_shouldFail() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-notenabled@example.com", "Foto", "NotEnabled");
         String roomId = createRoomAndGetId(token);
 
@@ -204,7 +204,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void createThread_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-create@example.com", "Foto", "Creator");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -223,7 +223,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void createThread_withoutDescription_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-nodesc@example.com", "Foto", "NoDesc");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -241,7 +241,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void createThread_blankTitle_shouldFail() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-blanktitle@example.com", "Foto", "BlankTitle");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -257,7 +257,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void getThread_shouldReturnThread() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-getthread@example.com", "Foto", "GetThread");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -274,7 +274,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void getThread_wrongRoom_shouldFail() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-wrongroom@example.com", "Foto", "WrongRoom");
         String roomId1 = createRoomAndGetId(token);
         String roomId2 = createRoomAndGetId(token);
@@ -291,7 +291,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void updateThread_asOwner_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-updatethread@example.com", "Foto", "UpdateThread");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -310,7 +310,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void deleteThread_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-delete@example.com", "Foto", "Delete");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -329,7 +329,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void deleteThread_nonExistent_shouldFail() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-delnone@example.com", "Foto", "DelNone");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -341,7 +341,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void createMultipleThreads_shouldAllAppear() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-multi@example.com", "Foto", "Multi");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -361,7 +361,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void uploadImages_shouldUploadFile() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-upload@example.com", "Foto", "Upload");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -382,7 +382,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void uploadImages_withCaption_shouldStoreCaption() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-caption@example.com", "Foto", "Caption");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -403,7 +403,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void uploadImages_shouldSetCoverImage() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-cover@example.com", "Foto", "Cover");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -430,7 +430,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void uploadImages_multipleFiles_shouldUploadAll() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-multiup@example.com", "Foto", "MultiUp");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -455,7 +455,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void getThreadImages_shouldReturnImages() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-getimgs@example.com", "Foto", "GetImgs");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -481,7 +481,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void getThreadImages_emptyThread_shouldReturnEmpty() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-emptyimgs@example.com", "Foto", "EmptyImgs");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -500,7 +500,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void deleteImage_asUploader_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-delimg@example.com", "Foto", "DelImg");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -532,7 +532,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void deleteImage_coverImage_shouldClearCover() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-delcover@example.com", "Foto", "DelCover");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -572,7 +572,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void updateImage_caption_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-updimg@example.com", "Foto", "UpdImg");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -606,7 +606,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void deleteThread_withImages_shouldDeleteAll() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-delcasc@example.com", "Foto", "DelCasc");
         String roomId = createRoomAndGetId(token);
         enableFotobox(token, roomId);
@@ -639,7 +639,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void createThread_withViewOnlyPermission_shouldFail() throws Exception {
-        String leaderToken = TestHelper.registerAndGetToken(mockMvc,
+        String leaderToken = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-leader-perm@example.com", "Foto", "LeaderPerm");
         String roomId = createRoomAndGetId(leaderToken);
         enableFotoboxWithPermission(leaderToken, roomId, "VIEW_ONLY");
@@ -663,7 +663,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void uploadImages_withViewOnlyPermission_shouldFail() throws Exception {
-        String leaderToken = TestHelper.registerAndGetToken(mockMvc,
+        String leaderToken = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-leader-upl@example.com", "Foto", "LeaderUpl");
         String roomId = createRoomAndGetId(leaderToken);
         enableFotoboxWithPermission(leaderToken, roomId, "VIEW_ONLY");
@@ -690,7 +690,7 @@ class FotoboxControllerIntegrationTest {
     @Disabled("Requires MinIO")
     @Test
     void uploadImages_withPostImagesPermission_shouldSucceed() throws Exception {
-        String leaderToken = TestHelper.registerAndGetToken(mockMvc,
+        String leaderToken = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-leader-post@example.com", "Foto", "LeaderPost");
         String roomId = createRoomAndGetId(leaderToken);
         enableFotoboxWithPermission(leaderToken, roomId, "POST_IMAGES");
@@ -716,7 +716,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void getThreads_asViewOnlyMember_shouldSucceed() throws Exception {
-        String leaderToken = TestHelper.registerAndGetToken(mockMvc,
+        String leaderToken = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-leader-view@example.com", "Foto", "LeaderView");
         String roomId = createRoomAndGetId(leaderToken);
         enableFotoboxWithPermission(leaderToken, roomId, "VIEW_ONLY");
@@ -739,7 +739,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void getSettings_asNonMember_shouldFail() throws Exception {
-        String leaderToken = TestHelper.registerAndGetToken(mockMvc,
+        String leaderToken = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-leader-nm@example.com", "Foto", "LeaderNm");
         String roomId = createRoomAndGetId(leaderToken);
 
@@ -753,7 +753,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void updateSettings_asNonLeader_shouldFail() throws Exception {
-        String leaderToken = TestHelper.registerAndGetToken(mockMvc,
+        String leaderToken = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-leader-nl@example.com", "Foto", "LeaderNl");
         String roomId = createRoomAndGetId(leaderToken);
 
@@ -777,7 +777,7 @@ class FotoboxControllerIntegrationTest {
 
     @Test
     void threads_shouldBeIsolatedPerRoom() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "fotobox-isolation@example.com", "Foto", "Isolation");
         String roomId1 = createRoomAndGetId(token);
         String roomId2 = createRoomAndGetId(token);

--- a/backend/src/test/java/com/monteweb/fotobox/FotoboxPermissionTest.java
+++ b/backend/src/test/java/com/monteweb/fotobox/FotoboxPermissionTest.java
@@ -5,6 +5,7 @@ import com.monteweb.fotobox.internal.repository.FotoboxImageRepository;
 import com.monteweb.fotobox.internal.repository.FotoboxRoomSettingsRepository;
 import com.monteweb.fotobox.internal.repository.FotoboxThreadRepository;
 import com.monteweb.fotobox.internal.service.FotoboxPermissionService;
+import com.monteweb.room.RoomInfo;
 import com.monteweb.room.RoomModuleApi;
 import com.monteweb.room.RoomRole;
 import com.monteweb.shared.exception.ForbiddenException;
@@ -39,6 +40,7 @@ class FotoboxPermissionTest {
 
     private static final UUID USER_ID = UUID.randomUUID();
     private static final UUID ROOM_ID = UUID.randomUUID();
+    private static final UUID SECTION_ID = UUID.randomUUID();
 
     @BeforeEach
     void setUp() {
@@ -48,10 +50,21 @@ class FotoboxPermissionTest {
     // ── Helpers ──────────────────────────────────────────────────────────
 
     private UserInfo makeUser(UUID id, UserRole role) {
+        return makeUser(id, role, Set.of());
+    }
+
+    private UserInfo makeUser(UUID id, UserRole role, Set<String> specialRoles) {
         return new UserInfo(
                 id, id + "@monteweb.local", "Max", "Mustermann",
                 "Max Mustermann", null, null,
-                role, Set.of(), Set.of(), true, "SYSTEM"
+                role, specialRoles, Set.of(), true, "SYSTEM"
+        );
+    }
+
+    private RoomInfo makeRoom(UUID roomId, UUID sectionId) {
+        return new RoomInfo(
+                roomId, "Room", "desc", "pub", null, "CLASS",
+                sectionId, false, 5, "OPEN", null, java.util.List.of(), null
         );
     }
 
@@ -143,16 +156,36 @@ class FotoboxPermissionTest {
         }
 
         @Test
-        @DisplayName("SECTION_ADMIN is treated as admin even when not a room member")
-        void sectionAdminNonMemberTreatedAsAdmin() {
-            when(userModule.findById(USER_ID))
-                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.SECTION_ADMIN)));
+        @DisplayName("SECTION_ADMIN scoped to the room's section is treated as admin (non-member)")
+        void sectionAdminScopedToRoomSectionTreatedAsAdmin() {
+            when(userModule.findById(USER_ID)).thenReturn(Optional.of(
+                    makeUser(USER_ID, UserRole.SECTION_ADMIN, Set.of("SECTION_ADMIN:" + SECTION_ID))));
+            when(roomModule.findById(ROOM_ID)).thenReturn(Optional.of(makeRoom(ROOM_ID, SECTION_ID)));
 
-            // requireRoomMember must NOT throw for a non-member SECTION_ADMIN
+            // requireRoomMember must NOT throw for a section-scoped SECTION_ADMIN of this room
             assertThatCode(() -> service.requireRoomMember(USER_ID, ROOM_ID))
                     .doesNotThrowAnyException();
-            // SECTION_ADMIN must be recognised as leader-or-admin for moderation
+            // SECTION_ADMIN of this room's section must be recognised as leader-or-admin
             assertThat(service.isLeaderOrAdmin(USER_ID, ROOM_ID)).isTrue();
+        }
+
+        @Test
+        @DisplayName("SECTION_ADMIN scoped to a DIFFERENT section is NOT admin for this room")
+        void sectionAdminScopedToOtherSectionNotAdmin() {
+            UUID otherSection = UUID.randomUUID();
+            when(userModule.findById(USER_ID)).thenReturn(Optional.of(
+                    makeUser(USER_ID, UserRole.SECTION_ADMIN, Set.of("SECTION_ADMIN:" + otherSection))));
+            when(roomModule.findById(ROOM_ID)).thenReturn(Optional.of(makeRoom(ROOM_ID, SECTION_ID)));
+            // Not a room member either
+            when(roomModule.isUserInRoom(USER_ID, ROOM_ID)).thenReturn(false);
+
+            // requireRoomMember MUST throw: section admin of another section has no access
+            assertThatThrownBy(() -> service.requireRoomMember(USER_ID, ROOM_ID))
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessageContaining("Not a member of this room");
+            // And must NOT be treated as leader-or-admin
+            when(roomModule.getUserRoleInRoom(USER_ID, ROOM_ID)).thenReturn(Optional.empty());
+            assertThat(service.isLeaderOrAdmin(USER_ID, ROOM_ID)).isFalse();
         }
     }
 }

--- a/backend/src/test/java/com/monteweb/fotobox/FotoboxPermissionTest.java
+++ b/backend/src/test/java/com/monteweb/fotobox/FotoboxPermissionTest.java
@@ -124,4 +124,35 @@ class FotoboxPermissionTest {
                     .doesNotThrowAnyException();
         }
     }
+
+    // ── Admin Role Consistency (SUPERADMIN + SECTION_ADMIN) ───────────────
+
+    @Nested
+    @DisplayName("Admin Role Consistency")
+    class AdminRoleConsistency {
+
+        @Test
+        @DisplayName("SUPERADMIN is treated as admin even when not a room member")
+        void superAdminNonMemberTreatedAsAdmin() {
+            when(userModule.findById(USER_ID))
+                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.SUPERADMIN)));
+
+            assertThatCode(() -> service.requireRoomMember(USER_ID, ROOM_ID))
+                    .doesNotThrowAnyException();
+            assertThat(service.isLeaderOrAdmin(USER_ID, ROOM_ID)).isTrue();
+        }
+
+        @Test
+        @DisplayName("SECTION_ADMIN is treated as admin even when not a room member")
+        void sectionAdminNonMemberTreatedAsAdmin() {
+            when(userModule.findById(USER_ID))
+                    .thenReturn(Optional.of(makeUser(USER_ID, UserRole.SECTION_ADMIN)));
+
+            // requireRoomMember must NOT throw for a non-member SECTION_ADMIN
+            assertThatCode(() -> service.requireRoomMember(USER_ID, ROOM_ID))
+                    .doesNotThrowAnyException();
+            // SECTION_ADMIN must be recognised as leader-or-admin for moderation
+            assertThat(service.isLeaderOrAdmin(USER_ID, ROOM_ID)).isTrue();
+        }
+    }
 }

--- a/backend/src/test/java/com/monteweb/fundgrube/FundgrubeServiceTest.java
+++ b/backend/src/test/java/com/monteweb/fundgrube/FundgrubeServiceTest.java
@@ -92,6 +92,87 @@ class FundgrubeServiceTest {
         lenient().when(imageRepo.findByItemIdOrderByCreatedAt(item.getId())).thenReturn(List.of());
     }
 
+    // ── List Items ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("List Items")
+    class ListItems {
+
+        @Test
+        @DisplayName("Section filter includes school-wide (null-section) items")
+        void listItems_sectionFilterIncludesSchoolWide() {
+            var sectionItem = makeItem(UUID.randomUUID(), OTHER_USER_ID, SECTION_ID);
+            var schoolWideItem = makeItem(UUID.randomUUID(), OTHER_USER_ID, null);
+            // The repository query (findActiveBySectionId) is responsible for returning both;
+            // here we verify the service forwards to it and maps all returned items.
+            when(itemRepo.findActiveBySectionId(eq(SECTION_ID), any(Instant.class)))
+                    .thenReturn(List.of(sectionItem, schoolWideItem));
+            stubToInfo(sectionItem);
+            stubToInfo(schoolWideItem);
+
+            var result = service.listItems(SECTION_ID, null);
+
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(FundgrubeItemInfo::id)
+                    .containsExactlyInAnyOrder(sectionItem.getId(), schoolWideItem.getId());
+            verify(itemRepo).findActiveBySectionId(eq(SECTION_ID), any(Instant.class));
+            verify(itemRepo, never()).findAllActive(any());
+        }
+
+        @Test
+        @DisplayName("claimed=true returns only claimed items")
+        void listItems_claimedTrue() {
+            var claimedItem = makeItem(UUID.randomUUID(), OTHER_USER_ID, SECTION_ID);
+            claimedItem.setClaimedBy(USER_ID);
+            claimedItem.setClaimedAt(Instant.now());
+            var availableItem = makeItem(UUID.randomUUID(), OTHER_USER_ID, SECTION_ID);
+            when(itemRepo.findAllActive(any(Instant.class)))
+                    .thenReturn(List.of(claimedItem, availableItem));
+            stubToInfo(claimedItem);
+
+            var result = service.listItems(null, true);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).id()).isEqualTo(claimedItem.getId());
+            assertThat(result.get(0).claimed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("claimed=false returns only available (unclaimed) items")
+        void listItems_claimedFalse() {
+            var claimedItem = makeItem(UUID.randomUUID(), OTHER_USER_ID, SECTION_ID);
+            claimedItem.setClaimedBy(USER_ID);
+            claimedItem.setClaimedAt(Instant.now());
+            var availableItem = makeItem(UUID.randomUUID(), OTHER_USER_ID, SECTION_ID);
+            when(itemRepo.findAllActive(any(Instant.class)))
+                    .thenReturn(List.of(claimedItem, availableItem));
+            stubToInfo(availableItem);
+
+            var result = service.listItems(null, false);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).id()).isEqualTo(availableItem.getId());
+            assertThat(result.get(0).claimed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("claimed=null returns all active items")
+        void listItems_claimedNullReturnsAll() {
+            var claimedItem = makeItem(UUID.randomUUID(), OTHER_USER_ID, SECTION_ID);
+            claimedItem.setClaimedBy(USER_ID);
+            claimedItem.setClaimedAt(Instant.now());
+            var availableItem = makeItem(UUID.randomUUID(), OTHER_USER_ID, SECTION_ID);
+            when(itemRepo.findAllActive(any(Instant.class)))
+                    .thenReturn(List.of(claimedItem, availableItem));
+            stubToInfo(claimedItem);
+            stubToInfo(availableItem);
+
+            var result = service.listItems(null, null);
+
+            assertThat(result).hasSize(2);
+        }
+    }
+
     // ── Claim Item ───────────────────────────────────────────────────────
 
     @Nested

--- a/backend/src/test/java/com/monteweb/jobboard/JobboardControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/jobboard/JobboardControllerIntegrationTest.java
@@ -196,4 +196,25 @@ class JobboardControllerIntegrationTest {
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    void confirmAssignment_nonAdmin_shouldBeForbidden() throws Exception {
+        // Newly registered users default to PARENT and must not be able to confirm
+        // assignments (which credits hours to a family). The role check runs in the
+        // controller before the service, so a random assignment id still yields 403.
+        String token = TestHelper.registerAndGetToken(mockMvc,
+                "job-confirm-parent@example.com", "Job", "ConfirmParent");
+
+        mockMvc.perform(put("/api/v1/jobs/assignments/"
+                        + java.util.UUID.randomUUID() + "/confirm")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void confirmAssignment_unauthenticated_shouldFail() throws Exception {
+        mockMvc.perform(put("/api/v1/jobs/assignments/"
+                        + java.util.UUID.randomUUID() + "/confirm"))
+                .andExpect(status().isUnauthorized());
+    }
 }

--- a/backend/src/test/java/com/monteweb/jobboard/JobboardControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/jobboard/JobboardControllerIntegrationTest.java
@@ -162,4 +162,38 @@ class JobboardControllerIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isArray());
     }
+
+    @Test
+    void exportCsv_unauthenticated_shouldFail() throws Exception {
+        mockMvc.perform(get("/api/v1/jobs/report/export"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void exportPdf_unauthenticated_shouldFail() throws Exception {
+        mockMvc.perform(get("/api/v1/jobs/report/pdf"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void exportCsv_nonAdmin_shouldBeForbidden() throws Exception {
+        // Newly registered users default to PARENT, which may not access reports.
+        String token = TestHelper.registerAndGetToken(mockMvc,
+                "job-export-csv@example.com", "Job", "ExportCsv");
+
+        mockMvc.perform(get("/api/v1/jobs/report/export")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void exportPdf_nonAdmin_shouldBeForbidden() throws Exception {
+        // Newly registered users default to PARENT, which may not access reports.
+        String token = TestHelper.registerAndGetToken(mockMvc,
+                "job-export-pdf@example.com", "Job", "ExportPdf");
+
+        mockMvc.perform(get("/api/v1/jobs/report/pdf")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
 }

--- a/backend/src/test/java/com/monteweb/jobboard/JobboardServiceIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/jobboard/JobboardServiceIntegrationTest.java
@@ -210,8 +210,11 @@ class JobboardServiceIntegrationTest {
     }
 
     @Test
-    void getReportPdf_authenticatedUser_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+    void getReportPdf_teacher_shouldSucceed() throws Exception {
+        // The family-hours export returns ALL families' billing data and is now
+        // restricted to SUPERADMIN/SECTION_ADMIN/TEACHER. A teacher must still get
+        // the PDF; non-admin (403) access is asserted in a separate test.
+        String token = loginAs("lehrer@monteweb.local");
 
         mockMvc.perform(get("/api/v1/jobs/report/pdf")
                         .header("Authorization", "Bearer " + token))

--- a/backend/src/test/java/com/monteweb/messaging/MessagingServiceTest.java
+++ b/backend/src/test/java/com/monteweb/messaging/MessagingServiceTest.java
@@ -404,4 +404,56 @@ class MessagingServiceTest {
                     .hasMessageContaining("not a participant");
         }
     }
+
+    // ── Message Reactions ────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Message Reactions")
+    class MessageReactions {
+
+        @Test
+        @DisplayName("Non-participant cannot toggle a reaction (IDOR blocked)")
+        void toggleMessageReaction_nonParticipantThrows() {
+            UUID msgId = UUID.randomUUID();
+            var msg = makeMessage(msgId, CONV_ID, USER_B, "Hello");
+            when(messageRepository.findById(msgId)).thenReturn(Optional.of(msg));
+            when(participantRepository.existsByConversationIdAndUserId(CONV_ID, USER_A)).thenReturn(false);
+
+            assertThatThrownBy(() -> service.toggleMessageReaction(msgId, USER_A, "👍"))
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessageContaining("not a participant");
+
+            verify(messageReactionRepository, never()).save(any(MessageReaction.class));
+        }
+
+        @Test
+        @DisplayName("Participant can add a reaction")
+        void toggleMessageReaction_participantAddsReaction() {
+            UUID msgId = UUID.randomUUID();
+            var msg = makeMessage(msgId, CONV_ID, USER_B, "Hello");
+            when(messageRepository.findById(msgId)).thenReturn(Optional.of(msg));
+            when(participantRepository.existsByConversationIdAndUserId(CONV_ID, USER_A)).thenReturn(true);
+            when(messageReactionRepository.findByMessageIdAndUserIdAndEmoji(msgId, USER_A, "👍"))
+                    .thenReturn(Optional.empty());
+
+            service.toggleMessageReaction(msgId, USER_A, "👍");
+
+            verify(messageReactionRepository).save(any(MessageReaction.class));
+        }
+
+        @Test
+        @DisplayName("Non-participant cannot read reactions (IDOR blocked)")
+        void getMessageReactions_nonParticipantThrows() {
+            UUID msgId = UUID.randomUUID();
+            var msg = makeMessage(msgId, CONV_ID, USER_B, "Hello");
+            when(messageRepository.findById(msgId)).thenReturn(Optional.of(msg));
+            when(participantRepository.existsByConversationIdAndUserId(CONV_ID, USER_A)).thenReturn(false);
+
+            assertThatThrownBy(() -> service.getMessageReactions(msgId, USER_A))
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessageContaining("not a participant");
+
+            verify(messageReactionRepository, never()).findByMessageId(any(UUID.class));
+        }
+    }
 }

--- a/backend/src/test/java/com/monteweb/messaging/MessagingServiceTest.java
+++ b/backend/src/test/java/com/monteweb/messaging/MessagingServiceTest.java
@@ -309,6 +309,93 @@ class MessagingServiceTest {
         }
     }
 
+    // ── Start Group Conversation ─────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Start User Group Conversation")
+    class StartUserGroupConversation {
+
+        private final UUID userC = UUID.randomUUID();
+
+        @Test
+        @DisplayName("Rejects group with fewer than 2 other participants")
+        void groupConversation_tooFewParticipants() {
+            assertThatThrownBy(() -> service.startUserGroupConversation(USER_A, "Group", List.of(USER_B)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("at least 2 other participants");
+
+            verify(conversationRepository, never()).save(any(Conversation.class));
+        }
+
+        @Test
+        @DisplayName("Rejects group where duplicates collapse below 2 participants")
+        void groupConversation_duplicatesCollapse() {
+            assertThatThrownBy(() -> service.startUserGroupConversation(USER_A, "Group", List.of(USER_B, USER_B)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("at least 2 other participants");
+
+            verify(conversationRepository, never()).save(any(Conversation.class));
+        }
+
+        @Test
+        @DisplayName("Parent cannot create group with parents when parent-to-parent disabled")
+        void groupConversation_parentToParentBlocked() {
+            when(userModuleApi.findById(USER_A)).thenReturn(Optional.of(makeUser(USER_A, UserRole.PARENT)));
+            when(userModuleApi.findById(USER_B)).thenReturn(Optional.of(makeUser(USER_B, UserRole.PARENT)));
+            when(adminModuleApi.getTenantConfig()).thenReturn(makeTenantConfig(false, false));
+
+            assertThatThrownBy(() -> service.startUserGroupConversation(USER_A, "Group", List.of(USER_B, userC)))
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessageContaining("Parent-to-parent");
+
+            verify(conversationRepository, never()).save(any(Conversation.class));
+        }
+
+        @Test
+        @DisplayName("Student cannot create group with students when student-to-student disabled")
+        void groupConversation_studentToStudentBlocked() {
+            when(userModuleApi.findById(USER_A)).thenReturn(Optional.of(makeUser(USER_A, UserRole.STUDENT)));
+            when(userModuleApi.findById(USER_B)).thenReturn(Optional.of(makeUser(USER_B, UserRole.STUDENT)));
+            when(adminModuleApi.getTenantConfig()).thenReturn(makeTenantConfig(false, false));
+
+            assertThatThrownBy(() -> service.startUserGroupConversation(USER_A, "Group", List.of(USER_B, userC)))
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessageContaining("Student-to-student");
+
+            verify(conversationRepository, never()).save(any(Conversation.class));
+        }
+
+        @Test
+        @DisplayName("Teacher can create a group with parents (staff bypasses comm rules)")
+        void groupConversation_staffCreatorSucceeds() {
+            when(userModuleApi.findById(USER_A)).thenReturn(Optional.of(makeUser(USER_A, UserRole.TEACHER)));
+            when(userModuleApi.findById(USER_B)).thenReturn(Optional.of(makeUser(USER_B, UserRole.PARENT)));
+            when(userModuleApi.findById(userC)).thenReturn(Optional.of(makeUser(userC, UserRole.PARENT)));
+
+            var savedConv = makeConversation(CONV_ID, true, USER_A);
+            when(conversationRepository.save(any(Conversation.class))).thenReturn(savedConv);
+
+            lenient().when(participantRepository.findByConversationId(CONV_ID))
+                    .thenReturn(List.of(
+                            makeParticipant(CONV_ID, USER_A),
+                            makeParticipant(CONV_ID, USER_B),
+                            makeParticipant(CONV_ID, userC)));
+            lenient().when(messageRepository.findFirstByConversationIdOrderByCreatedAtDesc(CONV_ID))
+                    .thenReturn(Optional.empty());
+            lenient().when(messageRepository.countUnreadMessages(eq(CONV_ID), any(UUID.class), any(Instant.class)))
+                    .thenReturn(0L);
+
+            var result = service.startUserGroupConversation(USER_A, "Group", List.of(USER_B, userC));
+
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(CONV_ID);
+            verify(conversationRepository).save(any(Conversation.class));
+            // creator + 2 participants
+            verify(participantRepository, times(3)).save(any(ConversationParticipant.class));
+            verify(adminModuleApi, never()).getTenantConfig();
+        }
+    }
+
     // ── Send Message ─────────────────────────────────────────────────────
 
     @Nested
@@ -454,6 +541,44 @@ class MessagingServiceTest {
                     .hasMessageContaining("not a participant");
 
             verify(messageReactionRepository, never()).findByMessageId(any(UUID.class));
+        }
+
+        @Test
+        @DisplayName("getMessages returns pre-existing reactions with counts and own-highlight")
+        void getMessages_returnsExistingReactions() {
+            UUID msgId = UUID.randomUUID();
+            var msg = makeMessage(msgId, CONV_ID, USER_B, "Hello");
+
+            when(participantRepository.existsByConversationIdAndUserId(CONV_ID, USER_A)).thenReturn(true);
+            when(messageRepository.findByConversationIdOrderByCreatedAtDesc(eq(CONV_ID), any(org.springframework.data.domain.Pageable.class)))
+                    .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(msg)));
+            when(messageImageRepository.findByMessageIdIn(anyList())).thenReturn(List.of());
+            when(messageAttachmentRepository.findByMessageIdIn(anyList())).thenReturn(List.of());
+
+            // Two reactions on the message: USER_A (current user) and USER_B both used 👍
+            var reactionA = new MessageReaction();
+            reactionA.setMessageId(msgId);
+            reactionA.setUserId(USER_A);
+            reactionA.setEmoji("👍");
+            var reactionB = new MessageReaction();
+            reactionB.setMessageId(msgId);
+            reactionB.setUserId(USER_B);
+            reactionB.setEmoji("👍");
+            when(messageReactionRepository.findByMessageIdIn(List.of(msgId)))
+                    .thenReturn(List.of(reactionA, reactionB));
+
+            when(messagePollRepository.findByMessageId(msgId)).thenReturn(Optional.empty());
+            when(userModuleApi.findById(USER_B)).thenReturn(Optional.of(makeUser(USER_B, UserRole.PARENT)));
+
+            var page = service.getMessages(CONV_ID, USER_A,
+                    org.springframework.data.domain.PageRequest.of(0, 50));
+
+            assertThat(page.getContent()).hasSize(1);
+            var reactions = page.getContent().get(0).reactions();
+            assertThat(reactions).hasSize(1);
+            assertThat(reactions.get(0).emoji()).isEqualTo("👍");
+            assertThat(reactions.get(0).count()).isEqualTo(2);
+            assertThat(reactions.get(0).userReacted()).isTrue();
         }
     }
 }

--- a/backend/src/test/java/com/monteweb/room/DiscussionThreadControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/room/DiscussionThreadControllerIntegrationTest.java
@@ -41,7 +41,7 @@ class DiscussionThreadControllerIntegrationTest {
 
     @Test
     void getThreads_authenticated_shouldReturnPage() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "disc-list@example.com", "Disc", "List");
 
         String roomId = createRoomAndGetId(token);
@@ -54,7 +54,7 @@ class DiscussionThreadControllerIntegrationTest {
 
     @Test
     void createThread_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "disc-create@example.com", "Disc", "Creator");
 
         String roomId = createRoomAndGetId(token);
@@ -74,7 +74,7 @@ class DiscussionThreadControllerIntegrationTest {
 
     @Test
     void getThread_shouldReturnThread() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "disc-get@example.com", "Disc", "Getter");
 
         String roomId = createRoomAndGetId(token);
@@ -97,7 +97,7 @@ class DiscussionThreadControllerIntegrationTest {
 
     @Test
     void addReply_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "disc-reply@example.com", "Disc", "Replier");
 
         String roomId = createRoomAndGetId(token);
@@ -126,7 +126,7 @@ class DiscussionThreadControllerIntegrationTest {
     void getThread_leaderCanReadKinderAudienceThread() throws Exception {
         // Regression guard for the audience-filter refactor: a room LEADER (canSeeAll)
         // must still be able to read a thread restricted to the KINDER audience.
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "disc-kinder@example.com", "Disc", "Kinder");
 
         String roomId = createRoomAndGetId(token);
@@ -155,7 +155,7 @@ class DiscussionThreadControllerIntegrationTest {
 
     @Test
     void getReplies_shouldReturnPage() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "disc-replies@example.com", "Disc", "Replies");
 
         String roomId = createRoomAndGetId(token);

--- a/backend/src/test/java/com/monteweb/room/DiscussionThreadControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/room/DiscussionThreadControllerIntegrationTest.java
@@ -123,6 +123,37 @@ class DiscussionThreadControllerIntegrationTest {
     }
 
     @Test
+    void getThread_leaderCanReadKinderAudienceThread() throws Exception {
+        // Regression guard for the audience-filter refactor: a room LEADER (canSeeAll)
+        // must still be able to read a thread restricted to the KINDER audience.
+        String token = TestHelper.registerAndGetToken(mockMvc,
+                "disc-kinder@example.com", "Disc", "Kinder");
+
+        String roomId = createRoomAndGetId(token);
+
+        var threadResult = mockMvc.perform(post("/api/v1/rooms/" + roomId + "/threads")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"title": "Kinder Thread", "content": "Content", "audience": "KINDER"}
+                                """))
+                .andReturn();
+        String threadId = TestHelper.parseResponse(threadResult.getResponse().getContentAsString())
+                .path("data").path("id").asText();
+
+        mockMvc.perform(get("/api/v1/rooms/" + roomId + "/threads/" + threadId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.audience").value("KINDER"));
+
+        // And replies endpoint must remain accessible to the leader for that thread
+        mockMvc.perform(get("/api/v1/rooms/" + roomId + "/threads/" + threadId + "/replies")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isArray());
+    }
+
+    @Test
     void getReplies_shouldReturnPage() throws Exception {
         String token = TestHelper.registerAndGetToken(mockMvc,
                 "disc-replies@example.com", "Disc", "Replies");

--- a/backend/src/test/java/com/monteweb/room/RoleConceptIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/room/RoleConceptIntegrationTest.java
@@ -59,7 +59,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void createRoom_shouldHaveDefaultJoinPolicy() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-default-jp@example.com", "Default", "JP");
 
         var result = mockMvc.perform(post("/api/v1/rooms")
@@ -129,7 +129,7 @@ class RoleConceptIntegrationTest {
     @Test
     void joinRoom_requestPolicy_shouldFail() throws Exception {
         // User A creates a regular room (REQUEST policy by default)
-        String tokenA = TestHelper.registerAndGetToken(mockMvc,
+        String tokenA = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-joinreq-a@example.com", "Creator", "ReqA");
         String roomId = createRoomAndGetId(tokenA, "Request Only Room", "GRUPPE");
 
@@ -168,7 +168,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void muteRoom_asMember_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-mute@example.com", "Mute", "User");
         String roomId = createRoomAndGetId(token, "Mutable Room", "GRUPPE");
 
@@ -179,7 +179,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void unmuteRoom_afterMuting_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-unmute@example.com", "Unmute", "User");
         String roomId = createRoomAndGetId(token, "Unmutable Room", "GRUPPE");
 
@@ -204,7 +204,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void updateSettings_discussionMode_shouldPersist() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-discmode@example.com", "Disc", "Mode");
         String roomId = createRoomAndGetId(token, "Discussion Mode Room", "GRUPPE");
 
@@ -239,7 +239,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void updateSettings_disableDiscussions_shouldPersist() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-disableddisc@example.com", "Disabled", "Disc");
         String roomId = createRoomAndGetId(token, "No Discussions Room", "GRUPPE");
 
@@ -262,7 +262,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void updateSettings_allowMemberThreadCreation_shouldPersist() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-memberthreads@example.com", "Member", "Threads");
         String roomId = createRoomAndGetId(token, "Member Threads Room", "KLASSE");
 
@@ -299,7 +299,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void createThread_inDisabledMode_shouldStillWorkForLeader() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-thread-disabled@example.com", "Thread", "Disabled");
         String roomId = createRoomAndGetId(token, "Disabled Thread Room", "GRUPPE");
 
@@ -335,7 +335,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void createJoinRequest_requestPolicy_shouldSucceed() throws Exception {
-        String tokenA = TestHelper.registerAndGetToken(mockMvc,
+        String tokenA = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-jr-creator@example.com", "JR", "Creator");
         String roomId = createRoomAndGetId(tokenA, "Request Policy JR Room", "PROJEKT");
 
@@ -355,7 +355,7 @@ class RoleConceptIntegrationTest {
     @Test
     void approveJoinRequest_shouldAddMember() throws Exception {
         // Create room
-        String tokenA = TestHelper.registerAndGetToken(mockMvc,
+        String tokenA = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-approve-creator@example.com", "Approve", "Creator");
         String roomId = createRoomAndGetId(tokenA, "Approve JR Room", "GRUPPE");
 
@@ -389,7 +389,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void getRoom_asNonMember_shouldReturnPublicView() throws Exception {
-        String tokenA = TestHelper.registerAndGetToken(mockMvc,
+        String tokenA = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-public-creator@example.com", "Public", "Creator");
         String roomId = createRoomAndGetId(tokenA, "Public View Room", "GRUPPE");
 
@@ -410,7 +410,7 @@ class RoleConceptIntegrationTest {
 
     @Test
     void getRoom_asMember_shouldReturnDetailView() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc,
                 "rc-detail-member@example.com", "Detail", "Member");
         String roomId = createRoomAndGetId(token, "Detail View Room", "GRUPPE");
 

--- a/backend/src/test/java/com/monteweb/room/RoomControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/room/RoomControllerIntegrationTest.java
@@ -21,6 +21,22 @@ class RoomControllerIntegrationTest {
     @Autowired
     private MockMvc mockMvc;
 
+    /**
+     * Logs in as a seeded account (password {@code test1234}) and returns its access token.
+     * Used to obtain a TEACHER token, since room creation (US-050) is restricted to
+     * TEACHER / SECTION_ADMIN / SUPERADMIN.
+     */
+    private String loginAs(String email) throws Exception {
+        var result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email": "%s", "password": "test1234"}
+                                """.formatted(email)))
+                .andReturn();
+        return TestHelper.parseResponse(result.getResponse().getContentAsString())
+                .path("data").path("accessToken").asText();
+    }
+
     @Test
     void getMyRooms_unauthenticated_shouldFail() throws Exception {
         mockMvc.perform(get("/api/v1/rooms/mine"))
@@ -40,9 +56,8 @@ class RoomControllerIntegrationTest {
     }
 
     @Test
-    void createRoom_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
-                "room-creator@example.com", "Room", "Creator");
+    void createRoom_asTeacher_shouldSucceed() throws Exception {
+        String token = loginAs("lehrer@monteweb.local");
 
         mockMvc.perform(post("/api/v1/rooms")
                         .header("Authorization", "Bearer " + token)
@@ -57,9 +72,38 @@ class RoomControllerIntegrationTest {
     }
 
     @Test
-    void createRoom_blankName_shouldFail() throws Exception {
+    void createRoom_asParent_shouldReturn403() throws Exception {
+        // US-050: PARENT must not be able to create rooms. Freshly registered
+        // users default to UserRole.PARENT.
         String token = TestHelper.registerAndGetToken(mockMvc,
-                "room-blank@example.com", "Room", "Blank");
+                "room-parent-create@example.com", "Parent", "Creator");
+
+        mockMvc.perform(post("/api/v1/rooms")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name": "Forbidden Room", "type": "PROJEKT"}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void createRoom_asStudent_shouldReturn403() throws Exception {
+        // US-050: STUDENT must not be able to create rooms.
+        String token = loginAs("schueler@monteweb.local");
+
+        mockMvc.perform(post("/api/v1/rooms")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name": "Forbidden Room", "type": "PROJEKT"}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void createRoom_blankName_shouldFail() throws Exception {
+        String token = loginAs("lehrer@monteweb.local");
 
         mockMvc.perform(post("/api/v1/rooms")
                         .header("Authorization", "Bearer " + token)
@@ -72,8 +116,7 @@ class RoomControllerIntegrationTest {
 
     @Test
     void getRoom_shouldReturnRoom() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
-                "room-get@example.com", "Room", "Getter");
+        String token = loginAs("lehrer@monteweb.local");
 
         // Create a room first
         var createResult = mockMvc.perform(post("/api/v1/rooms")
@@ -108,9 +151,8 @@ class RoomControllerIntegrationTest {
 
     @Test
     void createJoinRequest_shouldSucceed() throws Exception {
-        // Create room as user A
-        String tokenA = TestHelper.registerAndGetToken(mockMvc,
-                "room-owner-jr@example.com", "Owner", "JR");
+        // Create room as user A (teacher — only staff may create rooms)
+        String tokenA = loginAs("lehrer@monteweb.local");
         var createResult = mockMvc.perform(post("/api/v1/rooms")
                         .header("Authorization", "Bearer " + tokenA)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -159,8 +201,7 @@ class RoomControllerIntegrationTest {
 
     @Test
     void getRoomMembers_asMember_shouldSucceed() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc,
-                "room-members@example.com", "Room", "Member");
+        String token = loginAs("lehrer@monteweb.local");
 
         var createResult = mockMvc.perform(post("/api/v1/rooms")
                         .header("Authorization", "Bearer " + token)

--- a/backend/src/test/java/com/monteweb/room/RoomServiceIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/room/RoomServiceIntegrationTest.java
@@ -28,7 +28,7 @@ class RoomServiceIntegrationTest {
 
     @Test
     void createRoom_shouldReturnCreatedRoom() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         mockMvc.perform(post("/api/v1/rooms")
                         .header("Authorization", "Bearer " + token)
@@ -93,7 +93,7 @@ class RoomServiceIntegrationTest {
 
     @Test
     void updateRoom_asCreator_shouldWork() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room
         var createResult = mockMvc.perform(post("/api/v1/rooms")
@@ -122,7 +122,7 @@ class RoomServiceIntegrationTest {
 
     @Test
     void getMembers_ofOwnRoom_shouldWork() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room
         var createResult = mockMvc.perform(post("/api/v1/rooms")
@@ -192,7 +192,7 @@ class RoomServiceIntegrationTest {
 
     @Test
     void getThreads_forOwnRoom_shouldWork() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room
         var createResult = mockMvc.perform(post("/api/v1/rooms")
@@ -214,7 +214,7 @@ class RoomServiceIntegrationTest {
 
     @Test
     void createThread_asLeader_shouldWork() throws Exception {
-        String token = TestHelper.registerAndGetToken(mockMvc);
+        String token = TestHelper.registerTeacherAndGetToken(mockMvc);
 
         // Create room (creator = LEADER)
         var createResult = mockMvc.perform(post("/api/v1/rooms")

--- a/backend/src/test/java/com/monteweb/search/SolrSearchServiceTest.java
+++ b/backend/src/test/java/com/monteweb/search/SolrSearchServiceTest.java
@@ -177,10 +177,14 @@ class SolrSearchServiceTest {
     private SolrSearchService createInstance() {
         try {
             var constructor = SolrSearchService.class.getDeclaredConstructor(
-                    org.apache.solr.client.solrj.SolrClient.class
+                    org.apache.solr.client.solrj.SolrClient.class,
+                    com.monteweb.room.RoomModuleApi.class
             );
             constructor.setAccessible(true);
-            return constructor.newInstance((org.apache.solr.client.solrj.SolrClient) null);
+            return constructor.newInstance(
+                    (org.apache.solr.client.solrj.SolrClient) null,
+                    (com.monteweb.room.RoomModuleApi) null
+            );
         } catch (Exception e) {
             throw new RuntimeException("Failed to create SolrSearchService instance for testing", e);
         }

--- a/backend/src/test/java/com/monteweb/shared/SecurityUtilsTest.java
+++ b/backend/src/test/java/com/monteweb/shared/SecurityUtilsTest.java
@@ -3,8 +3,11 @@ package com.monteweb.shared;
 import com.monteweb.shared.util.SecurityUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Collections;
 import java.util.UUID;
@@ -17,6 +20,11 @@ class SecurityUtilsTest {
     @AfterEach
     void clearContext() {
         SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    private static void bindRequest(MockHttpServletRequest request) {
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
     }
 
     @Test
@@ -56,5 +64,94 @@ class SecurityUtilsTest {
 
         UUID result = SecurityUtils.requireCurrentUserId();
         assertThat(result).isEqualTo(userId);
+    }
+
+    @Test
+    void getClientIpAddress_shouldPreferXForwardedForFirstHop() {
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Forwarded-For", "203.0.113.7, 70.41.3.18, 150.172.238.178");
+        request.addHeader("X-Real-IP", "10.0.0.1");
+        request.setRemoteAddr("127.0.0.1");
+        bindRequest(request);
+
+        assertThat(SecurityUtils.getClientIpAddress()).isEqualTo("203.0.113.7");
+    }
+
+    @Test
+    void getClientIpAddress_shouldFallBackToXRealIp() {
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Real-IP", "198.51.100.42");
+        request.setRemoteAddr("127.0.0.1");
+        bindRequest(request);
+
+        assertThat(SecurityUtils.getClientIpAddress()).isEqualTo("198.51.100.42");
+    }
+
+    @Test
+    void getClientIpAddress_shouldFallBackToRemoteAddr() {
+        var request = new MockHttpServletRequest();
+        request.setRemoteAddr("192.0.2.55");
+        bindRequest(request);
+
+        assertThat(SecurityUtils.getClientIpAddress()).isEqualTo("192.0.2.55");
+    }
+
+    @Test
+    void getClientIpAddress_whenNoRequest_shouldReturnNull() {
+        RequestContextHolder.resetRequestAttributes();
+
+        assertThat(SecurityUtils.getClientIpAddress()).isNull();
+    }
+
+    @Test
+    void getImpersonatorId_whenAttributePresent_shouldReturnAdminId() {
+        UUID adminId = UUID.randomUUID();
+        var request = new MockHttpServletRequest();
+        request.setAttribute(SecurityUtils.IMPERSONATED_BY_ATTRIBUTE, adminId.toString());
+        bindRequest(request);
+
+        assertThat(SecurityUtils.getImpersonatorId()).isPresent().contains(adminId);
+    }
+
+    @Test
+    void getImpersonatorId_whenAttributeAbsent_shouldReturnEmpty() {
+        bindRequest(new MockHttpServletRequest());
+
+        assertThat(SecurityUtils.getImpersonatorId()).isEmpty();
+    }
+
+    @Test
+    void getImpersonatorId_whenAttributeNotAUuid_shouldReturnEmpty() {
+        var request = new MockHttpServletRequest();
+        request.setAttribute(SecurityUtils.IMPERSONATED_BY_ATTRIBUTE, "not-a-uuid");
+        bindRequest(request);
+
+        assertThat(SecurityUtils.getImpersonatorId()).isEmpty();
+    }
+
+    @Test
+    void requireAuditActorId_whenImpersonating_shouldReturnAdminNotTarget() {
+        UUID adminId = UUID.randomUUID();
+        UUID targetId = UUID.randomUUID();
+        var auth = new UsernamePasswordAuthenticationToken(
+                targetId.toString(), null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        var request = new MockHttpServletRequest();
+        request.setAttribute(SecurityUtils.IMPERSONATED_BY_ATTRIBUTE, adminId.toString());
+        bindRequest(request);
+
+        assertThat(SecurityUtils.requireAuditActorId()).isEqualTo(adminId);
+    }
+
+    @Test
+    void requireAuditActorId_whenNotImpersonating_shouldReturnCurrentUser() {
+        UUID userId = UUID.randomUUID();
+        var auth = new UsernamePasswordAuthenticationToken(
+                userId.toString(), null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        bindRequest(new MockHttpServletRequest());
+
+        assertThat(SecurityUtils.requireAuditActorId()).isEqualTo(userId);
     }
 }

--- a/backend/src/test/java/com/monteweb/user/UserControllerIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/user/UserControllerIntegrationTest.java
@@ -67,6 +67,56 @@ class UserControllerIntegrationTest {
     }
 
     @Test
+    void updateMe_blankFirstName_shouldReturn400() throws Exception {
+        String token = TestHelper.registerAndGetToken(mockMvc,
+                "update-blank-first@example.com", "Before", "Update");
+
+        mockMvc.perform(put("/api/v1/users/me")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "firstName": "   ",
+                                    "lastName": "Updated"
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updateMe_blankLastName_shouldReturn400() throws Exception {
+        String token = TestHelper.registerAndGetToken(mockMvc,
+                "update-blank-last@example.com", "Before", "Update");
+
+        mockMvc.perform(put("/api/v1/users/me")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "firstName": "After",
+                                    "lastName": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updateMe_missingNames_shouldReturn400() throws Exception {
+        String token = TestHelper.registerAndGetToken(mockMvc,
+                "update-missing-names@example.com", "Before", "Update");
+
+        mockMvc.perform(put("/api/v1/users/me")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "phone": "+49123456789"
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void updateMe_unauthenticated_shouldReturn401() throws Exception {
         mockMvc.perform(put("/api/v1/users/me")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/monteweb/user/UserServiceIntegrationTest.java
+++ b/backend/src/test/java/com/monteweb/user/UserServiceIntegrationTest.java
@@ -97,4 +97,40 @@ class UserServiceIntegrationTest {
         assertThat(found).isPresent();
         assertThat(found.get().id()).isEqualTo(user.id());
     }
+
+    @Test
+    void updateProfile_shouldTrimAndDeriveDisplayName() {
+        var user = userModuleApi.createUser(
+                "update-profile@example.com", "hash",
+                "Old", "Name", null, UserRole.PARENT);
+
+        var updated = userModuleApi.updateProfile(user.id(), "  New  ", "  Surname  ", "  123  ");
+
+        assertThat(updated.firstName()).isEqualTo("New");
+        assertThat(updated.lastName()).isEqualTo("Surname");
+        assertThat(updated.displayName()).isEqualTo("New Surname");
+        assertThat(updated.phone()).isEqualTo("123");
+    }
+
+    @Test
+    void updateProfile_blankFirstName_shouldThrow() {
+        var user = userModuleApi.createUser(
+                "update-blank-first-svc@example.com", "hash",
+                "Old", "Name", null, UserRole.PARENT);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> userModuleApi.updateProfile(user.id(), "   ", "Surname", null))
+                .isInstanceOf(com.monteweb.shared.exception.BadRequestException.class);
+    }
+
+    @Test
+    void updateProfile_nullLastName_shouldThrow() {
+        var user = userModuleApi.createUser(
+                "update-null-last-svc@example.com", "hash",
+                "Old", "Name", null, UserRole.PARENT);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> userModuleApi.updateProfile(user.id(), "First", null, null))
+                .isInstanceOf(com.monteweb.shared.exception.BadRequestException.class);
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,7 +257,10 @@ services:
       - JWT_ENABLED=${ONLYOFFICE_JWT_ENABLED:-true}
       - JWT_SECRET=${ONLYOFFICE_JWT_SECRET:?ONLYOFFICE_JWT_SECRET is required and must match the backend}
     ports:
-      - "8443:443"
+      # Loopback only — backend<->onlyoffice traffic stays on the internal Docker
+      # network. If browsers must reach the editor directly, proxy it via nginx/Caddy
+      # rather than exposing 8443 on all interfaces.
+      - "127.0.0.1:8443:443"
     volumes:
       - onlyoffice_data:/var/lib/onlyoffice
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,7 +233,9 @@ services:
     profiles: ["monitoring"]
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:?GRAFANA_PASSWORD is required (set a strong value in .env)}
+      # Set GRAFANA_PASSWORD in .env before enabling the monitoring profile. Bound to
+      # 127.0.0.1 only (see ports below), so the default is loopback-reachable at worst.
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
@@ -258,7 +260,11 @@ services:
       # callbacks with ONLYOFFICE_JWT_SECRET. With JWT disabled, anyone reaching
       # this server can drive document conversion/command callbacks unauthenticated.
       - JWT_ENABLED=${ONLYOFFICE_JWT_ENABLED:-true}
-      - JWT_SECRET=${ONLYOFFICE_JWT_SECRET:?ONLYOFFICE_JWT_SECRET is required and must match the backend}
+      # Set ONLYOFFICE_JWT_SECRET in .env when enabling the office profile (must match
+      # the backend). Empty default keeps `docker compose` usable without the profile;
+      # with JWT enabled the server rejects unsigned requests, so an unset secret simply
+      # makes the editor non-functional rather than insecure.
+      - JWT_SECRET=${ONLYOFFICE_JWT_SECRET:-}
     ports:
       # Loopback only — backend<->onlyoffice traffic stays on the internal Docker
       # network. If browsers must reach the editor directly, proxy it via nginx/Caddy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,11 @@ services:
       VAPID_SUBJECT: ${VAPID_SUBJECT:-mailto:admin@monteweb.local}
       SOLR_URL: http://solr:8983/solr/monteweb
       MONTEWEB_RATE_LIMIT_ENABLED: ${MONTEWEB_RATE_LIMIT_ENABLED:-true}
+      # Empty/default profile enforces strong-secret validation (fail closed).
+      # Set SPRING_PROFILES_ACTIVE=dev in .env for local dev with relaxed checks.
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-}
+      # Shared HMAC secret with the ONLYOFFICE document server (office profile).
+      ONLYOFFICE_JWT_SECRET: ${ONLYOFFICE_JWT_SECRET:-}
     networks:
       - backend
       - frontend
@@ -210,7 +215,8 @@ services:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     ports:
-      - "9090:9090"
+      # Loopback only — Prometheus has no auth; reach it via SSH tunnel.
+      - "127.0.0.1:9090:9090"
     networks:
       - backend
     depends_on:
@@ -224,13 +230,14 @@ services:
     profiles: ["monitoring"]
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:?GRAFANA_PASSWORD is required (set a strong value in .env)}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
     ports:
-      - "3000:3000"
+      # Loopback only — reach the dashboard via SSH tunnel, do not expose publicly.
+      - "127.0.0.1:3000:3000"
     networks:
       - backend
     depends_on:
@@ -244,7 +251,11 @@ services:
     restart: unless-stopped
     profiles: ["office"]
     environment:
-      - JWT_ENABLED=false
+      # JWT MUST be enabled — the backend WopiController signs/verifies WOPI
+      # callbacks with ONLYOFFICE_JWT_SECRET. With JWT disabled, anyone reaching
+      # this server can drive document conversion/command callbacks unauthenticated.
+      - JWT_ENABLED=${ONLYOFFICE_JWT_ENABLED:-true}
+      - JWT_SECRET=${ONLYOFFICE_JWT_SECRET:?ONLYOFFICE_JWT_SECRET is required and must match the backend}
     ports:
       - "8443:443"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,9 @@ services:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-}
       # Shared HMAC secret with the ONLYOFFICE document server (office profile).
       ONLYOFFICE_JWT_SECRET: ${ONLYOFFICE_JWT_SECRET:-}
+      # Signing secret for cleaning QR check-in tokens. Required: the backend fails
+      # closed on the built-in default (set CLEANING_QR_SECRET in .env).
+      MONTEWEB_CLEANING_QR_SECRET: ${CLEANING_QR_SECRET:-}
     networks:
       - backend
       - frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,9 +233,12 @@ services:
     profiles: ["monitoring"]
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
-      # Set GRAFANA_PASSWORD in .env before enabling the monitoring profile. Bound to
-      # 127.0.0.1 only (see ports below), so the default is loopback-reachable at worst.
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      # Set GRAFANA_PASSWORD in .env before enabling the monitoring profile. ${VAR:?}
+      # (required) can't be used — Compose interpolates all services regardless of
+      # `profiles:`, so it would break the core stack's `docker compose build`/`up`.
+      # The default is NOT the well-known admin/admin and the dashboard is bound to
+      # 127.0.0.1 only (see ports below), so it is loopback-reachable at worst.
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-changeme_set_a_strong_grafana_password}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
@@ -261,10 +264,13 @@ services:
       # this server can drive document conversion/command callbacks unauthenticated.
       - JWT_ENABLED=${ONLYOFFICE_JWT_ENABLED:-true}
       # Set ONLYOFFICE_JWT_SECRET in .env when enabling the office profile (must match
-      # the backend). Empty default keeps `docker compose` usable without the profile;
-      # with JWT enabled the server rejects unsigned requests, so an unset secret simply
-      # makes the editor non-functional rather than insecure.
-      - JWT_SECRET=${ONLYOFFICE_JWT_SECRET:-}
+      # the backend). NOTE: ${VAR:?} (required) cannot be used here — Docker Compose
+      # interpolates ALL services regardless of `profiles:`, so :? would break
+      # `docker compose build`/`up` of the core stack. Instead it FAILS CLOSED: the
+      # default is the placeholder the backend WopiController explicitly rejects
+      # (and the backend's own ONLYOFFICE_JWT_SECRET stays empty), so an unset secret
+      # makes WOPI operations be rejected on both sides — no auth bypass.
+      - JWT_SECRET=${ONLYOFFICE_JWT_SECRET:-changeme-onlyoffice-jwt-secret}
     ports:
       # Loopback only — backend<->onlyoffice traffic stays on the internal Docker
       # network. If browsers must reach the editor directly, proxy it via nginx/Caddy

--- a/docs/acceptance-tests.html
+++ b/docs/acceptance-tests.html
@@ -86,10 +86,10 @@ td:last-child { width: 40px; text-align: center; }
 <div class="container">
 <header>
   <h1>MonteWeb Akzeptanztest-Suite</h1>
-  <p>Erstellt: 2026-03-02 | 23 Module | 296 User Stories | 1118 Akzeptanzkriterien</p>
+  <p>Erstellt: 2026-03-02 | 24 Module | 312 User Stories | 1182 Akzeptanzkriterien</p>
   <div class="stats">
-    <div class="stat"><strong id="total-done">0</strong> / 1118 Kriterien</div>
-    <div class="stat"><strong id="stories-done">0</strong> / 296 Stories</div>
+    <div class="stat"><strong id="total-done">0</strong> / 1182 Kriterien</div>
+    <div class="stat"><strong id="stories-done">0</strong> / 312 Stories</div>
     <div class="stat"><strong id="percent-done">0</strong>% abgeschlossen</div>
   </div>
   <div class="progress-bar" style="margin-top:0.75rem;height:10px"><div class="progress-fill" id="global-progress" style="width:0%"></div></div>
@@ -127,8 +127,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-001</span> <span class="story-title">Login mit gueltigen Zugangsdaten</span></div>
       </div>
-      <div class="story-als">Als Benutzer (alle Rollen) moechte ich mich mit E-Mail und Passwort anmelden, damit ich auf das Intranet zugreifen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt; System ist erreichbar unter http://localhost.</div>
+      <div class="story-als">Als Benutzer (alle Rollen) moechte ich mich mit E-Mail und Passwort anmelden, damit ich auf das Intranet zugreifen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt; System ist erreichbar unter http://localhost.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -138,17 +138,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Button &quot;Anmelden&quot; klicken</td><td>Weiterleitung zum Dashboard; Begruessung &quot;Willkommen, [Vorname]!&quot; wird angezeigt</td><td><input type="checkbox" data-cb="step_US_001_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_001_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Login funktioniert fuer alle 5 Testkonten (SA, SECADMIN, T, P, S)</label>
-        <label><input type="checkbox" data-cb="crit_US_001_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach erfolgreichem Login wird das Dashboard angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_001_2" data-crit="1" data-module="Auth" onchange="onCheck()"> JWT-Token wird gesetzt (kein Token in sessionStorage sichtbar)</label>
+        <label><input type="checkbox" data-cb="crit_US_001_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Login funktioniert fuer alle 5 Testkonten (SA, SECADMIN, T, P, S)</label>
+        <label><input type="checkbox" data-cb="crit_US_001_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach erfolgreichem Login wird das Dashboard angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_001_2" data-crit="1" data-module="Auth" onchange="onCheck()"> JWT-Token wird gesetzt (kein Token in sessionStorage sichtbar)</label>
       </div>
     </div>
     <div class="story" id="story-US_002" data-story="US-002" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-002</span> <span class="story-title">Login mit falschen Zugangsdaten</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich eine verstaendliche Fehlermeldung erhalten, damit ich weiss, dass meine Zugangsdaten falsch sind.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
+      <div class="story-als">Als Benutzer moechte ich eine verstaendliche Fehlermeldung erhalten, damit ich weiss, dass meine Zugangsdaten falsch sind.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -159,17 +159,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Button &quot;Anmelden&quot; klicken</td><td>Gleiche Fehlermeldung erscheint (kein Hinweis ob E-Mail existiert)</td><td><input type="checkbox" data-cb="step_US_002_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_002_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Fehlermeldung gibt keinen Hinweis, ob die E-Mail existiert</label>
-        <label><input type="checkbox" data-cb="crit_US_002_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer bleibt auf der Login-Seite</label>
-        <label><input type="checkbox" data-cb="crit_US_002_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Formularfelder bleiben befuellt</label>
+        <label><input type="checkbox" data-cb="crit_US_002_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Fehlermeldung gibt keinen Hinweis, ob die E-Mail existiert</label>
+        <label><input type="checkbox" data-cb="crit_US_002_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer bleibt auf der Login-Seite</label>
+        <label><input type="checkbox" data-cb="crit_US_002_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Formularfelder bleiben befuellt</label>
       </div>
     </div>
     <div class="story" id="story-US_003" data-story="US-003" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-003</span> <span class="story-title">Login mit leerem Formular</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich auf Pflichtfelder hingewiesen werden, damit ich das Formular korrekt ausfuellen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
+      <div class="story-als">Als Benutzer moechte ich auf Pflichtfelder hingewiesen werden, damit ich das Formular korrekt ausfuellen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -178,16 +178,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Nur E-Mail eingeben, Passwort leer lassen</td><td>Browser-Validierung verhindert Absenden; Pflichtfeld-Hinweis bei Passwort</td><td><input type="checkbox" data-cb="step_US_003_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_003_0" data-crit="1" data-module="Auth" onchange="onCheck()"> HTML5-Validierung greift bei leeren Pflichtfeldern</label>
-        <label><input type="checkbox" data-cb="crit_US_003_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Kein API-Request wird gesendet</label>
+        <label><input type="checkbox" data-cb="crit_US_003_0" data-crit="1" data-module="Auth" onchange="onCheck()"> HTML5-Validierung greift bei leeren Pflichtfeldern</label>
+        <label><input type="checkbox" data-cb="crit_US_003_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Kein API-Request wird gesendet</label>
       </div>
     </div>
     <div class="story" id="story-US_004" data-story="US-004" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-004</span> <span class="story-title">Registrierung mit gueltigen Daten</span></div>
       </div>
-      <div class="story-als">Als neuer Benutzer moechte ich mich registrieren koennen, damit ich Zugang zum Schulintranet erhalte.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt; Admin-Einstellung &quot;Neue Benutzer muessen freigeschaltet werden&quot; ist aktiv.</div>
+      <div class="story-als">Als neuer Benutzer moechte ich mich registrieren koennen, damit ich Zugang zum Schulintranet erhalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt; Admin-Einstellung &quot;Neue Benutzer muessen freigeschaltet werden&quot; ist aktiv.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -199,18 +199,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Link &quot;Zurueck zur Anmeldung&quot; klicken</td><td>Login-Formular wird wieder angezeigt</td><td><input type="checkbox" data-cb="step_US_004_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_004_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Alle Pflichtfelder (Vorname, Nachname, E-Mail, Passwort) sind mit Stern markiert</label>
-        <label><input type="checkbox" data-cb="crit_US_004_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Telefon ist optional</label>
-        <label><input type="checkbox" data-cb="crit_US_004_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Nutzungsbedingungen-Link oeffnet /terms in neuem Tab</label>
-        <label><input type="checkbox" data-cb="crit_US_004_3" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach Registrierung erscheint Freischaltungs-Hinweis</label>
+        <label><input type="checkbox" data-cb="crit_US_004_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Alle Pflichtfelder (Vorname, Nachname, E-Mail, Passwort) sind mit Stern markiert</label>
+        <label><input type="checkbox" data-cb="crit_US_004_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Telefon ist optional</label>
+        <label><input type="checkbox" data-cb="crit_US_004_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Nutzungsbedingungen-Link oeffnet /terms in neuem Tab</label>
+        <label><input type="checkbox" data-cb="crit_US_004_3" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach Registrierung erscheint Freischaltungs-Hinweis</label>
       </div>
     </div>
     <div class="story" id="story-US_005" data-story="US-005" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-005</span> <span class="story-title">Registrierung ohne Nutzungsbedingungen</span></div>
       </div>
-      <div class="story-als">Als neuer Benutzer moechte ich darauf hingewiesen werden, dass ich die Nutzungsbedingungen akzeptieren muss.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
+      <div class="story-als">Als neuer Benutzer moechte ich darauf hingewiesen werden, dass ich die Nutzungsbedingungen akzeptieren muss.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -219,17 +219,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Button &quot;Registrieren&quot; klicken</td><td>Fehlermeldung: &quot;Sie muessen den Nutzungsbedingungen zustimmen.&quot;</td><td><input type="checkbox" data-cb="step_US_005_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_005_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Registrierung wird clientseitig blockiert</label>
-        <label><input type="checkbox" data-cb="crit_US_005_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Kein API-Request wird gesendet</label>
-        <label><input type="checkbox" data-cb="crit_US_005_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Fehlermeldung wird in rot angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_005_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Registrierung wird clientseitig blockiert</label>
+        <label><input type="checkbox" data-cb="crit_US_005_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Kein API-Request wird gesendet</label>
+        <label><input type="checkbox" data-cb="crit_US_005_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Fehlermeldung wird in rot angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_006" data-story="US-006" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-006</span> <span class="story-title">Registrierung mit bereits vorhandener E-Mail</span></div>
       </div>
-      <div class="story-als">Als neuer Benutzer moechte ich informiert werden, wenn meine E-Mail bereits registriert ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
+      <div class="story-als">Als neuer Benutzer moechte ich informiert werden, wenn meine E-Mail bereits registriert ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -238,16 +238,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Button &quot;Registrieren&quot; klicken</td><td>Fehlermeldung: &quot;Registrierung fehlgeschlagen.&quot; oder spezifische Fehlermeldung vom Backend</td><td><input type="checkbox" data-cb="step_US_006_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_006_0" data-crit="1" data-module="Auth" onchange="onCheck()"> System verhindert Doppelregistrierung</label>
-        <label><input type="checkbox" data-cb="crit_US_006_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer bleibt auf der Registrierungsseite</label>
+        <label><input type="checkbox" data-cb="crit_US_006_0" data-crit="1" data-module="Auth" onchange="onCheck()"> System verhindert Doppelregistrierung</label>
+        <label><input type="checkbox" data-cb="crit_US_006_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer bleibt auf der Registrierungsseite</label>
       </div>
     </div>
     <div class="story" id="story-US_007" data-story="US-007" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-007</span> <span class="story-title">Benutzer-Freischaltung durch Admin</span></div>
       </div>
-      <div class="story-als">Als SUPERADMIN moechte ich neue Benutzer freischalten, damit nur berechtigte Personen Zugang erhalten.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein neuer Benutzer hat sich registriert und wartet auf Freischaltung.</div>
+      <div class="story-als">Als SUPERADMIN moechte ich neue Benutzer freischalten, damit nur berechtigte Personen Zugang erhalten.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein neuer Benutzer hat sich registriert und wartet auf Freischaltung.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -259,17 +259,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Abmelden, als neuer Benutzer einloggen</td><td>Login erfolgreich, Dashboard wird angezeigt</td><td><input type="checkbox" data-cb="step_US_007_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_007_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Nur SA kann Benutzer freischalten</label>
-        <label><input type="checkbox" data-cb="crit_US_007_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Freigeschalteter Benutzer kann sich sofort einloggen</label>
-        <label><input type="checkbox" data-cb="crit_US_007_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Toast-Benachrichtigung bestaetigt Freischaltung</label>
+        <label><input type="checkbox" data-cb="crit_US_007_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Nur SA kann Benutzer freischalten</label>
+        <label><input type="checkbox" data-cb="crit_US_007_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Freigeschalteter Benutzer kann sich sofort einloggen</label>
+        <label><input type="checkbox" data-cb="crit_US_007_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Toast-Benachrichtigung bestaetigt Freischaltung</label>
       </div>
     </div>
     <div class="story" id="story-US_008" data-story="US-008" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-008</span> <span class="story-title">Login eines nicht freigeschalteten Benutzers</span></div>
       </div>
-      <div class="story-als">Als nicht freigeschalteter Benutzer moechte ich einen klaren Hinweis erhalten, damit ich weiss, dass mein Konto noch nicht aktiv ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat sich registriert, wurde aber noch nicht freigeschaltet.</div>
+      <div class="story-als">Als nicht freigeschalteter Benutzer moechte ich einen klaren Hinweis erhalten, damit ich weiss, dass mein Konto noch nicht aktiv ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat sich registriert, wurde aber noch nicht freigeschaltet.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -277,17 +277,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Mit den Zugangsdaten des nicht freigeschalteten Benutzers einloggen</td><td>Fehlermeldung: &quot;Ihr Konto wartet auf Freischaltung durch einen Administrator.&quot;</td><td><input type="checkbox" data-cb="step_US_008_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_008_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer kann sich nicht einloggen</label>
-        <label><input type="checkbox" data-cb="crit_US_008_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Fehlermeldung ist verstaendlich und hilfreich</label>
-        <label><input type="checkbox" data-cb="crit_US_008_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer bleibt auf der Login-Seite</label>
+        <label><input type="checkbox" data-cb="crit_US_008_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer kann sich nicht einloggen</label>
+        <label><input type="checkbox" data-cb="crit_US_008_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Fehlermeldung ist verstaendlich und hilfreich</label>
+        <label><input type="checkbox" data-cb="crit_US_008_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer bleibt auf der Login-Seite</label>
       </div>
     </div>
     <div class="story" id="story-US_009" data-story="US-009" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-009</span> <span class="story-title">Passwort-Zuruecksetzen anfordern</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich mein Passwort zuruecksetzen koennen, damit ich wieder Zugang zu meinem Konto erhalte.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt; E-Mail-Versand ist konfiguriert (`monteweb.email.enabled`).</div>
+      <div class="story-als">Als Benutzer moechte ich mein Passwort zuruecksetzen koennen, damit ich wieder Zugang zu meinem Konto erhalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt; E-Mail-Versand ist konfiguriert (`monteweb.email.enabled`).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -298,17 +298,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Gleichen Vorgang mit nicht existierender E-Mail wiederholen</td><td>Gleiche neutrale Bestaetigung (kein Hinweis ob E-Mail existiert)</td><td><input type="checkbox" data-cb="step_US_009_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_009_0" data-crit="1" data-module="Auth" onchange="onCheck()"> API-Endpunkt POST /api/v1/auth/password-reset wird aufgerufen</label>
-        <label><input type="checkbox" data-cb="crit_US_009_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Antwort verraet nicht, ob die E-Mail existiert</label>
-        <label><input type="checkbox" data-cb="crit_US_009_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Bei konfiguriertem E-Mail-Dienst wird eine Reset-Mail verschickt</label>
+        <label><input type="checkbox" data-cb="crit_US_009_0" data-crit="1" data-module="Auth" onchange="onCheck()"> API-Endpunkt POST /api/v1/auth/password-reset wird aufgerufen</label>
+        <label><input type="checkbox" data-cb="crit_US_009_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Antwort verraet nicht, ob die E-Mail existiert</label>
+        <label><input type="checkbox" data-cb="crit_US_009_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Bei konfiguriertem E-Mail-Dienst wird eine Reset-Mail verschickt</label>
       </div>
     </div>
     <div class="story" id="story-US_010" data-story="US-010" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-010</span> <span class="story-title">Passwort-Zuruecksetzen mit Token</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich ueber einen Reset-Link ein neues Passwort setzen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Gueltigem Reset-Token wurde generiert (API: POST /api/v1/auth/password-reset).</div>
+      <div class="story-als">Als Benutzer moechte ich ueber einen Reset-Link ein neues Passwort setzen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Gueltigem Reset-Token wurde generiert (API: POST /api/v1/auth/password-reset).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -317,17 +317,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>POST /api/v1/auth/password-reset/confirm mit abgelaufenem/ungueltigem Token aufrufen</td><td>Fehler 400/404</td><td><input type="checkbox" data-cb="step_US_010_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_010_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Neues Passwort wird gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_010_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Token ist danach ungueltig (einmalige Verwendung)</label>
-        <label><input type="checkbox" data-cb="crit_US_010_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Abgelaufene Tokens werden per Scheduler bereinigt (taeglich um 03:00)</label>
+        <label><input type="checkbox" data-cb="crit_US_010_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Neues Passwort wird gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_010_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Token ist danach ungueltig (einmalige Verwendung)</label>
+        <label><input type="checkbox" data-cb="crit_US_010_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Abgelaufene Tokens werden per Scheduler bereinigt (taeglich um 03:00)</label>
       </div>
     </div>
     <div class="story" id="story-US_011" data-story="US-011" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-011</span> <span class="story-title">2FA (TOTP) aktivieren</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich Zwei-Faktor-Authentifizierung einrichten, damit mein Konto sicherer ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; 2FA-Modus ist OPTIONAL oder MANDATORY.</div>
+      <div class="story-als">Als Benutzer moechte ich Zwei-Faktor-Authentifizierung einrichten, damit mein Konto sicherer ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; 2FA-Modus ist OPTIONAL oder MANDATORY.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -340,18 +340,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Button &quot;Ich habe die Codes gespeichert&quot; klicken</td><td>Dialog schliesst sich; Status zeigt &quot;2FA aktiv&quot;</td><td><input type="checkbox" data-cb="step_US_011_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_011_0" data-crit="1" data-module="Auth" onchange="onCheck()"> QR-Code ist scannbar und enthaelt korrektes TOTP-URI</label>
-        <label><input type="checkbox" data-cb="crit_US_011_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Recovery-Codes werden einmalig angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_011_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach Aktivierung wird bei jedem Login 2FA abgefragt</label>
-        <label><input type="checkbox" data-cb="crit_US_011_3" data-crit="1" data-module="Auth" onchange="onCheck()"> Status &quot;2FA aktiv&quot; wird im Profil angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_011_0" data-crit="1" data-module="Auth" onchange="onCheck()"> QR-Code ist scannbar und enthaelt korrektes TOTP-URI</label>
+        <label><input type="checkbox" data-cb="crit_US_011_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Recovery-Codes werden einmalig angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_011_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach Aktivierung wird bei jedem Login 2FA abgefragt</label>
+        <label><input type="checkbox" data-cb="crit_US_011_3" data-crit="1" data-module="Auth" onchange="onCheck()"> Status &quot;2FA aktiv&quot; wird im Profil angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_012" data-story="US-012" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-012</span> <span class="story-title">Login mit aktiviertem 2FA</span></div>
       </div>
-      <div class="story-als">Als Benutzer mit aktiviertem 2FA moechte ich nach Eingabe meines Passworts einen TOTP-Code eingeben, damit der Zugang doppelt gesichert ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> 2FA ist fuer den Benutzer aktiviert.</div>
+      <div class="story-als">Als Benutzer mit aktiviertem 2FA moechte ich nach Eingabe meines Passworts einen TOTP-Code eingeben, damit der Zugang doppelt gesichert ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> 2FA ist fuer den Benutzer aktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -361,17 +361,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Button &quot;Bestaetigen&quot; klicken</td><td>Login erfolgreich, Weiterleitung zum Dashboard</td><td><input type="checkbox" data-cb="step_US_012_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_012_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach korrektem Passwort wird 2FA-Schritt angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_012_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Link &quot;Zurueck&quot; fuehrt zum Login-Formular</label>
-        <label><input type="checkbox" data-cb="crit_US_012_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Eingabefeld akzeptiert maximal 8 Zeichen (auch Recovery-Codes)</label>
+        <label><input type="checkbox" data-cb="crit_US_012_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach korrektem Passwort wird 2FA-Schritt angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_012_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Link &quot;Zurueck&quot; fuehrt zum Login-Formular</label>
+        <label><input type="checkbox" data-cb="crit_US_012_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Eingabefeld akzeptiert maximal 8 Zeichen (auch Recovery-Codes)</label>
       </div>
     </div>
     <div class="story" id="story-US_013" data-story="US-013" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-013</span> <span class="story-title">Login mit falschem 2FA-Code</span></div>
       </div>
-      <div class="story-als">Als Benutzer mit aktiviertem 2FA moechte ich bei falschem Code informiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> 2FA ist fuer den Benutzer aktiviert.</div>
+      <div class="story-als">Als Benutzer mit aktiviertem 2FA moechte ich bei falschem Code informiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> 2FA ist fuer den Benutzer aktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -380,17 +380,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Erneut falschen Code eingeben</td><td>Gleiche Fehlermeldung</td><td><input type="checkbox" data-cb="step_US_013_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_013_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Fehlermeldung wird angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_013_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer kann erneut versuchen</label>
-        <label><input type="checkbox" data-cb="crit_US_013_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Kein Login ohne gueltigen Code moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_013_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Fehlermeldung wird angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_013_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer kann erneut versuchen</label>
+        <label><input type="checkbox" data-cb="crit_US_013_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Kein Login ohne gueltigen Code moeglich</label>
       </div>
     </div>
     <div class="story" id="story-US_014" data-story="US-014" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-014</span> <span class="story-title">Login mit Recovery-Code</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich einen Wiederherstellungscode verwenden koennen, damit ich mich einloggen kann, wenn mein Authenticator nicht verfuegbar ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> 2FA ist aktiviert; Benutzer hat Recovery-Codes gespeichert.</div>
+      <div class="story-als">Als Benutzer moechte ich einen Wiederherstellungscode verwenden koennen, damit ich mich einloggen kann, wenn mein Authenticator nicht verfuegbar ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> 2FA ist aktiviert; Benutzer hat Recovery-Codes gespeichert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -400,17 +400,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Abmelden und gleichen Recovery-Code erneut verwenden</td><td>Fehlermeldung: &quot;Ungueltiger Code&quot; (Code wurde verbraucht)</td><td><input type="checkbox" data-cb="step_US_014_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_014_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Recovery-Code funktioniert einmalig</label>
-        <label><input type="checkbox" data-cb="crit_US_014_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Hinweis unter dem Eingabefeld informiert ueber Recovery-Codes</label>
-        <label><input type="checkbox" data-cb="crit_US_014_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Jeder Recovery-Code kann nur einmal verwendet werden</label>
+        <label><input type="checkbox" data-cb="crit_US_014_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Recovery-Code funktioniert einmalig</label>
+        <label><input type="checkbox" data-cb="crit_US_014_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Hinweis unter dem Eingabefeld informiert ueber Recovery-Codes</label>
+        <label><input type="checkbox" data-cb="crit_US_014_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Jeder Recovery-Code kann nur einmal verwendet werden</label>
       </div>
     </div>
     <div class="story" id="story-US_015" data-story="US-015" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-015</span> <span class="story-title">2FA deaktivieren</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich 2FA deaktivieren koennen, damit ich den Login vereinfachen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> 2FA ist aktiviert; 2FA-Modus ist nicht MANDATORY.</div>
+      <div class="story-als">Als Benutzer moechte ich 2FA deaktivieren koennen, damit ich den Login vereinfachen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> 2FA ist aktiviert; 2FA-Modus ist nicht MANDATORY.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -420,17 +420,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Abmelden und erneut einloggen</td><td>Login erfolgt direkt ohne 2FA-Abfrage</td><td><input type="checkbox" data-cb="step_US_015_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_015_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Deaktivierung erfordert Passworteingabe</label>
-        <label><input type="checkbox" data-cb="crit_US_015_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Bei MANDATORY-Modus ist Deaktivierung nicht moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_015_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach Deaktivierung kein 2FA-Schritt beim Login</label>
+        <label><input type="checkbox" data-cb="crit_US_015_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Deaktivierung erfordert Passworteingabe</label>
+        <label><input type="checkbox" data-cb="crit_US_015_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Bei MANDATORY-Modus ist Deaktivierung nicht moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_015_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach Deaktivierung kein 2FA-Schritt beim Login</label>
       </div>
     </div>
     <div class="story" id="story-US_016" data-story="US-016" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-016</span> <span class="story-title">2FA MANDATORY-Modus (Admin-Erzwingung)</span></div>
       </div>
-      <div class="story-als">Als SUPERADMIN moechte ich 2FA fuer alle Benutzer erzwingen, damit die Sicherheit des Systems gewaehrleistet ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt.</div>
+      <div class="story-als">Als SUPERADMIN moechte ich 2FA fuer alle Benutzer erzwingen, damit die Sicherheit des Systems gewaehrleistet ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -441,18 +441,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Code eingeben (aus frisch eingerichtetem Authenticator)</td><td>Login erfolgreich oder Weiterleitung zur Profilseite fuer Einrichtung</td><td><input type="checkbox" data-cb="step_US_016_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_016_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Grace Period von 7 Tagen wird angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_016_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer ohne 2FA sieht Setup-Aufforderung beim Login</label>
-        <label><input type="checkbox" data-cb="crit_US_016_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach Ablauf der Frist ist Login ohne 2FA nicht mehr moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_016_3" data-crit="1" data-module="Auth" onchange="onCheck()"> SA kann den Modus zwischen DISABLED, OPTIONAL und MANDATORY wechseln</label>
+        <label><input type="checkbox" data-cb="crit_US_016_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Grace Period von 7 Tagen wird angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_016_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Benutzer ohne 2FA sieht Setup-Aufforderung beim Login</label>
+        <label><input type="checkbox" data-cb="crit_US_016_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Nach Ablauf der Frist ist Login ohne 2FA nicht mehr moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_016_3" data-crit="1" data-module="Auth" onchange="onCheck()"> SA kann den Modus zwischen DISABLED, OPTIONAL und MANDATORY wechseln</label>
       </div>
     </div>
     <div class="story" id="story-US_017" data-story="US-017" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-017</span> <span class="story-title">SSO/OIDC-Login</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich mich per SSO anmelden, damit ich meine bestehenden Schul-Zugangsdaten nutzen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> OIDC ist konfiguriert (`monteweb.oidc.enabled=true`); OIDC-Provider ist erreichbar.</div>
+      <div class="story-als">Als Benutzer moechte ich mich per SSO anmelden, damit ich meine bestehenden Schul-Zugangsdaten nutzen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> OIDC ist konfiguriert (`monteweb.oidc.enabled=true`); OIDC-Provider ist erreichbar.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -461,17 +461,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Am OIDC-Provider authentifizieren</td><td>Rueckleitung zu MonteWeb; Login erfolgreich, Dashboard wird angezeigt</td><td><input type="checkbox" data-cb="step_US_017_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_017_0" data-crit="1" data-module="Auth" onchange="onCheck()"> SSO-Button wird nur angezeigt wenn OIDC aktiviert ist</label>
-        <label><input type="checkbox" data-cb="crit_US_017_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Bei deaktiviertem OIDC ist kein SSO-Button sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_017_2" data-crit="1" data-module="Auth" onchange="onCheck()"> OIDC-Flow funktioniert mit Authorization Code</label>
+        <label><input type="checkbox" data-cb="crit_US_017_0" data-crit="1" data-module="Auth" onchange="onCheck()"> SSO-Button wird nur angezeigt wenn OIDC aktiviert ist</label>
+        <label><input type="checkbox" data-cb="crit_US_017_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Bei deaktiviertem OIDC ist kein SSO-Button sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_017_2" data-crit="1" data-module="Auth" onchange="onCheck()"> OIDC-Flow funktioniert mit Authorization Code</label>
       </div>
     </div>
     <div class="story" id="story-US_018" data-story="US-018" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-018</span> <span class="story-title">SSO-Button bei deaktiviertem OIDC</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich keinen SSO-Button sehen, wenn SSO nicht konfiguriert ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> OIDC ist nicht konfiguriert (`monteweb.oidc.enabled=false` oder nicht gesetzt).</div>
+      <div class="story-als">Als Benutzer moechte ich keinen SSO-Button sehen, wenn SSO nicht konfiguriert ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> OIDC ist nicht konfiguriert (`monteweb.oidc.enabled=false` oder nicht gesetzt).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -479,16 +479,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Pruefen ob SSO-Button sichtbar ist</td><td>Kein Button &quot;Mit SSO anmelden&quot; sichtbar; keine Trennlinie &quot;oder&quot;</td><td><input type="checkbox" data-cb="step_US_018_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_018_0" data-crit="1" data-module="Auth" onchange="onCheck()"> SSO-Button und Divider sind nicht sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_018_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Login-Formular funktioniert normal</label>
+        <label><input type="checkbox" data-cb="crit_US_018_0" data-crit="1" data-module="Auth" onchange="onCheck()"> SSO-Button und Divider sind nicht sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_018_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Login-Formular funktioniert normal</label>
       </div>
     </div>
     <div class="story" id="story-US_019" data-story="US-019" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-019</span> <span class="story-title">LDAP-Authentifizierung</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich mich mit meinen LDAP/Active-Directory-Zugangsdaten anmelden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> LDAP ist aktiviert (in `tenant_config.modules` JSONB); LDAP-Server ist erreichbar.</div>
+      <div class="story-als">Als Benutzer moechte ich mich mit meinen LDAP/Active-Directory-Zugangsdaten anmelden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> LDAP ist aktiviert (in `tenant_config.modules` JSONB); LDAP-Server ist erreichbar.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -497,18 +497,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Button &quot;Anmelden&quot; klicken</td><td>Login erfolgreich; bei erstem Login wird Benutzer automatisch erstellt</td><td><input type="checkbox" data-cb="step_US_019_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_019_0" data-crit="1" data-module="Auth" onchange="onCheck()"> LDAP-Benutzer wird bei erstem Login automatisch im System angelegt</label>
-        <label><input type="checkbox" data-cb="crit_US_019_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Standard-Rolle wird gemaess LDAP-Konfiguration zugewiesen</label>
-        <label><input type="checkbox" data-cb="crit_US_019_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Lokale Anmeldung bleibt als Fallback aktiv</label>
-        <label><input type="checkbox" data-cb="crit_US_019_3" data-crit="1" data-module="Auth" onchange="onCheck()"> Bei LDAP-Server-Ausfall greift Fallback auf lokale Authentifizierung</label>
+        <label><input type="checkbox" data-cb="crit_US_019_0" data-crit="1" data-module="Auth" onchange="onCheck()"> LDAP-Benutzer wird bei erstem Login automatisch im System angelegt</label>
+        <label><input type="checkbox" data-cb="crit_US_019_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Standard-Rolle wird gemaess LDAP-Konfiguration zugewiesen</label>
+        <label><input type="checkbox" data-cb="crit_US_019_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Lokale Anmeldung bleibt als Fallback aktiv</label>
+        <label><input type="checkbox" data-cb="crit_US_019_3" data-crit="1" data-module="Auth" onchange="onCheck()"> Bei LDAP-Server-Ausfall greift Fallback auf lokale Authentifizierung</label>
       </div>
     </div>
     <div class="story" id="story-US_020" data-story="US-020" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-020</span> <span class="story-title">LDAP-Konfiguration durch Admin</span></div>
       </div>
-      <div class="story-als">Als SUPERADMIN moechte ich LDAP konfigurieren koennen, damit Benutzer sich ueber den Verzeichnisdienst anmelden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt.</div>
+      <div class="story-als">Als SUPERADMIN moechte ich LDAP konfigurieren koennen, damit Benutzer sich ueber den Verzeichnisdienst anmelden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -520,18 +520,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>&quot;Speichern&quot; klicken</td><td>Toast: &quot;LDAP-Einstellungen gespeichert&quot;</td><td><input type="checkbox" data-cb="step_US_020_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_020_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Bind-Passwort wird verschluesselt gespeichert und nicht angezeigt (&quot;Gespeichert (wird nicht angezeigt)&quot;)</label>
-        <label><input type="checkbox" data-cb="crit_US_020_1" data-crit="1" data-module="Auth" onchange="onCheck()"> SSL-Option ist konfigurierbar</label>
-        <label><input type="checkbox" data-cb="crit_US_020_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Verbindungstest gibt klare Rueckmeldung</label>
-        <label><input type="checkbox" data-cb="crit_US_020_3" data-crit="1" data-module="Auth" onchange="onCheck()"> Standard-Rolle kann gewaehlt werden (TEACHER, PARENT, STUDENT)</label>
+        <label><input type="checkbox" data-cb="crit_US_020_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Bind-Passwort wird verschluesselt gespeichert und nicht angezeigt (&quot;Gespeichert (wird nicht angezeigt)&quot;)</label>
+        <label><input type="checkbox" data-cb="crit_US_020_1" data-crit="1" data-module="Auth" onchange="onCheck()"> SSL-Option ist konfigurierbar</label>
+        <label><input type="checkbox" data-cb="crit_US_020_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Verbindungstest gibt klare Rueckmeldung</label>
+        <label><input type="checkbox" data-cb="crit_US_020_3" data-crit="1" data-module="Auth" onchange="onCheck()"> Standard-Rolle kann gewaehlt werden (TEACHER, PARENT, STUDENT)</label>
       </div>
     </div>
     <div class="story" id="story-US_021" data-story="US-021" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-021</span> <span class="story-title">Terms of Service bei Registrierung</span></div>
       </div>
-      <div class="story-als">Als neuer Benutzer moechte ich die Nutzungsbedingungen vor der Registrierung einsehen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Nutzungsbedingungen sind unter `tenant_config.terms_text` konfiguriert.</div>
+      <div class="story-als">Als neuer Benutzer moechte ich die Nutzungsbedingungen vor der Registrierung einsehen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Nutzungsbedingungen sind unter `tenant_config.terms_text` konfiguriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -541,17 +541,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Checkbox anklicken und Formular absenden</td><td>Registrierung wird durchgefuehrt</td><td><input type="checkbox" data-cb="step_US_021_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_021_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Link oeffnet in neuem Tab (`target=&quot;_blank&quot;`)</label>
-        <label><input type="checkbox" data-cb="crit_US_021_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Nutzungsbedingungen-Text kommt aus der Datenbank</label>
-        <label><input type="checkbox" data-cb="crit_US_021_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Checkbox ist Pflicht fuer Registrierung</label>
+        <label><input type="checkbox" data-cb="crit_US_021_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Link oeffnet in neuem Tab (`target=&quot;_blank&quot;`)</label>
+        <label><input type="checkbox" data-cb="crit_US_021_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Nutzungsbedingungen-Text kommt aus der Datenbank</label>
+        <label><input type="checkbox" data-cb="crit_US_021_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Checkbox ist Pflicht fuer Registrierung</label>
       </div>
     </div>
     <div class="story" id="story-US_022" data-story="US-022" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-022</span> <span class="story-title">Logout</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich mich abmelden koennen, damit mein Konto geschuetzt ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich mich abmelden koennen, damit mein Konto geschuetzt ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -560,17 +560,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Direkt /dashboard im Browser aufrufen</td><td>Weiterleitung zur Login-Seite</td><td><input type="checkbox" data-cb="step_US_022_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_022_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Session wird serverseitig invalidiert</label>
-        <label><input type="checkbox" data-cb="crit_US_022_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Kein Zugriff auf geschuetzte Seiten nach Logout</label>
-        <label><input type="checkbox" data-cb="crit_US_022_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Weiterleitung zur Login-Seite</label>
+        <label><input type="checkbox" data-cb="crit_US_022_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Session wird serverseitig invalidiert</label>
+        <label><input type="checkbox" data-cb="crit_US_022_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Kein Zugriff auf geschuetzte Seiten nach Logout</label>
+        <label><input type="checkbox" data-cb="crit_US_022_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Weiterleitung zur Login-Seite</label>
       </div>
     </div>
     <div class="story" id="story-US_023" data-story="US-023" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-023</span> <span class="story-title">Automatische Weiterleitung nach Login</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich nach dem Login zur urspruenglich angefragten Seite weitergeleitet werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
+      <div class="story-als">Als Benutzer moechte ich nach dem Login zur urspruenglich angefragten Seite weitergeleitet werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist nicht eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -578,9 +578,9 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Einloggen</td><td>Nach erfolgreichem Login: Weiterleitung zu /rooms (nicht zum Dashboard)</td><td><input type="checkbox" data-cb="step_US_023_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_023_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Redirect-Parameter wird sicher verarbeitet (kein Open Redirect)</label>
-        <label><input type="checkbox" data-cb="crit_US_023_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Nur relative Pfade werden akzeptiert (kein //, kein ://)</label>
-        <label><input type="checkbox" data-cb="crit_US_023_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Ohne Redirect-Parameter wird zum Dashboard weitergeleitet</label>
+        <label><input type="checkbox" data-cb="crit_US_023_0" data-crit="1" data-module="Auth" onchange="onCheck()"> Redirect-Parameter wird sicher verarbeitet (kein Open Redirect)</label>
+        <label><input type="checkbox" data-cb="crit_US_023_1" data-crit="1" data-module="Auth" onchange="onCheck()"> Nur relative Pfade werden akzeptiert (kein //, kein ://)</label>
+        <label><input type="checkbox" data-cb="crit_US_023_2" data-crit="1" data-module="Auth" onchange="onCheck()"> Ohne Redirect-Parameter wird zum Dashboard weitergeleitet</label>
       </div>
     </div>
   </div>
@@ -598,8 +598,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-024</span> <span class="story-title">Profil anzeigen</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich mein Profil einsehen, damit ich meine Daten ueberpruefen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich mein Profil einsehen, damit ich meine Daten ueberpruefen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -607,17 +607,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Folgende Bereiche pruefen</td><td>Sichtbar: Profilbild/Avatar, Vorname, Nachname, Telefon, Rollen, Erscheinungsbild, Sprache</td><td><input type="checkbox" data-cb="step_US_024_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_024_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Profilseite zeigt alle persoenlichen Informationen</label>
-        <label><input type="checkbox" data-cb="crit_US_024_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Aktive Rolle wird angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_024_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Zugewiesene Rollen werden als Tags dargestellt</label>
+        <label><input type="checkbox" data-cb="crit_US_024_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Profilseite zeigt alle persoenlichen Informationen</label>
+        <label><input type="checkbox" data-cb="crit_US_024_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Aktive Rolle wird angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_024_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Zugewiesene Rollen werden als Tags dargestellt</label>
       </div>
     </div>
     <div class="story" id="story-US_025" data-story="US-025" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-025</span> <span class="story-title">Profil bearbeiten</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich meinen Vornamen, Nachnamen und Telefonnummer aendern.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich meinen Vornamen, Nachnamen und Telefonnummer aendern.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -627,17 +627,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Seite neu laden</td><td>Geaenderter Name bleibt bestehen</td><td><input type="checkbox" data-cb="step_US_025_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_025_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Aenderungen werden sofort wirksam</label>
-        <label><input type="checkbox" data-cb="crit_US_025_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Name im Navigationsheader aktualisiert sich</label>
-        <label><input type="checkbox" data-cb="crit_US_025_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Vorname und Nachname sind Pflichtfelder</label>
+        <label><input type="checkbox" data-cb="crit_US_025_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Aenderungen werden sofort wirksam</label>
+        <label><input type="checkbox" data-cb="crit_US_025_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Name im Navigationsheader aktualisiert sich</label>
+        <label><input type="checkbox" data-cb="crit_US_025_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Vorname und Nachname sind Pflichtfelder</label>
       </div>
     </div>
     <div class="story" id="story-US_026" data-story="US-026" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-026</span> <span class="story-title">Avatar hochladen</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich ein Profilbild hochladen, damit ich visuell erkennbar bin.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich ein Profilbild hochladen, damit ich visuell erkennbar bin.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -647,17 +647,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Bild wird im Avatar-Bereich und im Header angezeigt</td><td>Neues Profilbild ist sichtbar</td><td><input type="checkbox" data-cb="step_US_026_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_026_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Upload akzeptiert gaengige Bildformate (JPEG, PNG)</label>
-        <label><input type="checkbox" data-cb="crit_US_026_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Profilbild wird in Header-Navigation aktualisiert</label>
-        <label><input type="checkbox" data-cb="crit_US_026_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Zu grosse Dateien werden abgelehnt</label>
+        <label><input type="checkbox" data-cb="crit_US_026_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Upload akzeptiert gaengige Bildformate (JPEG, PNG)</label>
+        <label><input type="checkbox" data-cb="crit_US_026_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Profilbild wird in Header-Navigation aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_026_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Zu grosse Dateien werden abgelehnt</label>
       </div>
     </div>
     <div class="story" id="story-US_027" data-story="US-027" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-027</span> <span class="story-title">Avatar entfernen</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich mein Profilbild entfernen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat ein Profilbild hochgeladen.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich mein Profilbild entfernen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat ein Profilbild hochgeladen.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -665,16 +665,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Button &quot;Avatar entfernen&quot; klicken</td><td>Toast: &quot;Avatar entfernt&quot;; Platzhalter-Avatar wird angezeigt</td><td><input type="checkbox" data-cb="step_US_027_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_027_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Profilbild wird aus MinIO geloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_027_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Platzhalter wird an allen Stellen angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_027_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Profilbild wird aus MinIO geloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_027_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Platzhalter wird an allen Stellen angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_028" data-story="US-028" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-028</span> <span class="story-title">Dark Mode umschalten</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich zwischen hellem und dunklem Design wechseln.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich zwischen hellem und dunklem Design wechseln.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -686,18 +686,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Seite neu laden</td><td>Einstellung bleibt bestehen</td><td><input type="checkbox" data-cb="step_US_028_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_028_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Drei Modi: SYSTEM, LIGHT, DARK</label>
-        <label><input type="checkbox" data-cb="crit_US_028_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Einstellung wird in `users.dark_mode` gespeichert</label>
-        <label><input type="checkbox" data-cb="crit_US_028_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> CSS Custom Properties `--mw-*` wechseln korrekt</label>
-        <label><input type="checkbox" data-cb="crit_US_028_3" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Dark Mode ist auch auf der Login-Seite waehlbar</label>
+        <label><input type="checkbox" data-cb="crit_US_028_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Drei Modi: SYSTEM, LIGHT, DARK</label>
+        <label><input type="checkbox" data-cb="crit_US_028_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Einstellung wird in `users.dark_mode` gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_028_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> CSS Custom Properties `--mw-*` wechseln korrekt</label>
+        <label><input type="checkbox" data-cb="crit_US_028_3" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Dark Mode ist auch auf der Login-Seite waehlbar</label>
       </div>
     </div>
     <div class="story" id="story-US_029" data-story="US-029" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-029</span> <span class="story-title">Sprachauswahl</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich die Sprache der Oberflaeche wechseln.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Mehrsprachigkeit ist aktiviert (`available_languages` enthaelt &gt; 1 Sprache).</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich die Sprache der Oberflaeche wechseln.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Mehrsprachigkeit ist aktiviert (`available_languages` enthaelt &gt; 1 Sprache).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -706,18 +706,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Von &quot;English&quot; zurueck auf &quot;Deutsch&quot; wechseln</td><td>UI-Texte wechseln zurueck auf Deutsch</td><td><input type="checkbox" data-cb="step_US_029_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_029_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Sprachwechsler ist nur sichtbar wenn mehr als eine Sprache aktiviert ist</label>
-        <label><input type="checkbox" data-cb="crit_US_029_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Sprachwechsler ist auch auf der Login-Seite verfuegbar</label>
-        <label><input type="checkbox" data-cb="crit_US_029_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Einstellung wird beibehalten nach Neuladen</label>
-        <label><input type="checkbox" data-cb="crit_US_029_3" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Alle UI-Elemente werden korrekt uebersetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_029_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Sprachwechsler ist nur sichtbar wenn mehr als eine Sprache aktiviert ist</label>
+        <label><input type="checkbox" data-cb="crit_US_029_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Sprachwechsler ist auch auf der Login-Seite verfuegbar</label>
+        <label><input type="checkbox" data-cb="crit_US_029_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Einstellung wird beibehalten nach Neuladen</label>
+        <label><input type="checkbox" data-cb="crit_US_029_3" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Alle UI-Elemente werden korrekt uebersetzt</label>
       </div>
     </div>
     <div class="story" id="story-US_030" data-story="US-030" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-030</span> <span class="story-title">Sprachauswahl nicht sichtbar bei nur einer Sprache</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich keinen Sprachwechsler sehen, wenn nur eine Sprache konfiguriert ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> `available_languages` enthaelt nur `{de}`.</div>
+      <div class="story-als">Als Benutzer moechte ich keinen Sprachwechsler sehen, wenn nur eine Sprache konfiguriert ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> `available_languages` enthaelt nur `{de}`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -725,16 +725,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Login-Seite oeffnen (ausgeloggt)</td><td>Kein Sprachwechsler sichtbar</td><td><input type="checkbox" data-cb="step_US_030_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_030_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> LanguageSwitcher-Komponente wird ausgeblendet</label>
-        <label><input type="checkbox" data-cb="crit_US_030_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> System nutzt die Standardsprache</label>
+        <label><input type="checkbox" data-cb="crit_US_030_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> LanguageSwitcher-Komponente wird ausgeblendet</label>
+        <label><input type="checkbox" data-cb="crit_US_030_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> System nutzt die Standardsprache</label>
       </div>
     </div>
     <div class="story" id="story-US_031" data-story="US-031" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-031</span> <span class="story-title">Benutzerdefinierte Profilfelder anzeigen und ausfuellen</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich zusaetzliche Profilfelder ausfuellen, die der Admin definiert hat.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `profilefields` ist aktiviert; Admin hat Profilfelder definiert (z.B. &quot;Geburtstag&quot; als DATE, &quot;Hobby&quot; als TEXT).</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich zusaetzliche Profilfelder ausfuellen, die der Admin definiert hat.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `profilefields` ist aktiviert; Admin hat Profilfelder definiert (z.B. &quot;Geburtstag&quot; als DATE, &quot;Hobby&quot; als TEXT).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -745,22 +745,22 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Seite neu laden</td><td>Gespeicherte Werte bleiben erhalten</td><td><input type="checkbox" data-cb="step_US_031_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_031_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Verschiedene Feldtypen werden korrekt dargestellt (TEXT, DATE, SELECT, BOOLEAN)</label>
-        <label><input type="checkbox" data-cb="crit_US_031_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Pflichtfelder sind als solche gekennzeichnet</label>
-        <label><input type="checkbox" data-cb="crit_US_031_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Werte werden in `profile_field_values` gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_031_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Verschiedene Feldtypen werden korrekt dargestellt (TEXT, DATE, SELECT, BOOLEAN)</label>
+        <label><input type="checkbox" data-cb="crit_US_031_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Pflichtfelder sind als solche gekennzeichnet</label>
+        <label><input type="checkbox" data-cb="crit_US_031_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Werte werden in `profile_field_values` gespeichert</label>
       </div>
     </div>
     <div class="story" id="story-US_032" data-story="US-032" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-032</span> <span class="story-title">Profilfelder als Admin verwalten</span></div>
       </div>
-      <div class="story-als">Als SUPERADMIN moechte ich benutzerdefinierte Profilfelder erstellen und verwalten.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt; Modul `profilefields` ist aktiviert.</div>
+      <div class="story-als">Als SUPERADMIN moechte ich benutzerdefinierte Profilfelder erstellen und verwalten.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt; Modul `profilefields` ist aktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Verwaltung &gt; &quot;Profilfelder&quot; klicken</td><td>Seite &quot;Profilfelder verwalten&quot; mit Untertitel &quot;Benutzerdefinierte Felder fuer Benutzerprofile erstellen und verwalten&quot;</td><td><input type="checkbox" data-cb="step_US_032_1" onchange="onCheck()"></td></tr>
-          <tr><td>2</td><td>Button &quot;Neues Feld&quot; klicken</td><td>Dialog oeffnet sich mit Feldern: Feldschluessel, Bezeichnung (DE), Bezeichnung (EN), Feldtyp, Pflichtfeld, Position, Aktiv</td><td><input type="checkbox" data-cb="step_US_032_2" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Button &quot;Neues Feld&quot; klicken</td><td>Dialog oeffnet sich mit Feldern: Feldschluessel, Bezeichnung (DE), Bezeichnung (EN), Feldtyp, Pflichtfeld, Position (Aktiv-Toggle erscheint erst beim Bearbeiten; neue Felder sind serverseitig immer aktiv)</td><td><input type="checkbox" data-cb="step_US_032_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Feldschluessel &quot;hobby&quot;, Bezeichnung DE &quot;Hobby&quot;, Typ &quot;Text&quot; eingeben</td><td>Felder werden befuellt</td><td><input type="checkbox" data-cb="step_US_032_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Speichern</td><td>Toast: &quot;Profilfeld erstellt&quot;; Feld erscheint in der Liste</td><td><input type="checkbox" data-cb="step_US_032_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Feld bearbeiten: Typ auf &quot;Auswahl&quot; aendern, Optionen &quot;Lesen, Sport, Musik&quot; eingeben</td><td>Optionen-Feld wird sichtbar</td><td><input type="checkbox" data-cb="step_US_032_5" onchange="onCheck()"></td></tr>
@@ -768,19 +768,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Feld loeschen mit Bestaetigung</td><td>Toast: &quot;Profilfeld geloescht&quot;; Warnung: &quot;Alle Benutzerdaten fuer dieses Feld werden ebenfalls geloescht.&quot;</td><td><input type="checkbox" data-cb="step_US_032_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_032_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Feldschluessel akzeptiert nur Kleinbuchstaben, Zahlen und Unterstriche</label>
-        <label><input type="checkbox" data-cb="crit_US_032_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Vier Feldtypen: Text, Datum, Auswahl, Ja/Nein</label>
-        <label><input type="checkbox" data-cb="crit_US_032_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Optionen nur bei Typ &quot;Auswahl&quot; sichtbar (kommagetrennt)</label>
-        <label><input type="checkbox" data-cb="crit_US_032_3" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Position bestimmt Reihenfolge der Anzeige</label>
-        <label><input type="checkbox" data-cb="crit_US_032_4" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Loeschung entfernt auch alle zugehoerigen Werte</label>
+        <label><input type="checkbox" data-cb="crit_US_032_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Feldschluessel akzeptiert nur Kleinbuchstaben, Zahlen und Unterstriche</label>
+        <label><input type="checkbox" data-cb="crit_US_032_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Vier Feldtypen: Text, Datum, Auswahl, Ja/Nein</label>
+        <label><input type="checkbox" data-cb="crit_US_032_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Optionen nur bei Typ &quot;Auswahl&quot; sichtbar (kommagetrennt)</label>
+        <label><input type="checkbox" data-cb="crit_US_032_3" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Position bestimmt Reihenfolge der Anzeige</label>
+        <label><input type="checkbox" data-cb="crit_US_032_4" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Loeschung entfernt auch alle zugehoerigen Werte</label>
       </div>
     </div>
     <div class="story" id="story-US_033" data-story="US-033" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-033</span> <span class="story-title">Rollenwechsel im Profil</span></div>
       </div>
-      <div class="story-als">Als Benutzer mit mehreren Rollen moechte ich zwischen meinen Rollen wechseln koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat mehrere zugewiesene Rollen (z.B. TEACHER und PARENT).</div>
+      <div class="story-als">Als Benutzer mit mehreren Rollen moechte ich zwischen meinen Rollen wechseln koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat mehrere zugewiesene Rollen (z.B. TEACHER und PARENT).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -789,17 +789,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Navigation pruefen</td><td>Menuepunkte passen sich der neuen Rolle an (z.B. Admin-Menue nur fuer SA)</td><td><input type="checkbox" data-cb="step_US_033_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_033_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Rollenwechsel aktualisiert die Sichtbarkeit von Modulen und Inhalten</label>
-        <label><input type="checkbox" data-cb="crit_US_033_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Aktive Rolle wird visuell hervorgehoben</label>
-        <label><input type="checkbox" data-cb="crit_US_033_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Rollenwechsel erfordert keinen Neulogin</label>
+        <label><input type="checkbox" data-cb="crit_US_033_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Rollenwechsel aktualisiert die Sichtbarkeit von Modulen und Inhalten</label>
+        <label><input type="checkbox" data-cb="crit_US_033_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Aktive Rolle wird visuell hervorgehoben</label>
+        <label><input type="checkbox" data-cb="crit_US_033_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Rollenwechsel erfordert keinen Neulogin</label>
       </div>
     </div>
     <div class="story" id="story-US_034" data-story="US-034" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-034</span> <span class="story-title">Push-Benachrichtigungen aktivieren</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich Push-Benachrichtigungen aktivieren, damit ich ueber Neuigkeiten informiert werde.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Push ist konfiguriert (`monteweb.push.enabled`); Browser unterstuetzt Push.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich Push-Benachrichtigungen aktivieren, damit ich ueber Neuigkeiten informiert werde.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Push ist konfiguriert (`monteweb.push.enabled`); Browser unterstuetzt Push.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -808,16 +808,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Toggle ausschalten</td><td>Push-Benachrichtigungen werden deaktiviert</td><td><input type="checkbox" data-cb="step_US_034_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_034_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Bei blockierter Browser-Berechtigung: Hinweis &quot;Push-Benachrichtigungen wurden im Browser blockiert. Bitte erlauben Sie diese in den Browser-Einstellungen.&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_034_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Push funktioniert mit VAPID-Schluessel</label>
+        <label><input type="checkbox" data-cb="crit_US_034_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Bei blockierter Browser-Berechtigung: Hinweis &quot;Push-Benachrichtigungen wurden im Browser blockiert. Bitte erlauben Sie diese in den Browser-Einstellungen.&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_034_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Push funktioniert mit VAPID-Schluessel</label>
       </div>
     </div>
     <div class="story" id="story-US_035" data-story="US-035" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-035</span> <span class="story-title">Stummgeschaltete Chats verwalten</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich meine stummgeschalteten Chats sehen und die Stummschaltung aufheben.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat mindestens einen Chat stummgeschaltet.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich meine stummgeschalteten Chats sehen und die Stummschaltung aufheben.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat mindestens einen Chat stummgeschaltet.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -826,17 +826,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Wenn keine Chats stummgeschaltet sind</td><td>Hinweis: &quot;Keine stummgeschalteten Chats&quot;</td><td><input type="checkbox" data-cb="step_US_035_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_035_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Alle stummgeschalteten Chats werden aufgelistet</label>
-        <label><input type="checkbox" data-cb="crit_US_035_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Stummschaltung kann einzeln aufgehoben werden</label>
-        <label><input type="checkbox" data-cb="crit_US_035_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Aktualisierung erfolgt sofort</label>
+        <label><input type="checkbox" data-cb="crit_US_035_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Alle stummgeschalteten Chats werden aufgelistet</label>
+        <label><input type="checkbox" data-cb="crit_US_035_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Stummschaltung kann einzeln aufgehoben werden</label>
+        <label><input type="checkbox" data-cb="crit_US_035_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Aktualisierung erfolgt sofort</label>
       </div>
     </div>
     <div class="story" id="story-US_036" data-story="US-036" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-036</span> <span class="story-title">E-Mail-Zusammenfassung konfigurieren</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich die Haeufigkeit meiner E-Mail-Zusammenfassung einstellen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; E-Mail ist konfiguriert.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich die Haeufigkeit meiner E-Mail-Zusammenfassung einstellen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; E-Mail ist konfiguriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -845,9 +845,9 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>&quot;Woechentlich&quot; auswaehlen</td><td>Toast: &quot;E-Mail-Einstellung gespeichert&quot;</td><td><input type="checkbox" data-cb="step_US_036_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_036_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Fuenf Frequenz-Optionen verfuegbar</label>
-        <label><input type="checkbox" data-cb="crit_US_036_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Einstellung wird persistiert</label>
-        <label><input type="checkbox" data-cb="crit_US_036_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Hinweis erklaert den Zweck der Zusammenfassung</label>
+        <label><input type="checkbox" data-cb="crit_US_036_0" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Fuenf Frequenz-Optionen verfuegbar</label>
+        <label><input type="checkbox" data-cb="crit_US_036_1" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Einstellung wird persistiert</label>
+        <label><input type="checkbox" data-cb="crit_US_036_2" data-crit="1" data-module="Profil___Einstellungen" onchange="onCheck()"> Hinweis erklaert den Zweck der Zusammenfassung</label>
       </div>
     </div>
   </div>
@@ -865,8 +865,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-037</span> <span class="story-title">Dashboard nach Login</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich auf dem Dashboard eine Uebersicht ueber relevante Inhalte sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich auf dem Dashboard eine Uebersicht ueber relevante Inhalte sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -875,17 +875,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Feed-Bereich pruefen</td><td>Beitraege aus Raeumen des Benutzers werden angezeigt</td><td><input type="checkbox" data-cb="step_US_037_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_037_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Begruessung zeigt den Vornamen des Benutzers</label>
-        <label><input type="checkbox" data-cb="crit_US_037_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Feed zeigt nur Inhalte aus Raeumen, in denen der Benutzer Mitglied ist</label>
-        <label><input type="checkbox" data-cb="crit_US_037_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Banner werden kontextabhaengig angezeigt (Putz-Banner nur fuer betroffene Eltern)</label>
+        <label><input type="checkbox" data-cb="crit_US_037_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Begruessung zeigt den Vornamen des Benutzers</label>
+        <label><input type="checkbox" data-cb="crit_US_037_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Feed zeigt nur Inhalte aus Raeumen, in denen der Benutzer Mitglied ist</label>
+        <label><input type="checkbox" data-cb="crit_US_037_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Banner werden kontextabhaengig angezeigt (Putz-Banner nur fuer betroffene Eltern)</label>
       </div>
     </div>
     <div class="story" id="story-US_038" data-story="US-038" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-038</span> <span class="story-title">Dashboard-Widget offene Formulare</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich offene Formulare direkt auf dem Dashboard sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `forms` ist aktiviert; es gibt veroeffentlichte Formulare fuer den Benutzer.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich offene Formulare direkt auf dem Dashboard sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `forms` ist aktiviert; es gibt veroeffentlichte Formulare fuer den Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -894,17 +894,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Alle Formulare beantwortet</td><td>Widget zeigt keine Eintraege oder wird ausgeblendet</td><td><input type="checkbox" data-cb="step_US_038_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_038_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Widget wird nur angezeigt wenn Modul `forms` aktiviert ist</label>
-        <label><input type="checkbox" data-cb="crit_US_038_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Nur offene, noch nicht beantwortete Formulare werden angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_038_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Link &quot;Alle anzeigen&quot; fuehrt zur Formulare-Uebersicht</label>
+        <label><input type="checkbox" data-cb="crit_US_038_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Widget wird nur angezeigt wenn Modul `forms` aktiviert ist</label>
+        <label><input type="checkbox" data-cb="crit_US_038_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Nur offene, noch nicht beantwortete Formulare werden angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_038_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Link &quot;Alle anzeigen&quot; fuehrt zur Formulare-Uebersicht</label>
       </div>
     </div>
     <div class="story" id="story-US_039" data-story="US-039" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-039</span> <span class="story-title">PostComposer auf Dashboard (nur T/SA)</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft oder SUPERADMIN moechte ich direkt auf dem Dashboard Beitraege erstellen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als T oder SA eingeloggt.</div>
+      <div class="story-als">Als Lehrkraft oder SUPERADMIN moechte ich direkt auf dem Dashboard Beitraege erstellen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als T oder SA eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -913,38 +913,38 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Dashboard oeffnen als S</td><td>PostComposer ist NICHT sichtbar</td><td><input type="checkbox" data-cb="step_US_039_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_039_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> PostComposer nur fuer TEACHER und SUPERADMIN sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_039_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> PARENT und STUDENT sehen keinen PostComposer auf dem Dashboard</label>
+        <label><input type="checkbox" data-cb="crit_US_039_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> PostComposer nur fuer TEACHER und SUPERADMIN sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_039_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> PARENT und STUDENT sehen keinen PostComposer auf dem Dashboard</label>
       </div>
     </div>
     <div class="story" id="story-US_040" data-story="US-040" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-040</span> <span class="story-title">Hauptnavigation -- Menuepunkte nach Rolle</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich nur die fuer meine Rolle relevanten Navigationspunkte sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich nur die fuer meine Rolle relevanten Navigationspunkte sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
-          <tr><td>1</td><td>Als SA einloggen</td><td>Navigation enthaelt: Dashboard, Raeume, Familie, Nachrichten, Kalender, Formulare, Entdecken, Verwaltung, Profil, Abmelden (+ optionale Module)</td><td><input type="checkbox" data-cb="step_US_040_1" onchange="onCheck()"></td></tr>
-          <tr><td>2</td><td>Als T einloggen</td><td>Navigation enthaelt: Dashboard, Raeume, Nachrichten, Kalender, Entdecken, Profil, Abmelden (kein &quot;Verwaltung&quot;)</td><td><input type="checkbox" data-cb="step_US_040_2" onchange="onCheck()"></td></tr>
+          <tr><td>1</td><td>Als SA einloggen</td><td>Navigation enthaelt: Dashboard, Raeume, Familie, Nachrichten, Kalender, Formulare, Verzeichnis, Verwaltung, Profil, Abmelden (+ optionale Module)</td><td><input type="checkbox" data-cb="step_US_040_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Als T einloggen</td><td>Navigation enthaelt: Dashboard, Raeume, Nachrichten, Kalender, Verzeichnis, Profil, Abmelden (kein &quot;Verwaltung&quot;)</td><td><input type="checkbox" data-cb="step_US_040_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Als P einloggen</td><td>Navigation enthaelt: Dashboard, Raeume, Familie, Nachrichten, Kalender, Profil, Abmelden</td><td><input type="checkbox" data-cb="step_US_040_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Als S einloggen</td><td>Navigation enthaelt: Dashboard, Raeume, Nachrichten, Kalender, Profil, Abmelden (kein &quot;Familie&quot;)</td><td><input type="checkbox" data-cb="step_US_040_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Als SECADMIN einloggen</td><td>Navigation enthaelt zusaetzlich &quot;Bereichsverwaltung&quot;</td><td><input type="checkbox" data-cb="step_US_040_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_040_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> &quot;Verwaltung&quot; nur fuer SA sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_040_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> &quot;Bereichsverwaltung&quot; nur fuer SECADMIN sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_040_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> &quot;Familie&quot; nicht fuer STUDENT sichtbar (da nicht selbst erstellbar)</label>
-        <label><input type="checkbox" data-cb="crit_US_040_3" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Optionale Module (Jobboerse, Putz-Orga, Fundgrube etc.) nur sichtbar wenn aktiviert</label>
+        <label><input type="checkbox" data-cb="crit_US_040_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> &quot;Verwaltung&quot; nur fuer SA sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_040_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> &quot;Bereichsverwaltung&quot; nur fuer SECADMIN sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_040_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> &quot;Familie&quot; nicht fuer STUDENT sichtbar (da nicht selbst erstellbar)</label>
+        <label><input type="checkbox" data-cb="crit_US_040_3" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Optionale Module (Jobboerse, Putz-Orga, Fundgrube etc.) nur sichtbar wenn aktiviert</label>
       </div>
     </div>
     <div class="story" id="story-US_041" data-story="US-041" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-041</span> <span class="story-title">Navigation -- optionale Module</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich nur Navigationspunkte fuer aktivierte Module sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich nur Navigationspunkte fuer aktivierte Module sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -954,17 +954,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Modul &quot;Jobboerse&quot; wieder aktivieren</td><td>Menuepunkt &quot;Jobboerse&quot; erscheint wieder</td><td><input type="checkbox" data-cb="step_US_041_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_041_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Deaktivierte Module verschwinden aus der Navigation fuer ALLE Rollen</label>
-        <label><input type="checkbox" data-cb="crit_US_041_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Backend-Endpunkte deaktivierter Module geben 404 zurueck</label>
-        <label><input type="checkbox" data-cb="crit_US_041_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Module: messaging, files, jobboard, cleaning, calendar, forms, fotobox, fundgrube, bookmarks, tasks, wiki, profilefields</label>
+        <label><input type="checkbox" data-cb="crit_US_041_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Deaktivierte Module verschwinden aus der Navigation fuer ALLE Rollen</label>
+        <label><input type="checkbox" data-cb="crit_US_041_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Backend-Endpunkte deaktivierter Module geben 404 zurueck</label>
+        <label><input type="checkbox" data-cb="crit_US_041_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Module: messaging, files, jobboard, cleaning, calendar, forms, fotobox, fundgrube, bookmarks, tasks, wiki, profilefields</label>
       </div>
     </div>
     <div class="story" id="story-US_042" data-story="US-042" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-042</span> <span class="story-title">Navigation -- Benachrichtigungsglocke</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich ungelesene Benachrichtigungen in der Navigation sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; es gibt ungelesene Benachrichtigungen.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich ungelesene Benachrichtigungen in der Navigation sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; es gibt ungelesene Benachrichtigungen.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -973,18 +973,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>&quot;Alle gelesen&quot; klicken</td><td>Zaehler verschwindet; alle Benachrichtigungen als gelesen markiert</td><td><input type="checkbox" data-cb="step_US_042_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_042_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Badge zeigt korrekte Anzahl ungelesener Benachrichtigungen</label>
-        <label><input type="checkbox" data-cb="crit_US_042_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Benachrichtigungen zeigen Zeitangaben (Gerade eben, vor Xm, vor Xh, vor Xd)</label>
-        <label><input type="checkbox" data-cb="crit_US_042_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> &quot;Alle gelesen&quot; markiert alle als gelesen</label>
-        <label><input type="checkbox" data-cb="crit_US_042_3" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Bei keinen Benachrichtigungen: &quot;Keine Benachrichtigungen&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_042_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Badge zeigt korrekte Anzahl ungelesener Benachrichtigungen</label>
+        <label><input type="checkbox" data-cb="crit_US_042_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Benachrichtigungen zeigen Zeitangaben (Gerade eben, vor Xm, vor Xh, vor Xd)</label>
+        <label><input type="checkbox" data-cb="crit_US_042_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> &quot;Alle gelesen&quot; markiert alle als gelesen</label>
+        <label><input type="checkbox" data-cb="crit_US_042_3" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Bei keinen Benachrichtigungen: &quot;Keine Benachrichtigungen&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_043" data-story="US-043" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-043</span> <span class="story-title">404-Seite</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich bei einer ungueltige URL eine hilfreiche Fehlerseite sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als Benutzer moechte ich bei einer ungueltige URL eine hilfreiche Fehlerseite sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -992,17 +992,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Button &quot;Zurueck zum Dashboard&quot; klicken</td><td>Weiterleitung zum Dashboard</td><td><input type="checkbox" data-cb="step_US_043_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_043_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> 404-Seite zeigt klare Fehlermeldung auf Deutsch</label>
-        <label><input type="checkbox" data-cb="crit_US_043_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Link zurueck zum Dashboard funktioniert</label>
-        <label><input type="checkbox" data-cb="crit_US_043_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Catch-All Route im Router faengt alle ungultigen Pfade ab</label>
+        <label><input type="checkbox" data-cb="crit_US_043_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> 404-Seite zeigt klare Fehlermeldung auf Deutsch</label>
+        <label><input type="checkbox" data-cb="crit_US_043_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Link zurueck zum Dashboard funktioniert</label>
+        <label><input type="checkbox" data-cb="crit_US_043_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Catch-All Route im Router faengt alle ungultigen Pfade ab</label>
       </div>
     </div>
     <div class="story" id="story-US_044" data-story="US-044" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-044</span> <span class="story-title">Wartungsmodus</span></div>
       </div>
-      <div class="story-als">Als SUPERADMIN moechte ich das System in den Wartungsmodus versetzen koennen, damit ich Wartungsarbeiten durchfuehren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt.</div>
+      <div class="story-als">Als SUPERADMIN moechte ich das System in den Wartungsmodus versetzen koennen, damit ich Wartungsarbeiten durchfuehren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1015,18 +1015,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Wartungsmodus deaktivieren</td><td>System ist wieder fuer alle zugaenglich</td><td><input type="checkbox" data-cb="step_US_044_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_044_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Nur SA kann auf das System zugreifen waehrend Wartungsmodus aktiv</label>
-        <label><input type="checkbox" data-cb="crit_US_044_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Alle anderen Rollen sehen Wartungsseite</label>
-        <label><input type="checkbox" data-cb="crit_US_044_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Wartungsnachricht wird angezeigt (Fallback: &quot;Das System wird gerade gewartet. Bitte versuchen Sie es spaeter erneut.&quot;)</label>
-        <label><input type="checkbox" data-cb="crit_US_044_3" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Link &quot;Als Admin anmelden&quot; ist auf Wartungsseite verfuegbar</label>
+        <label><input type="checkbox" data-cb="crit_US_044_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Nur SA kann auf das System zugreifen waehrend Wartungsmodus aktiv</label>
+        <label><input type="checkbox" data-cb="crit_US_044_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Alle anderen Rollen sehen Wartungsseite</label>
+        <label><input type="checkbox" data-cb="crit_US_044_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Wartungsnachricht wird angezeigt (Fallback: &quot;Das System wird gerade gewartet. Bitte versuchen Sie es spaeter erneut.&quot;)</label>
+        <label><input type="checkbox" data-cb="crit_US_044_3" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Link &quot;Als Admin anmelden&quot; ist auf Wartungsseite verfuegbar</label>
       </div>
     </div>
     <div class="story" id="story-US_045" data-story="US-045" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-045</span> <span class="story-title">Globale Suche (Ctrl+K)</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich ueber eine globale Suche schnell Inhalte finden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Solr ist konfiguriert (optional, Fallback auf DB-Suche).</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich ueber eine globale Suche schnell Inhalte finden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Solr ist konfiguriert (optional, Fallback auf DB-Suche).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1035,18 +1035,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Auf ein Ergebnis klicken</td><td>Navigation zum entsprechenden Inhalt</td><td><input type="checkbox" data-cb="step_US_045_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_045_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Suche durchsucht alle relevanten Dokumenttypen</label>
-        <label><input type="checkbox" data-cb="crit_US_045_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Ergebnisse sind nach Relevanz sortiert</label>
-        <label><input type="checkbox" data-cb="crit_US_045_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Bei deaktiviertem Solr greift Fallback auf DB-Suche</label>
-        <label><input type="checkbox" data-cb="crit_US_045_3" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Suchfeld ist im Dialog fokussiert</label>
+        <label><input type="checkbox" data-cb="crit_US_045_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Suche durchsucht alle relevanten Dokumenttypen</label>
+        <label><input type="checkbox" data-cb="crit_US_045_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Ergebnisse sind nach Relevanz sortiert</label>
+        <label><input type="checkbox" data-cb="crit_US_045_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Bei deaktiviertem Solr greift Fallback auf DB-Suche</label>
+        <label><input type="checkbox" data-cb="crit_US_045_3" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Suchfeld ist im Dialog fokussiert</label>
       </div>
     </div>
     <div class="story" id="story-US_046" data-story="US-046" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-046</span> <span class="story-title">PWA-Installation</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich MonteWeb als App auf meinem Geraet installieren koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Browser unterstuetzt PWA; Benutzer hat die Installation nicht innerhalb der letzten 7 Tage abgelehnt.</div>
+      <div class="story-als">Als Benutzer moechte ich MonteWeb als App auf meinem Geraet installieren koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Browser unterstuetzt PWA; Benutzer hat die Installation nicht innerhalb der letzten 7 Tage abgelehnt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1055,9 +1055,9 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Install-Banner schliessen</td><td>Banner verschwindet; wird fuer 7 Tage nicht mehr angezeigt</td><td><input type="checkbox" data-cb="step_US_046_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_046_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Install-Banner hat 7-Tage Dismiss-Delay</label>
-        <label><input type="checkbox" data-cb="crit_US_046_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Service Worker mit NetworkFirst-Caching fuer API-Calls</label>
-        <label><input type="checkbox" data-cb="crit_US_046_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Icons in verschiedenen Groessen vorhanden</label>
+        <label><input type="checkbox" data-cb="crit_US_046_0" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Install-Banner hat 7-Tage Dismiss-Delay</label>
+        <label><input type="checkbox" data-cb="crit_US_046_1" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Service Worker mit NetworkFirst-Caching fuer API-Calls</label>
+        <label><input type="checkbox" data-cb="crit_US_046_2" data-crit="1" data-module="Dashboard___Navigation" onchange="onCheck()"> Icons in verschiedenen Groessen vorhanden</label>
       </div>
     </div>
   </div>
@@ -1075,8 +1075,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-047</span> <span class="story-title">Meine Raeume anzeigen</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich eine Uebersicht meiner Raeume sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt und Mitglied in mindestens einem Raum.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich eine Uebersicht meiner Raeume sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt und Mitglied in mindestens einem Raum.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1085,17 +1085,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Raum-Karten pruefen</td><td>Jede Karte zeigt: Name, Typ-Tag (Klasse/Gruppe/Projekt/...), Mitgliederanzahl</td><td><input type="checkbox" data-cb="step_US_047_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_047_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur eigene Raeume werden angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_047_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Raumtypen werden als farbige Tags dargestellt (Klasse, Gruppe, Projekt, Interessengruppe, Sonstige)</label>
-        <label><input type="checkbox" data-cb="crit_US_047_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei keinen Raeumen: &quot;Sie sind noch keinem Raum zugeordnet.&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_047_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur eigene Raeume werden angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_047_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Raumtypen werden als farbige Tags dargestellt (Klasse, Gruppe, Projekt, Interessengruppe, Sonstige)</label>
+        <label><input type="checkbox" data-cb="crit_US_047_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei keinen Raeumen: &quot;Sie sind noch keinem Raum zugeordnet.&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_048" data-story="US-048" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-048</span> <span class="story-title">Raeume entdecken</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich verfuegbare Raeume durchsuchen und ihnen beitreten.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; es gibt oeffentliche Raeume.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich verfuegbare Raeume durchsuchen und ihnen beitreten.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; es gibt oeffentliche Raeume.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1106,18 +1106,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Ergebnisliste pruefen</td><td>Raeume nach Schulbereich gruppiert, mit Mitgliederanzahl und Beitrittsoption</td><td><input type="checkbox" data-cb="step_US_048_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_048_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Suchfeld: &quot;Nach Raeumen suchen...&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_048_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Filter kombinierbar (Bereich + Typ + Suchtext)</label>
-        <label><input type="checkbox" data-cb="crit_US_048_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Raeume zeigen oeffentliche Beschreibung</label>
-        <label><input type="checkbox" data-cb="crit_US_048_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bereits beigetretene Raeume sind markiert</label>
+        <label><input type="checkbox" data-cb="crit_US_048_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Suchfeld: &quot;Nach Raeumen suchen...&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_048_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Filter kombinierbar (Bereich + Typ + Suchtext)</label>
+        <label><input type="checkbox" data-cb="crit_US_048_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Raeume zeigen oeffentliche Beschreibung</label>
+        <label><input type="checkbox" data-cb="crit_US_048_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bereits beigetretene Raeume sind markiert</label>
       </div>
     </div>
     <div class="story" id="story-US_049" data-story="US-049" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-049</span> <span class="story-title">Raum erstellen (T/SA)</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft oder SUPERADMIN moechte ich einen neuen Raum erstellen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als T oder SA eingeloggt.</div>
+      <div class="story-als">Als Lehrkraft oder SUPERADMIN moechte ich einen neuen Raum erstellen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als T oder SA eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1128,18 +1128,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Button &quot;Erstellen&quot; klicken</td><td>Toast: &quot;Raum erstellt&quot;; Weiterleitung zum neuen Raum</td><td><input type="checkbox" data-cb="step_US_049_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_049_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Name ist Pflichtfeld</label>
-        <label><input type="checkbox" data-cb="crit_US_049_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Beschreibung und Tags sind optional</label>
-        <label><input type="checkbox" data-cb="crit_US_049_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Ersteller wird automatisch LEADER des Raumes</label>
-        <label><input type="checkbox" data-cb="crit_US_049_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei KLASSE-Typ wird automatisch ein Standard-Ordner im Files-Modul erstellt</label>
+        <label><input type="checkbox" data-cb="crit_US_049_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Name ist Pflichtfeld</label>
+        <label><input type="checkbox" data-cb="crit_US_049_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Beschreibung und Tags sind optional</label>
+        <label><input type="checkbox" data-cb="crit_US_049_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Ersteller wird automatisch LEADER des Raumes</label>
+        <label><input type="checkbox" data-cb="crit_US_049_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei KLASSE-Typ wird automatisch ein Standard-Ordner im Files-Modul erstellt</label>
       </div>
     </div>
     <div class="story" id="story-US_050" data-story="US-050" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-050</span> <span class="story-title">Raum erstellen -- nicht erlaubt fuer P/S</span></div>
       </div>
-      <div class="story-als">Als Parent oder Student moechte ich keinen Raum erstellen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als P oder S eingeloggt.</div>
+      <div class="story-als">Als Parent oder Student moechte ich keinen Raum erstellen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als P oder S eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1147,16 +1147,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>API-Aufruf POST /api/v1/rooms als P</td><td>HTTP 403 Forbidden</td><td><input type="checkbox" data-cb="step_US_050_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_050_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Kein &quot;Raum erstellen&quot;-Button fuer PARENT und STUDENT</label>
-        <label><input type="checkbox" data-cb="crit_US_050_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Backend blockiert unbefugte Erstellung</label>
+        <label><input type="checkbox" data-cb="crit_US_050_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Kein &quot;Raum erstellen&quot;-Button fuer PARENT und STUDENT</label>
+        <label><input type="checkbox" data-cb="crit_US_050_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Backend blockiert unbefugte Erstellung</label>
       </div>
     </div>
     <div class="story" id="story-US_051" data-story="US-051" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-051</span> <span class="story-title">Raum beitreten (offene Raeume)</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich einem offenen Raum beitreten.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt einen Raum mit Join-Policy &quot;Offen&quot; (OPEN).</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich einem offenen Raum beitreten.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt einen Raum mit Join-Policy &quot;Offen&quot; (OPEN).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1165,17 +1165,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Erneut &quot;Beitreten&quot; versuchen</td><td>Button nicht mehr sichtbar (bereits Mitglied)</td><td><input type="checkbox" data-cb="step_US_051_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_051_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Beitritt zu offenen Raeumen ist sofort wirksam</label>
-        <label><input type="checkbox" data-cb="crit_US_051_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Benutzer wird als MEMBER hinzugefuegt</label>
-        <label><input type="checkbox" data-cb="crit_US_051_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Raum erscheint sofort in &quot;Meine Raeume&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_051_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Beitritt zu offenen Raeumen ist sofort wirksam</label>
+        <label><input type="checkbox" data-cb="crit_US_051_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Benutzer wird als MEMBER hinzugefuegt</label>
+        <label><input type="checkbox" data-cb="crit_US_051_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Raum erscheint sofort in &quot;Meine Raeume&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_052" data-story="US-052" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-052</span> <span class="story-title">Beitrittsanfrage (Anfrage-Raeume)</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich eine Beitrittsanfrage fuer geschuetzte Raeume stellen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt einen Raum mit Join-Policy &quot;Auf Anfrage&quot; (REQUEST).</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich eine Beitrittsanfrage fuer geschuetzte Raeume stellen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt einen Raum mit Join-Policy &quot;Auf Anfrage&quot; (REQUEST).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1185,18 +1185,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Anfrage absenden</td><td>Toast: &quot;Anfrage gesendet&quot;; Button wechselt zu &quot;Anfrage gesendet&quot; (deaktiviert)</td><td><input type="checkbox" data-cb="step_US_052_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_052_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nachricht an Leitung ist optional</label>
-        <label><input type="checkbox" data-cb="crit_US_052_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Platzhalter: &quot;Nachricht an die Leitung (optional)...&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_052_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nach Absenden kann keine zweite Anfrage gestellt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_052_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> LEADER des Raumes erhaelt Benachrichtigung</label>
+        <label><input type="checkbox" data-cb="crit_US_052_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nachricht an Leitung ist optional</label>
+        <label><input type="checkbox" data-cb="crit_US_052_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Platzhalter: &quot;Nachricht an die Leitung (optional)...&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_052_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nach Absenden kann keine zweite Anfrage gestellt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_052_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> LEADER des Raumes erhaelt Benachrichtigung</label>
       </div>
     </div>
     <div class="story" id="story-US_053" data-story="US-053" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-053</span> <span class="story-title">Beitrittsanfrage genehmigen/ablehnen (LEADER)</span></div>
       </div>
-      <div class="story-als">Als Raum-LEADER moechte ich Beitrittsanfragen bearbeiten koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt eine offene Beitrittsanfrage fuer den Raum.</div>
+      <div class="story-als">Als Raum-LEADER moechte ich Beitrittsanfragen bearbeiten koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt eine offene Beitrittsanfrage fuer den Raum.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1205,17 +1205,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Bei einer anderen Anfrage: Button &quot;Ablehnen&quot; klicken</td><td>Toast: &quot;Anfrage abgelehnt&quot;; Anfrage wird entfernt</td><td><input type="checkbox" data-cb="step_US_053_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_053_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur LEADER und SUPERADMIN koennen Anfragen bearbeiten</label>
-        <label><input type="checkbox" data-cb="crit_US_053_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Angenommene Benutzer werden automatisch MEMBER</label>
-        <label><input type="checkbox" data-cb="crit_US_053_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Anfragender Benutzer wird per Benachrichtigung informiert</label>
+        <label><input type="checkbox" data-cb="crit_US_053_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur LEADER und SUPERADMIN koennen Anfragen bearbeiten</label>
+        <label><input type="checkbox" data-cb="crit_US_053_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Angenommene Benutzer werden automatisch MEMBER</label>
+        <label><input type="checkbox" data-cb="crit_US_053_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Anfragender Benutzer wird per Benachrichtigung informiert</label>
       </div>
     </div>
     <div class="story" id="story-US_054" data-story="US-054" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-054</span> <span class="story-title">Raum-Nur-Einladung</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich keinem Raum beitreten koennen, der auf &quot;Nur auf Einladung&quot; steht.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt einen Raum mit Join-Policy &quot;Nur auf Einladung&quot; (INVITE_ONLY).</div>
+      <div class="story-als">Als Benutzer moechte ich keinem Raum beitreten koennen, der auf &quot;Nur auf Einladung&quot; steht.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt einen Raum mit Join-Policy &quot;Nur auf Einladung&quot; (INVITE_ONLY).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1223,17 +1223,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Raum-Detail-Seite als Nicht-Mitglied aufrufen</td><td>Hinweis &quot;Kein Mitglied&quot; und &quot;Beitreten um Inhalte zu sehen&quot; oder nur oeffentliche Beschreibung sichtbar</td><td><input type="checkbox" data-cb="step_US_054_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_054_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Keine Moeglichkeit zum Beitritt ohne Einladung</label>
-        <label><input type="checkbox" data-cb="crit_US_054_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Inhalte des Raumes nicht sichtbar fuer Nicht-Mitglieder</label>
-        <label><input type="checkbox" data-cb="crit_US_054_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur oeffentliche Beschreibung ist einsehbar</label>
+        <label><input type="checkbox" data-cb="crit_US_054_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Keine Moeglichkeit zum Beitritt ohne Einladung</label>
+        <label><input type="checkbox" data-cb="crit_US_054_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Inhalte des Raumes nicht sichtbar fuer Nicht-Mitglieder</label>
+        <label><input type="checkbox" data-cb="crit_US_054_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur oeffentliche Beschreibung ist einsehbar</label>
       </div>
     </div>
     <div class="story" id="story-US_055" data-story="US-055" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-055</span> <span class="story-title">Raum-Detail-Seite -- Tabs</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich die verschiedenen Bereiche eines Raumes ueber Tabs erreichen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raumes; diverse Module sind aktiviert.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich die verschiedenen Bereiche eines Raumes ueber Tabs erreichen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raumes; diverse Module sind aktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1248,17 +1248,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>9</td><td>Tab &quot;Einstellungen&quot; (nur LEADER/SA)</td><td>Raum-Konfiguration</td><td><input type="checkbox" data-cb="step_US_055_9" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_055_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur aktivierte Module zeigen Tabs</label>
-        <label><input type="checkbox" data-cb="crit_US_055_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Tab &quot;Einstellungen&quot; nur fuer LEADER und SUPERADMIN sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_055_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Standard-Tab ist &quot;Info-Board&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_055_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur aktivierte Module zeigen Tabs</label>
+        <label><input type="checkbox" data-cb="crit_US_055_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Tab &quot;Einstellungen&quot; nur fuer LEADER und SUPERADMIN sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_055_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Standard-Tab ist &quot;Info-Board&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_056" data-story="US-056" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-056</span> <span class="story-title">Raum-Mitglieder verwalten (LEADER)</span></div>
       </div>
-      <div class="story-als">Als Raum-LEADER moechte ich Mitglieder hinzufuegen und entfernen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines Raumes.</div>
+      <div class="story-als">Als Raum-LEADER moechte ich Mitglieder hinzufuegen und entfernen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines Raumes.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1271,18 +1271,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Mitglied entfernen mit Bestaetigung</td><td>Dialog: &quot;Mitglied wirklich entfernen?&quot;; nach Bestaetigung: &quot;Mitglied entfernt&quot;</td><td><input type="checkbox" data-cb="step_US_056_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_056_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Suche nach Name oder E-Mail funktioniert</label>
-        <label><input type="checkbox" data-cb="crit_US_056_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bereits vorhandene Mitglieder zeigen Hinweis &quot;Ist bereits Mitglied&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_056_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Rollen: LEADER, MEMBER, PARENT_MEMBER, GUEST</label>
-        <label><input type="checkbox" data-cb="crit_US_056_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Entfernung erfordert Bestaetigung</label>
+        <label><input type="checkbox" data-cb="crit_US_056_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Suche nach Name oder E-Mail funktioniert</label>
+        <label><input type="checkbox" data-cb="crit_US_056_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bereits vorhandene Mitglieder zeigen Hinweis &quot;Ist bereits Mitglied&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_056_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Rollen: LEADER, MEMBER, PARENT_MEMBER, GUEST</label>
+        <label><input type="checkbox" data-cb="crit_US_056_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Entfernung erfordert Bestaetigung</label>
       </div>
     </div>
     <div class="story" id="story-US_057" data-story="US-057" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-057</span> <span class="story-title">Familie einem Raum hinzufuegen (LEADER)</span></div>
       </div>
-      <div class="story-als">Als Raum-LEADER moechte ich eine ganze Familie einem Raum hinzufuegen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER; es gibt Familienverbuende im System.</div>
+      <div class="story-als">Als Raum-LEADER moechte ich eine ganze Familie einem Raum hinzufuegen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER; es gibt Familienverbuende im System.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1291,17 +1291,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Familie auswaehlen und hinzufuegen</td><td>Toast: &quot;Familienmitglieder hinzugefuegt&quot;; alle Familienmitglieder sind nun Mitglieder</td><td><input type="checkbox" data-cb="step_US_057_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_057_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Eltern werden als PARENT_MEMBER hinzugefuegt</label>
-        <label><input type="checkbox" data-cb="crit_US_057_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Kinder werden als MEMBER hinzugefuegt</label>
-        <label><input type="checkbox" data-cb="crit_US_057_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei KLASSE-Raeumen: separate Darstellung von Lehrkraeften, Schuelern, Familien</label>
+        <label><input type="checkbox" data-cb="crit_US_057_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Eltern werden als PARENT_MEMBER hinzugefuegt</label>
+        <label><input type="checkbox" data-cb="crit_US_057_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Kinder werden als MEMBER hinzugefuegt</label>
+        <label><input type="checkbox" data-cb="crit_US_057_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei KLASSE-Raeumen: separate Darstellung von Lehrkraeften, Schuelern, Familien</label>
       </div>
     </div>
     <div class="story" id="story-US_058" data-story="US-058" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-058</span> <span class="story-title">Raum-Einstellungen (LEADER)</span></div>
       </div>
-      <div class="story-als">Als Raum-LEADER moechte ich die Raum-Einstellungen konfigurieren.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines Raumes.</div>
+      <div class="story-als">Als Raum-LEADER moechte ich die Raum-Einstellungen konfigurieren.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines Raumes.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1313,18 +1313,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>&quot;Speichern&quot; klicken</td><td>Toast: &quot;Einstellungen gespeichert&quot;</td><td><input type="checkbox" data-cb="step_US_058_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_058_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur LEADER und SA sehen den Einstellungen-Tab</label>
-        <label><input type="checkbox" data-cb="crit_US_058_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Modul-Toggles aktivieren/deaktivieren entsprechende Tabs</label>
-        <label><input type="checkbox" data-cb="crit_US_058_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Sichtbarkeit beeinflusst, wer den Raum auf der Entdecken-Seite sieht</label>
-        <label><input type="checkbox" data-cb="crit_US_058_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Diskussionsmodus steuert, wer Diskussionen erstellen kann</label>
+        <label><input type="checkbox" data-cb="crit_US_058_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur LEADER und SA sehen den Einstellungen-Tab</label>
+        <label><input type="checkbox" data-cb="crit_US_058_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Modul-Toggles aktivieren/deaktivieren entsprechende Tabs</label>
+        <label><input type="checkbox" data-cb="crit_US_058_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Sichtbarkeit beeinflusst, wer den Raum auf der Entdecken-Seite sieht</label>
+        <label><input type="checkbox" data-cb="crit_US_058_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Diskussionsmodus steuert, wer Diskussionen erstellen kann</label>
       </div>
     </div>
     <div class="story" id="story-US_059" data-story="US-059" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-059</span> <span class="story-title">Raum archivieren (SA)</span></div>
       </div>
-      <div class="story-als">Als SUPERADMIN moechte ich einen Raum archivieren koennen, damit er nicht mehr aktiv genutzt wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt.</div>
+      <div class="story-als">Als SUPERADMIN moechte ich einen Raum archivieren koennen, damit er nicht mehr aktiv genutzt wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1335,18 +1335,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Bestaetigen</td><td>Toast: &quot;Raum reaktiviert&quot;; Raum ist wieder sichtbar</td><td><input type="checkbox" data-cb="step_US_059_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_059_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Deaktivierter Raum ist fuer Nutzer nicht mehr sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_059_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Deaktivierung ist reversibel (Reaktivierung moeglich)</label>
-        <label><input type="checkbox" data-cb="crit_US_059_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur SA kann Raeume deaktivieren/reaktivieren</label>
-        <label><input type="checkbox" data-cb="crit_US_059_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Endgueltiges Loeschen mit Warnung: &quot;Alle Mitgliedschaften, Diskussionen, Dateien und Chat-Nachrichten werden unwiderruflich geloescht.&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_059_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Deaktivierter Raum ist fuer Nutzer nicht mehr sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_059_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Deaktivierung ist reversibel (Reaktivierung moeglich)</label>
+        <label><input type="checkbox" data-cb="crit_US_059_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur SA kann Raeume deaktivieren/reaktivieren</label>
+        <label><input type="checkbox" data-cb="crit_US_059_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Endgueltiges Loeschen mit Warnung: &quot;Alle Mitgliedschaften, Diskussionen, Dateien und Chat-Nachrichten werden unwiderruflich geloescht.&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_060" data-story="US-060" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-060</span> <span class="story-title">Diskussions-Thread erstellen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich eine Diskussion im Raum starten.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Diskussionsmodus ist &quot;Vollstaendig&quot; oder &quot;Nur Ankuendigungen&quot; (fuer LEADER); Einstellung &quot;Mitglieder duerfen Themen erstellen&quot; ist an.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich eine Diskussion im Raum starten.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Diskussionsmodus ist &quot;Vollstaendig&quot; oder &quot;Nur Ankuendigungen&quot; (fuer LEADER); Einstellung &quot;Mitglieder duerfen Themen erstellen&quot; ist an.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1358,19 +1358,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Absenden</td><td>Diskussion erscheint in der Liste mit Antworten-Zaehler</td><td><input type="checkbox" data-cb="step_US_060_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_060_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Titel ist Pflichtfeld</label>
-        <label><input type="checkbox" data-cb="crit_US_060_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Beschreibung ist optional</label>
-        <label><input type="checkbox" data-cb="crit_US_060_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Zielgruppe (Audience): Alle, Eltern, Kinder</label>
-        <label><input type="checkbox" data-cb="crit_US_060_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei deaktivierter Mitglieder-Erstellung: nur LEADER/SA koennen Diskussionen erstellen</label>
-        <label><input type="checkbox" data-cb="crit_US_060_4" data-crit="1" data-module="Raeume" onchange="onCheck()"> Antworten-Zaehler zeigt &quot;{n} Antworten&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_060_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Titel ist Pflichtfeld</label>
+        <label><input type="checkbox" data-cb="crit_US_060_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Beschreibung ist optional</label>
+        <label><input type="checkbox" data-cb="crit_US_060_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Zielgruppe (Audience): Alle, Eltern, Kinder</label>
+        <label><input type="checkbox" data-cb="crit_US_060_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei deaktivierter Mitglieder-Erstellung: nur LEADER/SA koennen Diskussionen erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_060_4" data-crit="1" data-module="Raeume" onchange="onCheck()"> Antworten-Zaehler zeigt &quot;{n} Antworten&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_061" data-story="US-061" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-061</span> <span class="story-title">Diskussions-Thread beantworten</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich auf eine Diskussion antworten.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt eine offene Diskussion im Raum.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich auf eine Diskussion antworten.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Es gibt eine offene Diskussion im Raum.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1379,17 +1379,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Absenden</td><td>Antwort erscheint in der Liste; Antworten-Zaehler erhoet sich</td><td><input type="checkbox" data-cb="step_US_061_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_061_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Antworten werden chronologisch angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_061_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei &quot;Nur Ankuendigungen&quot; koennen nur LEADER/SA Diskussionen erstellen, aber alle antworten</label>
-        <label><input type="checkbox" data-cb="crit_US_061_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei deaktiviertem Diskussionsmodus: Tab &quot;Diskussionen&quot; nicht sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_061_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Antworten werden chronologisch angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_061_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei &quot;Nur Ankuendigungen&quot; koennen nur LEADER/SA Diskussionen erstellen, aber alle antworten</label>
+        <label><input type="checkbox" data-cb="crit_US_061_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bei deaktiviertem Diskussionsmodus: Tab &quot;Diskussionen&quot; nicht sichtbar</label>
       </div>
     </div>
     <div class="story" id="story-US_062" data-story="US-062" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-062</span> <span class="story-title">Diskussion archivieren (LEADER)</span></div>
       </div>
-      <div class="story-als">Als Raum-LEADER moechte ich eine Diskussion archivieren, damit keine weiteren Antworten moeglich sind.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER; es gibt eine aktive Diskussion.</div>
+      <div class="story-als">Als Raum-LEADER moechte ich eine Diskussion archivieren, damit keine weiteren Antworten moeglich sind.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER; es gibt eine aktive Diskussion.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1398,17 +1398,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Antwortfeld pruefen</td><td>Hinweis: &quot;Diese Diskussion ist archiviert. Antworten sind nicht mehr moeglich.&quot;</td><td><input type="checkbox" data-cb="step_US_062_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_062_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Archivierte Diskussionen zeigen Hinweis</label>
-        <label><input type="checkbox" data-cb="crit_US_062_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Antwortfeld ist deaktiviert/ausgeblendet</label>
-        <label><input type="checkbox" data-cb="crit_US_062_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur LEADER/SA koennen archivieren</label>
+        <label><input type="checkbox" data-cb="crit_US_062_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Archivierte Diskussionen zeigen Hinweis</label>
+        <label><input type="checkbox" data-cb="crit_US_062_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Antwortfeld ist deaktiviert/ausgeblendet</label>
+        <label><input type="checkbox" data-cb="crit_US_062_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur LEADER/SA koennen archivieren</label>
       </div>
     </div>
     <div class="story" id="story-US_063" data-story="US-063" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-063</span> <span class="story-title">Raum-Chat (Echtzeit-Nachrichten)</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich im Raum-Chat in Echtzeit kommunizieren.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Chat ist im Raum aktiviert (Raum-Einstellungen).</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich im Raum-Chat in Echtzeit kommunizieren.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Chat ist im Raum aktiviert (Raum-Einstellungen).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1420,19 +1420,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Auf eine Nachricht antworten (Button &quot;Antworten&quot;)</td><td>Antwort wird als Reply dargestellt mit Referenz zur Originalnachricht</td><td><input type="checkbox" data-cb="step_US_063_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_063_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> WebSocket-Verbindung fuer Echtzeit-Updates (/ws/messages)</label>
-        <label><input type="checkbox" data-cb="crit_US_063_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Drei Kanaele: MAIN (Alle), PARENTS (Eltern-Lehrer), STUDENTS (Schueler-Lehrer)</label>
-        <label><input type="checkbox" data-cb="crit_US_063_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bilder: JPEG, PNG, WebP, GIF; max. 10 MB</label>
-        <label><input type="checkbox" data-cb="crit_US_063_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Reply-Threading mit reply_to_id</label>
-        <label><input type="checkbox" data-cb="crit_US_063_4" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nachrichten zeigen Datum-Separatoren (Heute, Gestern)</label>
+        <label><input type="checkbox" data-cb="crit_US_063_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> WebSocket-Verbindung fuer Echtzeit-Updates (/ws/messages)</label>
+        <label><input type="checkbox" data-cb="crit_US_063_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Drei Kanaele: MAIN (Alle), PARENTS (Eltern-Lehrer), STUDENTS (Schueler-Lehrer)</label>
+        <label><input type="checkbox" data-cb="crit_US_063_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Bilder: JPEG, PNG, WebP, GIF; max. 10 MB</label>
+        <label><input type="checkbox" data-cb="crit_US_063_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Reply-Threading mit reply_to_id</label>
+        <label><input type="checkbox" data-cb="crit_US_063_4" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nachrichten zeigen Datum-Separatoren (Heute, Gestern)</label>
       </div>
     </div>
     <div class="story" id="story-US_064" data-story="US-064" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-064</span> <span class="story-title">Raum-Chat stummschalten</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich den Chat stummschalten, damit ich keine Benachrichtigungen erhalte.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Chat ist im Raum aktiviert.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich den Chat stummschalten, damit ich keine Benachrichtigungen erhalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Chat ist im Raum aktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1441,17 +1441,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Neue Nachricht im Chat pruefen</td><td>Keine Push-Benachrichtigung fuer stummgeschalteten Chat</td><td><input type="checkbox" data-cb="step_US_064_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_064_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Mute-Toggle in Chat-Header</label>
-        <label><input type="checkbox" data-cb="crit_US_064_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Stummgeschalteter Chat erscheint in Profil unter &quot;Stummgeschaltete Chats&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_064_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Persistiert in `conversation_participants.muted`</label>
+        <label><input type="checkbox" data-cb="crit_US_064_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Mute-Toggle in Chat-Header</label>
+        <label><input type="checkbox" data-cb="crit_US_064_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Stummgeschalteter Chat erscheint in Profil unter &quot;Stummgeschaltete Chats&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_064_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Persistiert in `conversation_participants.muted`</label>
       </div>
     </div>
     <div class="story" id="story-US_065" data-story="US-065" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-065</span> <span class="story-title">Jitsi-Videokonferenz im Raum starten</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich einen Videochat starten, damit wir uns virtuell treffen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Jitsi-Modul ist aktiviert (in modules JSONB); Jitsi-Server-URL ist konfiguriert.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich einen Videochat starten, damit wir uns virtuell treffen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Jitsi-Modul ist aktiviert (in modules JSONB); Jitsi-Server-URL ist konfiguriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1459,17 +1459,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Button klicken</td><td>Neuer Tab oeffnet sich mit Jitsi-Konferenz auf konfiguriertem Server</td><td><input type="checkbox" data-cb="step_US_065_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_065_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Jitsi-Button nur sichtbar wenn Modul aktiviert</label>
-        <label><input type="checkbox" data-cb="crit_US_065_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Jitsi-Server-URL aus Tenant-Konfiguration (Standard: meet.jit.si)</label>
-        <label><input type="checkbox" data-cb="crit_US_065_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Raum-spezifischer Konferenzname</label>
+        <label><input type="checkbox" data-cb="crit_US_065_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Jitsi-Button nur sichtbar wenn Modul aktiviert</label>
+        <label><input type="checkbox" data-cb="crit_US_065_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Jitsi-Server-URL aus Tenant-Konfiguration (Standard: meet.jit.si)</label>
+        <label><input type="checkbox" data-cb="crit_US_065_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Raum-spezifischer Konferenzname</label>
       </div>
     </div>
     <div class="story" id="story-US_066" data-story="US-066" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-066</span> <span class="story-title">Raum-Feed stummschalten</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich den Feed eines Raumes stummschalten.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raumes.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich den Feed eines Raumes stummschalten.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raumes.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1479,17 +1479,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>&quot;Stummschaltung aufheben&quot; klicken</td><td>Toast: &quot;Stummschaltung aufgehoben&quot;</td><td><input type="checkbox" data-cb="step_US_066_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_066_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Stummgeschaltete Raum-Feeds erscheinen nicht im globalen Feed</label>
-        <label><input type="checkbox" data-cb="crit_US_066_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Beitraege sind weiterhin im Raum selbst sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_066_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Toggle-Funktion (Stummschalten / Aufheben)</label>
+        <label><input type="checkbox" data-cb="crit_US_066_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Stummgeschaltete Raum-Feeds erscheinen nicht im globalen Feed</label>
+        <label><input type="checkbox" data-cb="crit_US_066_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Beitraege sind weiterhin im Raum selbst sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_066_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Toggle-Funktion (Stummschalten / Aufheben)</label>
       </div>
     </div>
     <div class="story" id="story-US_067" data-story="US-067" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-067</span> <span class="story-title">Raum-Zugriff als Nicht-Mitglied</span></div>
       </div>
-      <div class="story-als">Als Nicht-Mitglied moechte ich keinen Zugriff auf Raum-Inhalte haben.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist kein Mitglied des Raumes; Raum hat Sichtbarkeit &quot;Nur Mitglieder&quot;.</div>
+      <div class="story-als">Als Nicht-Mitglied moechte ich keinen Zugriff auf Raum-Inhalte haben.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist kein Mitglied des Raumes; Raum hat Sichtbarkeit &quot;Nur Mitglieder&quot;.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1497,17 +1497,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>API-Aufruf GET /api/v1/rooms/[raum-id]/files als Nicht-Mitglied</td><td>HTTP 403 Forbidden</td><td><input type="checkbox" data-cb="step_US_067_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_067_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Keine Inhalte (Posts, Dateien, Chat) fuer Nicht-Mitglieder sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_067_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur oeffentliche Beschreibung wird angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_067_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Backend-Endpunkte pruefen Mitgliedschaft</label>
+        <label><input type="checkbox" data-cb="crit_US_067_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Keine Inhalte (Posts, Dateien, Chat) fuer Nicht-Mitglieder sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_067_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur oeffentliche Beschreibung wird angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_067_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> Backend-Endpunkte pruefen Mitgliedschaft</label>
       </div>
     </div>
     <div class="story" id="story-US_068" data-story="US-068" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-068</span> <span class="story-title">Klassenwechsel / Migration (LEADER)</span></div>
       </div>
-      <div class="story-als">Als Raum-LEADER eines KLASSE-Raumes moechte ich Schueler in eine andere Klasse verschieben oder die Schule verlassen lassen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines KLASSE-Raumes mit Schuelern.</div>
+      <div class="story-als">Als Raum-LEADER eines KLASSE-Raumes moechte ich Schueler in eine andere Klasse verschieben oder die Schule verlassen lassen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines KLASSE-Raumes mit Schuelern.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1520,10 +1520,10 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Bestaetigen</td><td>Toast: &quot;{count} Kind(er) haben die Schule verlassen.&quot;; Familien werden deaktiviert</td><td><input type="checkbox" data-cb="step_US_068_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_068_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur bei KLASSE-Raeumen verfuegbar</label>
-        <label><input type="checkbox" data-cb="crit_US_068_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> &quot;Verschieben&quot; fuegt Kinder + Eltern zur Zielklasse hinzu</label>
-        <label><input type="checkbox" data-cb="crit_US_068_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> &quot;Schule verlassen&quot; entfernt aus allen Raeumen und deaktiviert Familien</label>
-        <label><input type="checkbox" data-cb="crit_US_068_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Warnung bei irreversibler Aktion</label>
+        <label><input type="checkbox" data-cb="crit_US_068_0" data-crit="1" data-module="Raeume" onchange="onCheck()"> Nur bei KLASSE-Raeumen verfuegbar</label>
+        <label><input type="checkbox" data-cb="crit_US_068_1" data-crit="1" data-module="Raeume" onchange="onCheck()"> &quot;Verschieben&quot; fuegt Kinder + Eltern zur Zielklasse hinzu</label>
+        <label><input type="checkbox" data-cb="crit_US_068_2" data-crit="1" data-module="Raeume" onchange="onCheck()"> &quot;Schule verlassen&quot; entfernt aus allen Raeumen und deaktiviert Familien</label>
+        <label><input type="checkbox" data-cb="crit_US_068_3" data-crit="1" data-module="Raeume" onchange="onCheck()"> Warnung bei irreversibler Aktion</label>
       </div>
     </div>
   </div>
@@ -1541,8 +1541,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-069</span> <span class="story-title">Feed-Beitraege anzeigen</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich den Feed mit Beitraegen aus meinen Raeumen sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt und Mitglied in Raeumen mit Beitraegen.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich den Feed mit Beitraegen aus meinen Raeumen sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt und Mitglied in Raeumen mit Beitraegen.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1552,18 +1552,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>&quot;Weitere laden&quot; am Ende der Liste klicken</td><td>Naechste Seite der Beitraege wird geladen (Pagination: 20 pro Seite)</td><td><input type="checkbox" data-cb="step_US_069_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_069_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Beitraege sind chronologisch sortiert (neueste zuerst)</label>
-        <label><input type="checkbox" data-cb="crit_US_069_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Angeheftete Beitraege stehen oben</label>
-        <label><input type="checkbox" data-cb="crit_US_069_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Pagination mit &quot;Weitere laden&quot;-Button</label>
-        <label><input type="checkbox" data-cb="crit_US_069_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Bei keinen Beitraegen: &quot;Noch keine Beitraege vorhanden.&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_069_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Beitraege sind chronologisch sortiert (neueste zuerst)</label>
+        <label><input type="checkbox" data-cb="crit_US_069_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Angeheftete Beitraege stehen oben</label>
+        <label><input type="checkbox" data-cb="crit_US_069_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Pagination mit &quot;Weitere laden&quot;-Button</label>
+        <label><input type="checkbox" data-cb="crit_US_069_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Bei keinen Beitraegen: &quot;Noch keine Beitraege vorhanden.&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_070" data-story="US-070" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-070</span> <span class="story-title">Beitrag erstellen (T/SA im Raum)</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft oder SUPERADMIN moechte ich einen Beitrag in einem Raum veroeffentlichen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER oder MEMBER des Raumes und hat Rolle T oder SA.</div>
+      <div class="story-als">Als Lehrkraft oder SUPERADMIN moechte ich einen Beitrag in einem Raum veroeffentlichen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER oder MEMBER des Raumes und hat Rolle T oder SA.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1573,18 +1573,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Button &quot;Veroeffentlichen&quot; klicken</td><td>Toast: &quot;Beitrag veroeffentlicht&quot;; Beitrag erscheint im Raum-Feed</td><td><input type="checkbox" data-cb="step_US_070_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_070_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Titel ist optional</label>
-        <label><input type="checkbox" data-cb="crit_US_070_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Inhalt ist Pflichtfeld (oder alternativ Poll/Dateianhang)</label>
-        <label><input type="checkbox" data-cb="crit_US_070_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Beitrag erscheint sofort im Feed des Raumes</label>
-        <label><input type="checkbox" data-cb="crit_US_070_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Beitrag erscheint auch im Dashboard-Feed der Raum-Mitglieder</label>
+        <label><input type="checkbox" data-cb="crit_US_070_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Titel ist optional</label>
+        <label><input type="checkbox" data-cb="crit_US_070_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Inhalt ist Pflichtfeld (oder alternativ Poll/Dateianhang)</label>
+        <label><input type="checkbox" data-cb="crit_US_070_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Beitrag erscheint sofort im Feed des Raumes</label>
+        <label><input type="checkbox" data-cb="crit_US_070_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Beitrag erscheint auch im Dashboard-Feed der Raum-Mitglieder</label>
       </div>
     </div>
     <div class="story" id="story-US_071" data-story="US-071" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-071</span> <span class="story-title">Beitrag erstellen -- nicht erlaubt fuer P/S</span></div>
       </div>
-      <div class="story-als">Als Parent oder Student moechte ich keinen Beitrag im Raum erstellen koennen (ausser in Diskussionen).</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als P oder S eingeloggt und Mitglied eines Raumes.</div>
+      <div class="story-als">Als Parent oder Student moechte ich keinen Beitrag im Raum erstellen koennen (ausser in Diskussionen).</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als P oder S eingeloggt und Mitglied eines Raumes.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1592,16 +1592,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Raum-Detail-Seite oeffnen als S</td><td>PostComposer ist NICHT sichtbar auf dem Info-Board</td><td><input type="checkbox" data-cb="step_US_071_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_071_0" data-crit="1" data-module="Feed" onchange="onCheck()"> PARENT und STUDENT koennen keine Feed-Beitraege erstellen</label>
-        <label><input type="checkbox" data-cb="crit_US_071_1" data-crit="1" data-module="Feed" onchange="onCheck()"> PostComposer auf Dashboard und Raum-Detail nur fuer T/SA sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_071_0" data-crit="1" data-module="Feed" onchange="onCheck()"> PARENT und STUDENT koennen keine Feed-Beitraege erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_071_1" data-crit="1" data-module="Feed" onchange="onCheck()"> PostComposer auf Dashboard und Raum-Detail nur fuer T/SA sichtbar</label>
       </div>
     </div>
     <div class="story" id="story-US_072" data-story="US-072" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-072</span> <span class="story-title">Beitrag mit Datei-Anhaengen erstellen</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft moechte ich Dateien an einen Beitrag anhaengen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA; Raum ist geoeffnet.</div>
+      <div class="story-als">Als Lehrkraft moechte ich Dateien an einen Beitrag anhaengen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA; Raum ist geoeffnet.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1612,20 +1612,20 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Beitrag veroeffentlichen</td><td>Toast: &quot;Beitrag veroeffentlicht&quot;; Anhaenge werden als Download-Links dargestellt</td><td><input type="checkbox" data-cb="step_US_072_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_072_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Maximal 10 Dateien pro Beitrag</label>
-        <label><input type="checkbox" data-cb="crit_US_072_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Maximale Dateigroesse: 50 MB pro Datei</label>
-        <label><input type="checkbox" data-cb="crit_US_072_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Bei zu grosser Datei: &quot;Datei zu gross (max. 50 MB)&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_072_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Bei zu vielen Dateien: &quot;Maximal 10 Dateien erlaubt&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_072_4" data-crit="1" data-module="Feed" onchange="onCheck()"> Zwei-Schritt-Prozess: Post erstellen, dann Dateien hochladen (transparent fuer Benutzer)</label>
-        <label><input type="checkbox" data-cb="crit_US_072_5" data-crit="1" data-module="Feed" onchange="onCheck()"> Verschiedene Datei-Icons (Bild, PDF, Video, Audio, Datei)</label>
+        <label><input type="checkbox" data-cb="crit_US_072_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Maximal 10 Dateien pro Beitrag</label>
+        <label><input type="checkbox" data-cb="crit_US_072_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Maximale Dateigroesse: 50 MB pro Datei</label>
+        <label><input type="checkbox" data-cb="crit_US_072_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Bei zu grosser Datei: &quot;Datei zu gross (max. 50 MB)&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_072_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Bei zu vielen Dateien: &quot;Maximal 10 Dateien erlaubt&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_072_4" data-crit="1" data-module="Feed" onchange="onCheck()"> Zwei-Schritt-Prozess: Post erstellen, dann Dateien hochladen (transparent fuer Benutzer)</label>
+        <label><input type="checkbox" data-cb="crit_US_072_5" data-crit="1" data-module="Feed" onchange="onCheck()"> Verschiedene Datei-Icons (Bild, PDF, Video, Audio, Datei)</label>
       </div>
     </div>
     <div class="story" id="story-US_073" data-story="US-073" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-073</span> <span class="story-title">Beitrag loeschen</span></div>
       </div>
-      <div class="story-als">Als Autor eines Beitrags oder SUPERADMIN moechte ich einen Beitrag loeschen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Beitrag existiert; Benutzer ist Autor oder SA.</div>
+      <div class="story-als">Als Autor eines Beitrags oder SUPERADMIN moechte ich einen Beitrag loeschen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Beitrag existiert; Benutzer ist Autor oder SA.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1635,18 +1635,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Als T: Beitrag eines anderen T loeschen versuchen</td><td>Loeschen-Option ist NICHT sichtbar</td><td><input type="checkbox" data-cb="step_US_073_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_073_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Nur Autor und SA koennen Beitraege loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_073_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Bestaetigungsdialog mit Titel &quot;Beitrag loeschen&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_073_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Loeschung ist endgueltig</label>
-        <label><input type="checkbox" data-cb="crit_US_073_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Zugehoerige Kommentare und Anhaenge werden mitgeloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_073_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Nur Autor und SA koennen Beitraege loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_073_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Bestaetigungsdialog mit Titel &quot;Beitrag loeschen&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_073_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Loeschung ist endgueltig</label>
+        <label><input type="checkbox" data-cb="crit_US_073_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Zugehoerige Kommentare und Anhaenge werden mitgeloescht</label>
       </div>
     </div>
     <div class="story" id="story-US_074" data-story="US-074" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-074</span> <span class="story-title">Kommentar verfassen</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich einen Beitrag kommentieren.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt und kann den Beitrag sehen.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich einen Beitrag kommentieren.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt und kann den Beitrag sehen.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1656,18 +1656,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Leeren Kommentar absenden versuchen</td><td>Button ist deaktiviert</td><td><input type="checkbox" data-cb="step_US_074_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_074_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Kommentare werden chronologisch unter dem Beitrag angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_074_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Kommentar-Zaehler wird aktualisiert</label>
-        <label><input type="checkbox" data-cb="crit_US_074_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Leere Kommentare werden verhindert</label>
-        <label><input type="checkbox" data-cb="crit_US_074_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Jeder Kommentar zeigt: Autorname, Inhalt, Zeitstempel</label>
+        <label><input type="checkbox" data-cb="crit_US_074_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Kommentare werden chronologisch unter dem Beitrag angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_074_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Kommentar-Zaehler wird aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_074_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Leere Kommentare werden verhindert</label>
+        <label><input type="checkbox" data-cb="crit_US_074_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Jeder Kommentar zeigt: Autorname, Inhalt, Zeitstempel</label>
       </div>
     </div>
     <div class="story" id="story-US_075" data-story="US-075" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-075</span> <span class="story-title">Beitrag anheften/loslösen (T/SA)</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft oder SUPERADMIN moechte ich einen Beitrag oben anheften.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA.</div>
+      <div class="story-als">Als Lehrkraft oder SUPERADMIN moechte ich einen Beitrag oben anheften.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1676,18 +1676,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Option &quot;Losloesen&quot; klicken</td><td>Label &quot;Angeheftet&quot; verschwindet; Beitrag rueckt an chronologische Position</td><td><input type="checkbox" data-cb="step_US_075_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_075_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Pin-Toggle: &quot;Anheften&quot; / &quot;Losloesen&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_075_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Angeheftete Beitraege zeigen Tag &quot;Angeheftet&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_075_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Nur T und SA koennen pinnen</label>
-        <label><input type="checkbox" data-cb="crit_US_075_3" data-crit="1" data-module="Feed" onchange="onCheck()"> P und S sehen keine Pin-Option</label>
+        <label><input type="checkbox" data-cb="crit_US_075_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Pin-Toggle: &quot;Anheften&quot; / &quot;Losloesen&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_075_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Angeheftete Beitraege zeigen Tag &quot;Angeheftet&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_075_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Nur T und SA koennen pinnen</label>
+        <label><input type="checkbox" data-cb="crit_US_075_3" data-crit="1" data-module="Feed" onchange="onCheck()"> P und S sehen keine Pin-Option</label>
       </div>
     </div>
     <div class="story" id="story-US_076" data-story="US-076" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-076</span> <span class="story-title">Reaktionen auf Beitraege</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich auf Beitraege mit Emojis reagieren.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Beitraege sind sichtbar.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich auf Beitraege mit Emojis reagieren.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Beitraege sind sichtbar.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1697,18 +1697,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Andere Benutzer reagieren auf gleichen Beitrag</td><td>Zaehler erhoeht sich; eigene Reaktion ist hervorgehoben</td><td><input type="checkbox" data-cb="step_US_076_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_076_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Toggle-Pattern: Klick setzt/entfernt Reaktion</label>
-        <label><input type="checkbox" data-cb="crit_US_076_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Zaehler zeigt Anzahl pro Emoji</label>
-        <label><input type="checkbox" data-cb="crit_US_076_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Eigene Reaktionen sind visuell markiert (userReacted: true)</label>
-        <label><input type="checkbox" data-cb="crit_US_076_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Reaktionen auch auf Kommentare moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_076_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Toggle-Pattern: Klick setzt/entfernt Reaktion</label>
+        <label><input type="checkbox" data-cb="crit_US_076_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Zaehler zeigt Anzahl pro Emoji</label>
+        <label><input type="checkbox" data-cb="crit_US_076_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Eigene Reaktionen sind visuell markiert (userReacted: true)</label>
+        <label><input type="checkbox" data-cb="crit_US_076_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Reaktionen auch auf Kommentare moeglich</label>
       </div>
     </div>
     <div class="story" id="story-US_077" data-story="US-077" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-077</span> <span class="story-title">Reaktionen auf Kommentare</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich auf Kommentare mit Emojis reagieren.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Kommentare sind sichtbar.</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich auf Kommentare mit Emojis reagieren.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; Kommentare sind sichtbar.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1717,16 +1717,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Gleiche Reaktion erneut klicken</td><td>Reaktion wird zurueckgenommen</td><td><input type="checkbox" data-cb="step_US_077_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_077_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Selbes Toggle-Verhalten wie bei Post-Reaktionen</label>
-        <label><input type="checkbox" data-cb="crit_US_077_1" data-crit="1" data-module="Feed" onchange="onCheck()"> API: POST /api/v1/feed/comments/{id}/reactions</label>
+        <label><input type="checkbox" data-cb="crit_US_077_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Selbes Toggle-Verhalten wie bei Post-Reaktionen</label>
+        <label><input type="checkbox" data-cb="crit_US_077_1" data-crit="1" data-module="Feed" onchange="onCheck()"> API: POST /api/v1/feed/comments/{id}/reactions</label>
       </div>
     </div>
     <div class="story" id="story-US_078" data-story="US-078" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-078</span> <span class="story-title">Beitrag mit Umfrage (Poll)</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft moechte ich eine Umfrage in einem Beitrag erstellen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA.</div>
+      <div class="story-als">Als Lehrkraft moechte ich eine Umfrage in einem Beitrag erstellen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1739,19 +1739,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Als T: &quot;Umfrage beenden&quot; klicken</td><td>Umfrage zeigt &quot;Beendet&quot;; keine weiteren Abstimmungen moeglich</td><td><input type="checkbox" data-cb="step_US_078_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_078_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Mindestens 2 Optionen erforderlich</label>
-        <label><input type="checkbox" data-cb="crit_US_078_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Einfach- oder Mehrfachauswahl konfigurierbar</label>
-        <label><input type="checkbox" data-cb="crit_US_078_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Ergebnis zeigt Stimmenanzahl: &quot;{count} Stimme(n)&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_078_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Ersteller kann Umfrage beenden</label>
-        <label><input type="checkbox" data-cb="crit_US_078_4" data-crit="1" data-module="Feed" onchange="onCheck()"> Beendete Umfrage zeigt &quot;Beendet&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_078_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Mindestens 2 Optionen erforderlich</label>
+        <label><input type="checkbox" data-cb="crit_US_078_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Einfach- oder Mehrfachauswahl konfigurierbar</label>
+        <label><input type="checkbox" data-cb="crit_US_078_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Ergebnis zeigt Stimmenanzahl: &quot;{count} Stimme(n)&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_078_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Ersteller kann Umfrage beenden</label>
+        <label><input type="checkbox" data-cb="crit_US_078_4" data-crit="1" data-module="Feed" onchange="onCheck()"> Beendete Umfrage zeigt &quot;Beendet&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_079" data-story="US-079" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-079</span> <span class="story-title">Parent-Only Beitraege</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft moechte ich Beitraege erstellen, die nur fuer Eltern sichtbar sind.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA; Raum hat Eltern-Mitglieder.</div>
+      <div class="story-als">Als Lehrkraft moechte ich Beitraege erstellen, die nur fuer Eltern sichtbar sind.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA; Raum hat Eltern-Mitglieder.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1760,17 +1760,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Als S den Raum-Feed oeffnen</td><td>Beitrag ist NICHT sichtbar</td><td><input type="checkbox" data-cb="step_US_079_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_079_0" data-crit="1" data-module="Feed" onchange="onCheck()"> FeedPost.parentOnly = true filtert fuer Schueler</label>
-        <label><input type="checkbox" data-cb="crit_US_079_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Nur T/SA koennen Parent-Only-Beitraege erstellen</label>
-        <label><input type="checkbox" data-cb="crit_US_079_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Eltern und Lehrkraefte sehen den Beitrag</label>
+        <label><input type="checkbox" data-cb="crit_US_079_0" data-crit="1" data-module="Feed" onchange="onCheck()"> FeedPost.parentOnly = true filtert fuer Schueler</label>
+        <label><input type="checkbox" data-cb="crit_US_079_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Nur T/SA koennen Parent-Only-Beitraege erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_079_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Eltern und Lehrkraefte sehen den Beitrag</label>
       </div>
     </div>
     <div class="story" id="story-US_080" data-story="US-080" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-080</span> <span class="story-title">Targeted Posts (gezielte Beitraege)</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft moechte ich Beitraege fuer bestimmte Benutzer sichtbar machen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA.</div>
+      <div class="story-als">Als Lehrkraft moechte ich Beitraege fuer bestimmte Benutzer sichtbar machen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist T oder SA.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1779,17 +1779,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Als nicht gezielter Benutzer Feed oeffnen</td><td>Beitrag ist NICHT sichtbar</td><td><input type="checkbox" data-cb="step_US_080_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_080_0" data-crit="1" data-module="Feed" onchange="onCheck()"> `feed_posts.target_user_ids`: NULL = alle sichtbar, gefuellt = nur gelistete User</label>
-        <label><input type="checkbox" data-cb="crit_US_080_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Gezielte Beitraege werden nur den ausgewaehlten Benutzern angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_080_2" data-crit="1" data-module="Feed" onchange="onCheck()"> PostgreSQL UUID-Array fuer target_user_ids</label>
+        <label><input type="checkbox" data-cb="crit_US_080_0" data-crit="1" data-module="Feed" onchange="onCheck()"> `feed_posts.target_user_ids`: NULL = alle sichtbar, gefuellt = nur gelistete User</label>
+        <label><input type="checkbox" data-cb="crit_US_080_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Gezielte Beitraege werden nur den ausgewaehlten Benutzern angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_080_2" data-crit="1" data-module="Feed" onchange="onCheck()"> PostgreSQL UUID-Array fuer target_user_ids</label>
       </div>
     </div>
     <div class="story" id="story-US_081" data-story="US-081" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-081</span> <span class="story-title">System-Banner auf Dashboard</span></div>
       </div>
-      <div class="story-als">Als eingeloggter Benutzer moechte ich kontextabhaengige Banner sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; es gibt aktive Banner (z.B. Putz-Banner fuer betroffene Eltern).</div>
+      <div class="story-als">Als eingeloggter Benutzer moechte ich kontextabhaengige Banner sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt; es gibt aktive Banner (z.B. Putz-Banner fuer betroffene Eltern).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1799,17 +1799,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Als P ohne Putztermin</td><td>Putz-Banner wird NICHT angezeigt</td><td><input type="checkbox" data-cb="step_US_081_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_081_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Banner sind kontextabhaengig (z.B. Putz-Banner nur fuer betroffene Eltern)</label>
-        <label><input type="checkbox" data-cb="crit_US_081_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Banner haben optionales Ablaufdatum (expiresAt)</label>
-        <label><input type="checkbox" data-cb="crit_US_081_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Banner koennen einen Link enthalten</label>
+        <label><input type="checkbox" data-cb="crit_US_081_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Banner sind kontextabhaengig (z.B. Putz-Banner nur fuer betroffene Eltern)</label>
+        <label><input type="checkbox" data-cb="crit_US_081_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Banner haben optionales Ablaufdatum (expiresAt)</label>
+        <label><input type="checkbox" data-cb="crit_US_081_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Banner koennen einen Link enthalten</label>
       </div>
     </div>
     <div class="story" id="story-US_082" data-story="US-082" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-082</span> <span class="story-title">Feed im Raum (Raum-spezifische Beitraege)</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich nur Beitraege des aktuellen Raumes sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raumes mit Beitraegen.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich nur Beitraege des aktuellen Raumes sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raumes mit Beitraegen.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1818,17 +1818,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Leerer Raum-Feed</td><td>Hinweis: &quot;Noch keine Beitraege in diesem Raum&quot;</td><td><input type="checkbox" data-cb="step_US_082_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_082_0" data-crit="1" data-module="Feed" onchange="onCheck()"> API: GET /api/v1/feed/rooms/{roomId}/posts</label>
-        <label><input type="checkbox" data-cb="crit_US_082_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Nur Beitraege des spezifischen Raumes werden angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_082_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Pagination funktioniert auch im Raum-Feed</label>
+        <label><input type="checkbox" data-cb="crit_US_082_0" data-crit="1" data-module="Feed" onchange="onCheck()"> API: GET /api/v1/feed/rooms/{roomId}/posts</label>
+        <label><input type="checkbox" data-cb="crit_US_082_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Nur Beitraege des spezifischen Raumes werden angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_082_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Pagination funktioniert auch im Raum-Feed</label>
       </div>
     </div>
     <div class="story" id="story-US_083" data-story="US-083" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-083</span> <span class="story-title">Beitrag-Quell-Labels</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich erkennen koennen, woher ein Beitrag stammt.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Feed zeigt Beitraege aus verschiedenen Quellen.</div>
+      <div class="story-als">Als Benutzer moechte ich erkennen koennen, woher ein Beitrag stammt.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Feed zeigt Beitraege aus verschiedenen Quellen.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1838,17 +1838,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Schulweiter Beitrag pruefen</td><td>Label: &quot;Schulweit&quot;</td><td><input type="checkbox" data-cb="step_US_083_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_083_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Quell-Labels: Raum, Schulbereich, Schulweit, Pinnwand, System</label>
-        <label><input type="checkbox" data-cb="crit_US_083_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Label ist farblich unterscheidbar</label>
-        <label><input type="checkbox" data-cb="crit_US_083_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Klick auf Raum-Label navigiert zum Raum</label>
+        <label><input type="checkbox" data-cb="crit_US_083_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Quell-Labels: Raum, Schulbereich, Schulweit, Pinnwand, System</label>
+        <label><input type="checkbox" data-cb="crit_US_083_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Label ist farblich unterscheidbar</label>
+        <label><input type="checkbox" data-cb="crit_US_083_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Klick auf Raum-Label navigiert zum Raum</label>
       </div>
     </div>
     <div class="story" id="story-US_084" data-story="US-084" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-084</span> <span class="story-title">Link-Vorschau in Beitraegen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich bei Links im Beitrag eine Vorschau sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Beitrag enthaelt eine URL.</div>
+      <div class="story-als">Als Benutzer moechte ich bei Links im Beitrag eine Vorschau sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Beitrag enthaelt eine URL.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1856,17 +1856,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Vorschau pruefen</td><td>API: GET /api/v1/feed/link-preview?url=...</td><td><input type="checkbox" data-cb="step_US_084_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_084_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Link-Vorschau zeigt: Titel, Beschreibung, Bild (optional), Seitenname</label>
-        <label><input type="checkbox" data-cb="crit_US_084_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Label &quot;Link-Vorschau&quot; wird angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_084_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Fallback bei nicht erreichbaren URLs</label>
+        <label><input type="checkbox" data-cb="crit_US_084_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Link-Vorschau zeigt: Titel, Beschreibung, Bild (optional), Seitenname</label>
+        <label><input type="checkbox" data-cb="crit_US_084_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Label &quot;Link-Vorschau&quot; wird angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_084_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Fallback bei nicht erreichbaren URLs</label>
       </div>
     </div>
     <div class="story" id="story-US_085" data-story="US-085" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-085</span> <span class="story-title">Anhang herunterladen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich Datei-Anhaenge von Beitraegen herunterladen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Beitrag hat Datei-Anhaenge.</div>
+      <div class="story-als">Als Benutzer moechte ich Datei-Anhaenge von Beitraegen herunterladen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Beitrag hat Datei-Anhaenge.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1874,17 +1874,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Auf einen Anhang klicken</td><td>Datei wird heruntergeladen</td><td><input type="checkbox" data-cb="step_US_085_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_085_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Download-URL: /api/v1/feed/attachments/{attachmentId}/download</label>
-        <label><input type="checkbox" data-cb="crit_US_085_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Dateiname, Dateityp und Groesse werden angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_085_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Icons fuer verschiedene Dateitypen (Bild, PDF, Video, Audio)</label>
+        <label><input type="checkbox" data-cb="crit_US_085_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Download-URL: /api/v1/feed/attachments/{attachmentId}/download</label>
+        <label><input type="checkbox" data-cb="crit_US_085_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Dateiname, Dateityp und Groesse werden angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_085_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Icons fuer verschiedene Dateitypen (Bild, PDF, Video, Audio)</label>
       </div>
     </div>
     <div class="story" id="story-US_086" data-story="US-086" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-086</span> <span class="story-title">Feed -- kein Beitrag ohne Inhalt</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich keine leeren Beitraege erstellen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> PostComposer ist sichtbar.</div>
+      <div class="story-als">Als Benutzer moechte ich keine leeren Beitraege erstellen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> PostComposer ist sichtbar.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1893,17 +1893,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Inhalt eingeben ODER Datei anhaengen ODER Umfrage erstellen</td><td>Button wird aktiv</td><td><input type="checkbox" data-cb="step_US_086_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_086_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Mindestens einer von: Inhalt, Datei-Anhang, Umfrage muss vorhanden sein</label>
-        <label><input type="checkbox" data-cb="crit_US_086_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Button &quot;Veroeffentlichen&quot; ist deaktiviert solange kein Inhalt vorhanden</label>
-        <label><input type="checkbox" data-cb="crit_US_086_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Titel allein reicht nicht aus</label>
+        <label><input type="checkbox" data-cb="crit_US_086_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Mindestens einer von: Inhalt, Datei-Anhang, Umfrage muss vorhanden sein</label>
+        <label><input type="checkbox" data-cb="crit_US_086_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Button &quot;Veroeffentlichen&quot; ist deaktiviert solange kein Inhalt vorhanden</label>
+        <label><input type="checkbox" data-cb="crit_US_086_2" data-crit="1" data-module="Feed" onchange="onCheck()"> Titel allein reicht nicht aus</label>
       </div>
     </div>
     <div class="story" id="story-US_087" data-story="US-087" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-087</span> <span class="story-title">Beitrag schulweit erstellen (nur SA)</span></div>
       </div>
-      <div class="story-als">Als SUPERADMIN moechte ich schulweite Beitraege im Dashboard erstellen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist SA.</div>
+      <div class="story-als">Als SUPERADMIN moechte ich schulweite Beitraege im Dashboard erstellen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist SA.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1913,17 +1913,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Als S Dashboard oeffnen</td><td>Schulweiter Beitrag ist sichtbar</td><td><input type="checkbox" data-cb="step_US_087_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_087_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Schulweite Beitraege sind fuer alle Benutzer sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_087_1" data-crit="1" data-module="Feed" onchange="onCheck()"> SourceType SCHOOL</label>
-        <label><input type="checkbox" data-cb="crit_US_087_2" data-crit="1" data-module="Feed" onchange="onCheck()"> PostComposer auf Dashboard erstellt schulweite Beitraege</label>
+        <label><input type="checkbox" data-cb="crit_US_087_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Schulweite Beitraege sind fuer alle Benutzer sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_087_1" data-crit="1" data-module="Feed" onchange="onCheck()"> SourceType SCHOOL</label>
+        <label><input type="checkbox" data-cb="crit_US_087_2" data-crit="1" data-module="Feed" onchange="onCheck()"> PostComposer auf Dashboard erstellt schulweite Beitraege</label>
       </div>
     </div>
     <div class="story" id="story-US_088" data-story="US-088" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-088</span> <span class="story-title">Video-Embed in Beitraegen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich eingebettete Videos in Beitraegen sehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Beitrag enthaelt einen Video-Link (z.B. YouTube).</div>
+      <div class="story-als">Als Benutzer moechte ich eingebettete Videos in Beitraegen sehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Beitrag enthaelt einen Video-Link (z.B. YouTube).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1931,16 +1931,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Video-Label pruefen</td><td>Label &quot;Video&quot; wird angezeigt</td><td><input type="checkbox" data-cb="step_US_088_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_088_0" data-crit="1" data-module="Feed" onchange="onCheck()"> YouTube- und aehnliche Video-Links werden eingebettet</label>
-        <label><input type="checkbox" data-cb="crit_US_088_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Fallback: normaler Link wenn Embed nicht moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_088_0" data-crit="1" data-module="Feed" onchange="onCheck()"> YouTube- und aehnliche Video-Links werden eingebettet</label>
+        <label><input type="checkbox" data-cb="crit_US_088_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Fallback: normaler Link wenn Embed nicht moeglich</label>
       </div>
     </div>
     <div class="story" id="story-US_089" data-story="US-089" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-089</span> <span class="story-title">Impersonation (SA)</span></div>
       </div>
-      <div class="story-als">Als SUPERADMIN moechte ich mich als anderer Benutzer anmelden koennen, damit ich Probleme nachstellen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt; Impersonation ist aktiviert.</div>
+      <div class="story-als">Als SUPERADMIN moechte ich mich als anderer Benutzer anmelden koennen, damit ich Probleme nachstellen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> SA ist eingeloggt; Impersonation ist aktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1949,18 +1949,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Button &quot;Zurueck zum Admin&quot; klicken</td><td>Zurueck zur SA-Session</td><td><input type="checkbox" data-cb="step_US_089_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_089_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Banner &quot;Angemeldet als {name} (Impersonation)&quot; wird angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_089_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Hinweis: &quot;Nur fuer Test- und Supportzwecke&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_089_2" data-crit="1" data-module="Feed" onchange="onCheck()"> &quot;Zurueck zum Admin&quot; beendet die Impersonation</label>
-        <label><input type="checkbox" data-cb="crit_US_089_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Sicherheitsrelevante Funktion -- nur wenn aktiviert</label>
+        <label><input type="checkbox" data-cb="crit_US_089_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Banner &quot;Angemeldet als {name} (Impersonation)&quot; wird angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_089_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Hinweis: &quot;Nur fuer Test- und Supportzwecke&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_089_2" data-crit="1" data-module="Feed" onchange="onCheck()"> &quot;Zurueck zum Admin&quot; beendet die Impersonation</label>
+        <label><input type="checkbox" data-cb="crit_US_089_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Sicherheitsrelevante Funktion -- nur wenn aktiviert</label>
       </div>
     </div>
     <div class="story" id="story-US_090" data-story="US-090" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-090</span> <span class="story-title">Zugriffsschutz -- unautorisierter API-Zugriff</span></div>
       </div>
-      <div class="story-als">Als nicht authentifizierter Benutzer moechte ich keinen Zugriff auf geschuetzte API-Endpunkte haben.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Kein gueltiger JWT-Token.</div>
+      <div class="story-als">Als nicht authentifizierter Benutzer moechte ich keinen Zugriff auf geschuetzte API-Endpunkte haben.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Kein gueltiger JWT-Token.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -1970,10 +1970,10 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>POST /api/v1/auth/login (oeffentlicher Endpunkt)</td><td>HTTP 200 (mit gueltigen Daten)</td><td><input type="checkbox" data-cb="step_US_090_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_090_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Alle geschuetzten Endpunkte geben 401 ohne Token zurueck</label>
-        <label><input type="checkbox" data-cb="crit_US_090_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Oeffentliche Endpunkte (login, register, password-reset) sind ohne Token erreichbar</label>
-        <label><input type="checkbox" data-cb="crit_US_090_2" data-crit="1" data-module="Feed" onchange="onCheck()"> JWT-Token hat 15 Minuten Gueltigkeit</label>
-        <label><input type="checkbox" data-cb="crit_US_090_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Refresh-Token hat 7 Tage Gueltigkeit (httpOnly Cookie)</label>
+        <label><input type="checkbox" data-cb="crit_US_090_0" data-crit="1" data-module="Feed" onchange="onCheck()"> Alle geschuetzten Endpunkte geben 401 ohne Token zurueck</label>
+        <label><input type="checkbox" data-cb="crit_US_090_1" data-crit="1" data-module="Feed" onchange="onCheck()"> Oeffentliche Endpunkte (login, register, password-reset) sind ohne Token erreichbar</label>
+        <label><input type="checkbox" data-cb="crit_US_090_2" data-crit="1" data-module="Feed" onchange="onCheck()"> JWT-Token hat 15 Minuten Gueltigkeit</label>
+        <label><input type="checkbox" data-cb="crit_US_090_3" data-crit="1" data-module="Feed" onchange="onCheck()"> Refresh-Token hat 7 Tage Gueltigkeit (httpOnly Cookie)</label>
       </div>
     </div>
   </div>
@@ -1991,8 +1991,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-100</span> <span class="story-title">Raum-Termin erstellen (LEADER)</span></div>
       </div>
-      <div class="story-als">Als Raumleiter (LEADER) moechte ich einen Termin fuer meinen Raum erstellen, damit alle Raummitglieder ueber anstehende Veranstaltungen informiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als LEADER in mindestens einem Raum eingetragen. Login als `lehrer@monteweb.local`.</div>
+      <div class="story-als">Als Raumleiter (LEADER) moechte ich einen Termin fuer meinen Raum erstellen, damit alle Raummitglieder ueber anstehende Veranstaltungen informiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als LEADER in mindestens einem Raum eingetragen. Login als `lehrer@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2008,18 +2008,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>10</td><td>Formular absenden</td><td>Toast &quot;Termin erstellt&quot; erscheint, Termin ist im Kalender sichtbar</td><td><input type="checkbox" data-cb="step_US_100_10" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_100_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin erscheint in der Kalenderansicht am richtigen Datum</label>
-        <label><input type="checkbox" data-cb="crit_US_100_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin ist nur fuer Mitglieder der Sonnengruppe sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_100_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin zeigt Titel, Beschreibung, Ort und Zeitraum korrekt an</label>
-        <label><input type="checkbox" data-cb="crit_US_100_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Ersteller wird als Autor des Termins angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_100_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin erscheint in der Kalenderansicht am richtigen Datum</label>
+        <label><input type="checkbox" data-cb="crit_US_100_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin ist nur fuer Mitglieder der Sonnengruppe sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_100_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin zeigt Titel, Beschreibung, Ort und Zeitraum korrekt an</label>
+        <label><input type="checkbox" data-cb="crit_US_100_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Ersteller wird als Autor des Termins angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_101" data-story="US-101" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-101</span> <span class="story-title">Bereichs-Termin erstellen (TEACHER)</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft moechte ich einen Termin fuer einen Schulbereich erstellen, damit alle Benutzer des Bereichs informiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (TEACHER).</div>
+      <div class="story-als">Als Lehrkraft moechte ich einen Termin fuer einen Schulbereich erstellen, damit alle Benutzer des Bereichs informiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (TEACHER).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2032,17 +2032,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Formular absenden</td><td>Toast &quot;Termin erstellt&quot; erscheint</td><td><input type="checkbox" data-cb="step_US_101_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_101_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin ist fuer alle Benutzer des gewaehlten Schulbereichs sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_101_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin ist NICHT fuer Benutzer anderer Bereiche sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_101_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> SECTION_ADMIN kann ebenfalls Bereichs-Termine erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_101_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin ist fuer alle Benutzer des gewaehlten Schulbereichs sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_101_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin ist NICHT fuer Benutzer anderer Bereiche sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_101_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> SECTION_ADMIN kann ebenfalls Bereichs-Termine erstellen</label>
       </div>
     </div>
     <div class="story" id="story-US_102" data-story="US-102" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-102</span> <span class="story-title">Schulweiten Termin erstellen (SUPERADMIN)</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich einen schulweiten Termin erstellen, damit alle Benutzer der Schule informiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local` (SUPERADMIN).</div>
+      <div class="story-als">Als Superadmin moechte ich einen schulweiten Termin erstellen, damit alle Benutzer der Schule informiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local` (SUPERADMIN).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2057,17 +2057,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>9</td><td>Formular absenden</td><td>Toast &quot;Termin erstellt&quot; erscheint</td><td><input type="checkbox" data-cb="step_US_102_9" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_102_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin ist fuer ALLE Benutzer der Schule sichtbar (SA, SECADMIN, T, P, S)</label>
-        <label><input type="checkbox" data-cb="crit_US_102_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur SUPERADMIN kann schulweite Termine erstellen</label>
-        <label><input type="checkbox" data-cb="crit_US_102_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Ganztaegiger Termin zeigt keine Uhrzeit an</label>
+        <label><input type="checkbox" data-cb="crit_US_102_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termin ist fuer ALLE Benutzer der Schule sichtbar (SA, SECADMIN, T, P, S)</label>
+        <label><input type="checkbox" data-cb="crit_US_102_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur SUPERADMIN kann schulweite Termine erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_102_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Ganztaegiger Termin zeigt keine Uhrzeit an</label>
       </div>
     </div>
     <div class="story" id="story-US_103" data-story="US-103" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-103</span> <span class="story-title">Berechtigungspruefung — Eltern koennen keine Termine erstellen</span></div>
       </div>
-      <div class="story-als">Als System moechte ich verhindern, dass Eltern oder Schueler Termine erstellen, damit nur autorisierte Rollen Termine anlegen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `eltern@monteweb.local` (PARENT).</div>
+      <div class="story-als">Als System moechte ich verhindern, dass Eltern oder Schueler Termine erstellen, damit nur autorisierte Rollen Termine anlegen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `eltern@monteweb.local` (PARENT).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2079,18 +2079,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>API-Aufruf `POST /api/v1/calendar/events` als PARENT</td><td>HTTP 400 oder 403 — Zugriff verweigert</td><td><input type="checkbox" data-cb="step_US_103_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_103_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> PARENT sieht keinen &quot;Termin erstellen&quot;-Button</label>
-        <label><input type="checkbox" data-cb="crit_US_103_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> STUDENT sieht keinen &quot;Termin erstellen&quot;-Button</label>
-        <label><input type="checkbox" data-cb="crit_US_103_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Direkter API-Zugriff wird abgelehnt</label>
-        <label><input type="checkbox" data-cb="crit_US_103_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur LEADER (Raum), TEACHER/SECADMIN (Bereich) und SUPERADMIN (Schulweit) koennen erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_103_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> PARENT sieht keinen &quot;Termin erstellen&quot;-Button</label>
+        <label><input type="checkbox" data-cb="crit_US_103_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> STUDENT sieht keinen &quot;Termin erstellen&quot;-Button</label>
+        <label><input type="checkbox" data-cb="crit_US_103_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Direkter API-Zugriff wird abgelehnt</label>
+        <label><input type="checkbox" data-cb="crit_US_103_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur LEADER (Raum), TEACHER/SECADMIN (Bereich) und SUPERADMIN (Schulweit) koennen erstellen</label>
       </div>
     </div>
     <div class="story" id="story-US_104" data-story="US-104" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-104</span> <span class="story-title">RSVP — Teilnahme zusagen/absagen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich meine Teilnahme an einem Termin zu- oder absagen, damit der Organisator die Teilnehmerzahl planen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Raum-Termin existiert, Benutzer ist Mitglied dieses Raums. Login als `eltern@monteweb.local`.</div>
+      <div class="story-als">Als Benutzer moechte ich meine Teilnahme an einem Termin zu- oder absagen, damit der Organisator die Teilnehmerzahl planen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Raum-Termin existiert, Benutzer ist Mitglied dieses Raums. Login als `eltern@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2101,18 +2101,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Erneut &quot;Zusage&quot; klicken</td><td>Status wechselt zurueck auf &quot;Zusage&quot;</td><td><input type="checkbox" data-cb="step_US_104_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_104_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Jeder Benutzer kann genau einen RSVP-Status pro Termin setzen (Zusage/Vielleicht/Absage)</label>
-        <label><input type="checkbox" data-cb="crit_US_104_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Zaehler fuer Zusagen, Vielleicht und Absagen werden korrekt angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_104_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> RSVP-Status ist nach Seitenneuladung persistent</label>
-        <label><input type="checkbox" data-cb="crit_US_104_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Alle Rollen (SA, SECADMIN, T, P, S) koennen RSVP abgeben</label>
+        <label><input type="checkbox" data-cb="crit_US_104_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Jeder Benutzer kann genau einen RSVP-Status pro Termin setzen (Zusage/Vielleicht/Absage)</label>
+        <label><input type="checkbox" data-cb="crit_US_104_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Zaehler fuer Zusagen, Vielleicht und Absagen werden korrekt angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_104_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> RSVP-Status ist nach Seitenneuladung persistent</label>
+        <label><input type="checkbox" data-cb="crit_US_104_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Alle Rollen (SA, SECADMIN, T, P, S) koennen RSVP abgeben</label>
       </div>
     </div>
     <div class="story" id="story-US_105" data-story="US-105" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-105</span> <span class="story-title">Termin absagen mit Feed-Benachrichtigung</span></div>
       </div>
-      <div class="story-als">Als Terminersteller moechte ich einen Termin absagen, damit alle Teilnehmer automatisch informiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Termin existiert mit mindestens einer RSVP-Zusage. Login als Ersteller des Termins.</div>
+      <div class="story-als">Als Terminersteller moechte ich einen Termin absagen, damit alle Teilnehmer automatisch informiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Termin existiert mit mindestens einer RSVP-Zusage. Login als Ersteller des Termins.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2123,18 +2123,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Feed pruefen (alle betroffenen Benutzer)</td><td>Absage-Beitrag erscheint im Feed fuer ALLE Benutzer im Scope</td><td><input type="checkbox" data-cb="step_US_105_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_105_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Abgesagter Termin zeigt deutlich &quot;Abgesagt&quot; im Kalender</label>
-        <label><input type="checkbox" data-cb="crit_US_105_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Feed-Post ueber Absage wird fuer alle Benutzer im Termin-Scope erstellt</label>
-        <label><input type="checkbox" data-cb="crit_US_105_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> RSVP-Buttons sind nach Absage deaktiviert</label>
-        <label><input type="checkbox" data-cb="crit_US_105_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann einen Termin absagen</label>
+        <label><input type="checkbox" data-cb="crit_US_105_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Abgesagter Termin zeigt deutlich &quot;Abgesagt&quot; im Kalender</label>
+        <label><input type="checkbox" data-cb="crit_US_105_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Feed-Post ueber Absage wird fuer alle Benutzer im Termin-Scope erstellt</label>
+        <label><input type="checkbox" data-cb="crit_US_105_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> RSVP-Buttons sind nach Absage deaktiviert</label>
+        <label><input type="checkbox" data-cb="crit_US_105_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann einen Termin absagen</label>
       </div>
     </div>
     <div class="story" id="story-US_106" data-story="US-106" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-106</span> <span class="story-title">Termin loeschen — Feed nur fuer Zusager</span></div>
       </div>
-      <div class="story-als">Als Terminersteller moechte ich einen Termin loeschen, damit er aus dem Kalender entfernt wird und nur Zusager informiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Termin existiert mit RSVP-Zusagen. Login als Ersteller.</div>
+      <div class="story-als">Als Terminersteller moechte ich einen Termin loeschen, damit er aus dem Kalender entfernt wird und nur Zusager informiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Termin existiert mit RSVP-Zusagen. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2146,18 +2146,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Feed pruefen als Benutzer OHNE Zusage</td><td>Kein Feed-Post ueber den geloeschten Termin</td><td><input type="checkbox" data-cb="step_US_106_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_106_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Geloeschter Termin ist aus der Kalenderansicht entfernt</label>
-        <label><input type="checkbox" data-cb="crit_US_106_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Feed-Benachrichtigung nur fuer Benutzer mit RSVP-Status &quot;Zusage&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_106_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Benutzer ohne Zusage erhalten KEINE Feed-Benachrichtigung</label>
-        <label><input type="checkbox" data-cb="crit_US_106_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_106_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Geloeschter Termin ist aus der Kalenderansicht entfernt</label>
+        <label><input type="checkbox" data-cb="crit_US_106_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Feed-Benachrichtigung nur fuer Benutzer mit RSVP-Status &quot;Zusage&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_106_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Benutzer ohne Zusage erhalten KEINE Feed-Benachrichtigung</label>
+        <label><input type="checkbox" data-cb="crit_US_106_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann loeschen</label>
       </div>
     </div>
     <div class="story" id="story-US_107" data-story="US-107" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-107</span> <span class="story-title">Termin bearbeiten</span></div>
       </div>
-      <div class="story-als">Als Terminersteller moechte ich einen bestehenden Termin bearbeiten, damit ich Aenderungen an Titel, Beschreibung, Ort oder Zeit vornehmen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein eigener Termin existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Terminersteller moechte ich einen bestehenden Termin bearbeiten, damit ich Aenderungen an Titel, Beschreibung, Ort oder Zeit vornehmen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein eigener Termin existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2169,18 +2169,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Termindetails erneut oeffnen</td><td>Aktualisierter Titel und Datum werden angezeigt</td><td><input type="checkbox" data-cb="step_US_107_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_107_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Alle Felder (Titel, Beschreibung, Ort, Datum, Zeit, Farbe) sind editierbar</label>
-        <label><input type="checkbox" data-cb="crit_US_107_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Scope (Raum/Bereich/Schule) kann NICHT nachtraeglich geaendert werden</label>
-        <label><input type="checkbox" data-cb="crit_US_107_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann bearbeiten</label>
-        <label><input type="checkbox" data-cb="crit_US_107_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> RSVP-Status der Teilnehmer bleibt nach Bearbeitung erhalten</label>
+        <label><input type="checkbox" data-cb="crit_US_107_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Alle Felder (Titel, Beschreibung, Ort, Datum, Zeit, Farbe) sind editierbar</label>
+        <label><input type="checkbox" data-cb="crit_US_107_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Scope (Raum/Bereich/Schule) kann NICHT nachtraeglich geaendert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_107_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann bearbeiten</label>
+        <label><input type="checkbox" data-cb="crit_US_107_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> RSVP-Status der Teilnehmer bleibt nach Bearbeitung erhalten</label>
       </div>
     </div>
     <div class="story" id="story-US_108" data-story="US-108" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-108</span> <span class="story-title">Wiederkehrende Termine erstellen</span></div>
       </div>
-      <div class="story-als">Als Raumleiter moechte ich einen wiederkehrenden Termin erstellen, damit regelmaessige Veranstaltungen automatisch im Kalender erscheinen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (LEADER in Sonnengruppe).</div>
+      <div class="story-als">Als Raumleiter moechte ich einen wiederkehrenden Termin erstellen, damit regelmaessige Veranstaltungen automatisch im Kalender erscheinen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (LEADER in Sonnengruppe).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2194,41 +2194,41 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Kalenderansicht auf 3-Monats-Ansicht wechseln</td><td>Termin erscheint jede Woche bis zum Enddatum</td><td><input type="checkbox" data-cb="step_US_108_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_108_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Wiederholungsoptionen: Keine, Taeglich, Woechentlich, Monatlich, Jaehrlich</label>
-        <label><input type="checkbox" data-cb="crit_US_108_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Feld &quot;Wiederholung bis&quot; erscheint nur bei Wiederholung != &quot;Keine&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_108_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termine werden korrekt in der Kalenderansicht angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_108_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Einzelne Wiederholungen koennen individuell bearbeitet/geloescht werden</label>
+        <label><input type="checkbox" data-cb="crit_US_108_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Wiederholungsoptionen: Keine, Taeglich, Woechentlich, Monatlich, Jaehrlich</label>
+        <label><input type="checkbox" data-cb="crit_US_108_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Feld &quot;Wiederholung bis&quot; erscheint nur bei Wiederholung != &quot;Keine&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_108_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Termine werden korrekt in der Kalenderansicht angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_108_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Einzelne Wiederholungen koennen individuell bearbeitet/geloescht werden</label>
       </div>
     </div>
     <div class="story" id="story-US_109" data-story="US-109" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-109</span> <span class="story-title">Kalenderansichten wechseln</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich zwischen verschiedenen Kalenderansichten wechseln, damit ich Termine in unterschiedlichen Zeitraeumen ueberblicken kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Termine existieren in verschiedenen Monaten. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich zwischen verschiedenen Kalenderansichten wechseln, damit ich Termine in unterschiedlichen Zeitraeumen ueberblicken kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Termine existieren in verschiedenen Monaten. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Kalender oeffnen</td><td>Standard-Ansicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_109_1" onchange="onCheck()"></td></tr>
-          <tr><td>2</td><td>Auf &quot;1 Monat&quot; klicken</td><td>Monatsansicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_109_2" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Auf &quot;Monat&quot; klicken</td><td>Monatsansicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_109_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Auf &quot;3 Monate&quot; klicken</td><td>3-Monats-Ansicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_109_3" onchange="onCheck()"></td></tr>
-          <tr><td>4</td><td>Auf &quot;Schuljahr&quot; klicken</td><td>Jahresansicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_109_4" onchange="onCheck()"></td></tr>
-          <tr><td>5</td><td>Auf &quot;Liste&quot; klicken</td><td>Listenansicht mit Terminen wird angezeigt</td><td><input type="checkbox" data-cb="step_US_109_5" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Auf &quot;Jahr&quot; klicken</td><td>Jahresansicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_109_4" onchange="onCheck()"></td></tr>
+          <tr><td>5</td><td>Auf &quot;Agenda&quot; klicken</td><td>Agenda-/Listenansicht mit Terminen wird angezeigt</td><td><input type="checkbox" data-cb="step_US_109_5" onchange="onCheck()"></td></tr>
           <tr><td>6</td><td>Button &quot;Heute&quot; klicken</td><td>Ansicht springt auf das aktuelle Datum</td><td><input type="checkbox" data-cb="step_US_109_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_109_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Vier Ansichten verfuegbar: Liste, 1 Monat, 3 Monate, Schuljahr</label>
-        <label><input type="checkbox" data-cb="crit_US_109_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> &quot;Heute&quot;-Button navigiert zum aktuellen Datum</label>
-        <label><input type="checkbox" data-cb="crit_US_109_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Feiertage werden rot markiert angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_109_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Schulferien werden orange markiert angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_109_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Vier Ansichten verfuegbar: Agenda, Monat, 3 Monate, Jahr</label>
+        <label><input type="checkbox" data-cb="crit_US_109_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> &quot;Heute&quot;-Button navigiert zum aktuellen Datum</label>
+        <label><input type="checkbox" data-cb="crit_US_109_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Feiertage werden rot markiert angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_109_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Schulferien werden grau markiert angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_110" data-story="US-110" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-110</span> <span class="story-title">Termin als .ics exportieren</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich einen einzelnen Termin als .ics-Datei exportieren, damit ich ihn in meinen persoenlichen Kalender importieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Termin existiert, auf den der Benutzer Zugriff hat. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich einen einzelnen Termin als .ics-Datei exportieren, damit ich ihn in meinen persoenlichen Kalender importieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Termin existiert, auf den der Benutzer Zugriff hat. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2238,18 +2238,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Datei in externem Kalender (z.B. Outlook, Google Calendar) importieren</td><td>Termin wird korrekt angezeigt mit Titel, Ort, Datum/Zeit</td><td><input type="checkbox" data-cb="step_US_110_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_110_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Export-Button ist fuer alle Benutzer sichtbar, die den Termin sehen koennen</label>
-        <label><input type="checkbox" data-cb="crit_US_110_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> .ics-Datei enthaelt VEVENT mit SUMMARY, DTSTART, DTEND, LOCATION, DESCRIPTION</label>
-        <label><input type="checkbox" data-cb="crit_US_110_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Content-Type der Antwort ist `text/calendar`</label>
-        <label><input type="checkbox" data-cb="crit_US_110_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Content-Disposition enthaelt `attachment; filename=&quot;event.ics&quot;`</label>
+        <label><input type="checkbox" data-cb="crit_US_110_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Export-Button ist fuer alle Benutzer sichtbar, die den Termin sehen koennen</label>
+        <label><input type="checkbox" data-cb="crit_US_110_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> .ics-Datei enthaelt VEVENT mit SUMMARY, DTSTART, DTEND, LOCATION, DESCRIPTION</label>
+        <label><input type="checkbox" data-cb="crit_US_110_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Content-Type der Antwort ist `text/calendar`</label>
+        <label><input type="checkbox" data-cb="crit_US_110_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Content-Disposition enthaelt `attachment; filename=&quot;event.ics&quot;`</label>
       </div>
     </div>
     <div class="story" id="story-US_111" data-story="US-111" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-111</span> <span class="story-title">iCal-Abonnement erstellen (SUPERADMIN)</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich ein externes iCal-Abonnement hinzufuegen, damit externe Kalender automatisch in den Schulkalender importiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local` (SUPERADMIN).</div>
+      <div class="story-als">Als Superadmin moechte ich ein externes iCal-Abonnement hinzufuegen, damit externe Kalender automatisch in den Schulkalender importiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local` (SUPERADMIN).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2263,18 +2263,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Kalenderansicht oeffnen, &quot;Importierte Termine anzeigen&quot; aktivieren</td><td>Importierte Termine werden in der gewaehlten Farbe angezeigt</td><td><input type="checkbox" data-cb="step_US_111_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_111_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> iCal-Abonnements sind nur fuer SUPERADMIN verwaltbar</label>
-        <label><input type="checkbox" data-cb="crit_US_111_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Importierte Termine werden mit eigener Farbe dargestellt</label>
-        <label><input type="checkbox" data-cb="crit_US_111_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Letzte Synchronisierung wird mit Zeitstempel angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_111_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Abonnement kann geloescht werden (Bestaetigungsdialog)</label>
+        <label><input type="checkbox" data-cb="crit_US_111_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> iCal-Abonnements sind nur fuer SUPERADMIN verwaltbar</label>
+        <label><input type="checkbox" data-cb="crit_US_111_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Importierte Termine werden mit eigener Farbe dargestellt</label>
+        <label><input type="checkbox" data-cb="crit_US_111_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Letzte Synchronisierung wird mit Zeitstempel angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_111_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Abonnement kann geloescht werden (Bestaetigungsdialog)</label>
       </div>
     </div>
     <div class="story" id="story-US_112" data-story="US-112" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-112</span> <span class="story-title">iCal-Abonnement loeschen</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich ein iCal-Abonnement loeschen, damit nicht mehr benoetigte externe Kalender entfernt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein iCal-Abonnement existiert. Login als `admin@monteweb.local`.</div>
+      <div class="story-als">Als Superadmin moechte ich ein iCal-Abonnement loeschen, damit nicht mehr benoetigte externe Kalender entfernt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein iCal-Abonnement existiert. Login als `admin@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2284,17 +2284,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Kalenderansicht pruefen</td><td>Importierte Termine des geloeschten Abonnements sind entfernt</td><td><input type="checkbox" data-cb="step_US_112_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_112_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
-        <label><input type="checkbox" data-cb="crit_US_112_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Zugehoerige importierte Termine werden mitgeloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_112_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur SUPERADMIN kann Abonnements loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_112_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
+        <label><input type="checkbox" data-cb="crit_US_112_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Zugehoerige importierte Termine werden mitgeloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_112_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur SUPERADMIN kann Abonnements loeschen</label>
       </div>
     </div>
     <div class="story" id="story-US_113" data-story="US-113" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-113</span> <span class="story-title">Jitsi-Videokonferenz zu Termin hinzufuegen</span></div>
       </div>
-      <div class="story-als">Als Terminersteller moechte ich eine Jitsi-Videokonferenz zu meinem Termin hinzufuegen, damit Teilnehmer online beitreten koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Jitsi-Modul ist aktiviert (Admin &gt; Module &gt; Jitsi). Ein eigener Termin existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Terminersteller moechte ich eine Jitsi-Videokonferenz zu meinem Termin hinzufuegen, damit Teilnehmer online beitreten koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Jitsi-Modul ist aktiviert (Admin &gt; Module &gt; Jitsi). Ein eigener Termin existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2305,18 +2305,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Button &quot;Videokonferenz entfernen&quot; klicken</td><td>Jitsi-Link wird entfernt, Button aendert sich zurueck zu &quot;Videokonferenz hinzufuegen&quot;</td><td><input type="checkbox" data-cb="step_US_113_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_113_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Jitsi-Button nur sichtbar, wenn Jitsi-Modul aktiviert ist</label>
-        <label><input type="checkbox" data-cb="crit_US_113_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Generierter Link ist ein gueltiger Jitsi-Raum-Name</label>
-        <label><input type="checkbox" data-cb="crit_US_113_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur Terminersteller oder SUPERADMIN kann Videokonferenz hinzufuegen/entfernen</label>
-        <label><input type="checkbox" data-cb="crit_US_113_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Alle Teilnehmer sehen den Jitsi-Link in den Termindetails</label>
+        <label><input type="checkbox" data-cb="crit_US_113_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Jitsi-Button nur sichtbar, wenn Jitsi-Modul aktiviert ist</label>
+        <label><input type="checkbox" data-cb="crit_US_113_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Generierter Link ist ein gueltiger Jitsi-Raum-Name</label>
+        <label><input type="checkbox" data-cb="crit_US_113_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Nur Terminersteller oder SUPERADMIN kann Videokonferenz hinzufuegen/entfernen</label>
+        <label><input type="checkbox" data-cb="crit_US_113_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Alle Teilnehmer sehen den Jitsi-Link in den Termindetails</label>
       </div>
     </div>
     <div class="story" id="story-US_114" data-story="US-114" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-114</span> <span class="story-title">Jitsi-Modul deaktiviert — kein Videokonferenz-Button</span></div>
       </div>
-      <div class="story-als">Als System moechte ich den Videokonferenz-Button ausblenden, wenn Jitsi deaktiviert ist, damit keine nicht verfuegbaren Funktionen angezeigt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Jitsi-Modul ist deaktiviert. Login als `admin@monteweb.local`.</div>
+      <div class="story-als">Als System moechte ich den Videokonferenz-Button ausblenden, wenn Jitsi deaktiviert ist, damit keine nicht verfuegbaren Funktionen angezeigt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Jitsi-Modul ist deaktiviert. Login als `admin@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2326,17 +2326,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>API-Aufruf `POST /api/v1/calendar/events/{id}/jitsi`</td><td>Fehlermeldung — Modul deaktiviert</td><td><input type="checkbox" data-cb="step_US_114_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_114_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Kein Jitsi-UI-Element sichtbar, wenn Modul deaktiviert</label>
-        <label><input type="checkbox" data-cb="crit_US_114_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> API lehnt Jitsi-Anfragen ab, wenn Modul deaktiviert</label>
-        <label><input type="checkbox" data-cb="crit_US_114_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Bereits vorhandene Jitsi-Links bleiben sichtbar, aber &quot;Entfernen&quot;-Button entfaellt</label>
+        <label><input type="checkbox" data-cb="crit_US_114_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Kein Jitsi-UI-Element sichtbar, wenn Modul deaktiviert</label>
+        <label><input type="checkbox" data-cb="crit_US_114_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> API lehnt Jitsi-Anfragen ab, wenn Modul deaktiviert</label>
+        <label><input type="checkbox" data-cb="crit_US_114_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Bereits vorhandene Jitsi-Links bleiben sichtbar, aber &quot;Entfernen&quot;-Button entfaellt</label>
       </div>
     </div>
     <div class="story" id="story-US_115" data-story="US-115" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-115</span> <span class="story-title">Farbmarkierung fuer Termine</span></div>
       </div>
-      <div class="story-als">Als Terminersteller moechte ich meinem Termin eine Farbe zuweisen, damit er im Kalender visuell hervorgehoben wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als Benutzer mit Terminberechtigungen.</div>
+      <div class="story-als">Als Terminersteller moechte ich meinem Termin eine Farbe zuweisen, damit er im Kalender visuell hervorgehoben wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als Benutzer mit Terminberechtigungen.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2348,18 +2348,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Kalenderansicht pruefen</td><td>Termin wird in der gewaehlten Farbe dargestellt</td><td><input type="checkbox" data-cb="step_US_115_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_115_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Vordefinierte Farbauswahl vorhanden</label>
-        <label><input type="checkbox" data-cb="crit_US_115_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Eigene Farbe per Farbwaehler moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_115_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Farbe wird in allen Kalenderansichten korrekt dargestellt</label>
-        <label><input type="checkbox" data-cb="crit_US_115_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Farbe kann nachtraeglich beim Bearbeiten geaendert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_115_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Vordefinierte Farbauswahl vorhanden</label>
+        <label><input type="checkbox" data-cb="crit_US_115_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Eigene Farbe per Farbwaehler moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_115_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Farbe wird in allen Kalenderansichten korrekt dargestellt</label>
+        <label><input type="checkbox" data-cb="crit_US_115_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Farbe kann nachtraeglich beim Bearbeiten geaendert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_116" data-story="US-116" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-116</span> <span class="story-title">Kalender mit Putzaktionen und Jobs</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich Putzaktionen und offene Jobs im Kalender ein-/ausblenden, damit ich eine vollstaendige Uebersicht ueber alle Termine habe.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Putzaktionen und Jobs existieren. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich Putzaktionen und offene Jobs im Kalender ein-/ausblenden, damit ich eine vollstaendige Uebersicht ueber alle Termine habe.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Putzaktionen und Jobs existieren. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2370,18 +2370,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Toggle &quot;Offene Jobs anzeigen&quot; deaktivieren</td><td>Jobs verschwinden</td><td><input type="checkbox" data-cb="step_US_116_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_116_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Putzaktionen werden mit speziellem Label &quot;Putzaktion&quot; dargestellt</label>
-        <label><input type="checkbox" data-cb="crit_US_116_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Jobs werden mit Label im Kalender dargestellt</label>
-        <label><input type="checkbox" data-cb="crit_US_116_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Toggles sind persistent (bleiben nach Seitenneuladen erhalten)</label>
-        <label><input type="checkbox" data-cb="crit_US_116_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Putzaktionen und Jobs sind visuell von normalen Terminen unterscheidbar</label>
+        <label><input type="checkbox" data-cb="crit_US_116_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Putzaktionen werden mit speziellem Label &quot;Putzaktion&quot; dargestellt</label>
+        <label><input type="checkbox" data-cb="crit_US_116_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Jobs werden mit Label im Kalender dargestellt</label>
+        <label><input type="checkbox" data-cb="crit_US_116_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Toggles sind persistent (bleiben nach Seitenneuladen erhalten)</label>
+        <label><input type="checkbox" data-cb="crit_US_116_3" data-crit="1" data-module="Kalender" onchange="onCheck()"> Putzaktionen und Jobs sind visuell von normalen Terminen unterscheidbar</label>
       </div>
     </div>
     <div class="story" id="story-US_117" data-story="US-117" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-117</span> <span class="story-title">Gesamtkalender exportieren</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich meinen gesamten Kalender als .ics-Datei exportieren, damit ich alle Termine in einem externen Kalender abonnieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Termine existieren. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich meinen gesamten Kalender als .ics-Datei exportieren, damit ich alle Termine in einem externen Kalender abonnieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Termine existieren. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2390,9 +2390,9 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Datei pruefen</td><td>Datei enthaelt VCALENDAR mit allen Terminen als VEVENT-Eintraege</td><td><input type="checkbox" data-cb="step_US_117_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_117_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Export enthaelt nur Termine, die der Benutzer sehen darf</label>
-        <label><input type="checkbox" data-cb="crit_US_117_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Alle Termin-Details (Titel, Beschreibung, Ort, Datum) sind in der Exportdatei</label>
-        <label><input type="checkbox" data-cb="crit_US_117_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Dateiformat ist valides iCalendar (RFC 5545)</label>
+        <label><input type="checkbox" data-cb="crit_US_117_0" data-crit="1" data-module="Kalender" onchange="onCheck()"> Export enthaelt nur Termine, die der Benutzer sehen darf</label>
+        <label><input type="checkbox" data-cb="crit_US_117_1" data-crit="1" data-module="Kalender" onchange="onCheck()"> Alle Termin-Details (Titel, Beschreibung, Ort, Datum) sind in der Exportdatei</label>
+        <label><input type="checkbox" data-cb="crit_US_117_2" data-crit="1" data-module="Kalender" onchange="onCheck()"> Dateiformat ist valides iCalendar (RFC 5545)</label>
       </div>
     </div>
   </div>
@@ -2410,8 +2410,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-120</span> <span class="story-title">Direktnachricht starten</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich eine Direktnachricht an einen anderen Benutzer senden, damit ich privat kommunizieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Messaging-Modul ist aktiviert. Login als `lehrer@monteweb.local` (TEACHER).</div>
+      <div class="story-als">Als Benutzer moechte ich eine Direktnachricht an einen anderen Benutzer senden, damit ich privat kommunizieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Messaging-Modul ist aktiviert. Login als `lehrer@monteweb.local` (TEACHER).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2424,18 +2424,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Senden-Button klicken oder Enter druecken</td><td>Nachricht erscheint im Chatverlauf</td><td><input type="checkbox" data-cb="step_US_120_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_120_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Konversation erscheint in der Konversationsliste beider Teilnehmer</label>
-        <label><input type="checkbox" data-cb="crit_US_120_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Nachricht zeigt Absendername, Inhalt und Zeitstempel</label>
-        <label><input type="checkbox" data-cb="crit_US_120_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Ungelesene Nachrichten werden mit Badge/Zaehler angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_120_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Lehrer kann an Eltern schreiben (immer erlaubt)</label>
+        <label><input type="checkbox" data-cb="crit_US_120_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Konversation erscheint in der Konversationsliste beider Teilnehmer</label>
+        <label><input type="checkbox" data-cb="crit_US_120_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Nachricht zeigt Absendername, Inhalt und Zeitstempel</label>
+        <label><input type="checkbox" data-cb="crit_US_120_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Ungelesene Nachrichten werden mit Badge/Zaehler angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_120_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Lehrer kann an Eltern schreiben (immer erlaubt)</label>
       </div>
     </div>
     <div class="story" id="story-US_121" data-story="US-121" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-121</span> <span class="story-title">Gruppenchat erstellen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich einen Gruppenchat mit mehreren Teilnehmern erstellen, damit wir gemeinsam kommunizieren koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local`.</div>
+      <div class="story-als">Als Benutzer moechte ich einen Gruppenchat mit mehreren Teilnehmern erstellen, damit wir gemeinsam kommunizieren koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2447,18 +2447,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Nachricht senden: &quot;Willkommen in der Gruppe!&quot;</td><td>Nachricht erscheint fuer alle Teilnehmer</td><td><input type="checkbox" data-cb="step_US_121_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_121_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Gruppenname wird in der Konversationsliste angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_121_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Alle Teilnehmer sehen die Konversation und empfangen Nachrichten</label>
-        <label><input type="checkbox" data-cb="crit_US_121_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Gruppenchat ist als Gruppe markiert (isGroup = true)</label>
-        <label><input type="checkbox" data-cb="crit_US_121_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Mindestens 2 Empfaenger muessen ausgewaehlt werden fuer Gruppenkonversation</label>
+        <label><input type="checkbox" data-cb="crit_US_121_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Gruppenname wird in der Konversationsliste angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_121_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Alle Teilnehmer sehen die Konversation und empfangen Nachrichten</label>
+        <label><input type="checkbox" data-cb="crit_US_121_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Gruppenchat ist als Gruppe markiert (isGroup = true)</label>
+        <label><input type="checkbox" data-cb="crit_US_121_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Mindestens 2 Empfaenger muessen ausgewaehlt werden fuer Gruppenkonversation</label>
       </div>
     </div>
     <div class="story" id="story-US_122" data-story="US-122" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-122</span> <span class="story-title">Bild in Nachricht senden</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich ein Bild in einer Nachricht senden, damit ich visuelle Inhalte teilen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation existiert. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich ein Bild in einer Nachricht senden, damit ich visuelle Inhalte teilen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation existiert. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2470,20 +2470,20 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Auf das Bild klicken</td><td>Bild wird in voller Groesse angezeigt</td><td><input type="checkbox" data-cb="step_US_122_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_122_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Unterstuetzte Formate: JPEG, PNG, WebP, GIF</label>
-        <label><input type="checkbox" data-cb="crit_US_122_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Maximale Dateigroesse: 10 MB</label>
-        <label><input type="checkbox" data-cb="crit_US_122_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Thumbnail wird im Chat angezeigt, Klick zeigt Originalbild</label>
-        <label><input type="checkbox" data-cb="crit_US_122_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Nachricht kann nur Bild (ohne Text) enthalten</label>
-        <label><input type="checkbox" data-cb="crit_US_122_4" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Fehlermeldung bei ungueltigem Format: &quot;Ungueltiges Bildformat. Erlaubt: JPEG, PNG, WebP, GIF&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_122_5" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Fehlermeldung bei zu grosser Datei: &quot;Datei ist zu gross. Maximal 10 MB erlaubt.&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_122_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Unterstuetzte Formate: JPEG, PNG, WebP, GIF</label>
+        <label><input type="checkbox" data-cb="crit_US_122_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Maximale Dateigroesse: 10 MB</label>
+        <label><input type="checkbox" data-cb="crit_US_122_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Thumbnail wird im Chat angezeigt, Klick zeigt Originalbild</label>
+        <label><input type="checkbox" data-cb="crit_US_122_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Nachricht kann nur Bild (ohne Text) enthalten</label>
+        <label><input type="checkbox" data-cb="crit_US_122_4" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Fehlermeldung bei ungueltigem Format: &quot;Ungueltiges Bildformat. Erlaubt: JPEG, PNG, WebP, GIF&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_122_5" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Fehlermeldung bei zu grosser Datei: &quot;Datei ist zu gross. Maximal 10 MB erlaubt.&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_123" data-story="US-123" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-123</span> <span class="story-title">Auf Nachricht antworten (Reply-Threading)</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich auf eine bestimmte Nachricht antworten, damit der Kontext der Antwort klar ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation mit mehreren Nachrichten existiert. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich auf eine bestimmte Nachricht antworten, damit der Kontext der Antwort klar ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation mit mehreren Nachrichten existiert. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2494,18 +2494,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Originalnachricht loeschen (falls moeglich)</td><td>reply_to wird auf NULL gesetzt, Antwort bleibt erhalten</td><td><input type="checkbox" data-cb="step_US_123_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_123_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Reply-Vorschau zeigt Absendername und gekuerzten Inhalt der Originalnachricht</label>
-        <label><input type="checkbox" data-cb="crit_US_123_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Antwort-Nachricht zeigt visuell den Bezug zur Originalnachricht</label>
-        <label><input type="checkbox" data-cb="crit_US_123_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bei Antwort auf Bild-Nachricht wird &quot;hat ein Bild&quot; als Vorschau angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_123_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Loeschung der Originalnachricht entfernt den Verweis (ON DELETE SET NULL), Antwort bleibt</label>
+        <label><input type="checkbox" data-cb="crit_US_123_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Reply-Vorschau zeigt Absendername und gekuerzten Inhalt der Originalnachricht</label>
+        <label><input type="checkbox" data-cb="crit_US_123_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Antwort-Nachricht zeigt visuell den Bezug zur Originalnachricht</label>
+        <label><input type="checkbox" data-cb="crit_US_123_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bei Antwort auf Bild-Nachricht wird &quot;hat ein Bild&quot; als Vorschau angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_123_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Loeschung der Originalnachricht entfernt den Verweis (ON DELETE SET NULL), Antwort bleibt</label>
       </div>
     </div>
     <div class="story" id="story-US_124" data-story="US-124" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-124</span> <span class="story-title">Reaktionen auf Nachrichten</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich auf eine Nachricht mit einem Emoji reagieren, damit ich schnell Feedback geben kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation mit Nachrichten existiert. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich auf eine Nachricht mit einem Emoji reagieren, damit ich schnell Feedback geben kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation mit Nachrichten existiert. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2516,18 +2516,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Reaktion erneut hinzufuegen, anderer Benutzer reagiert ebenfalls</td><td>Zaehler zeigt &quot;2&quot;, eigene Reaktion ist hervorgehoben</td><td><input type="checkbox" data-cb="step_US_124_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_124_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Mehrere Emoji-Reaktionen pro Nachricht moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_124_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Jeder Benutzer kann pro Emoji nur einmal reagieren (Toggle)</label>
-        <label><input type="checkbox" data-cb="crit_US_124_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Zaehler zeigt Gesamtanzahl der Reaktionen pro Emoji</label>
-        <label><input type="checkbox" data-cb="crit_US_124_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Eigene Reaktionen sind visuell hervorgehoben (userReacted)</label>
+        <label><input type="checkbox" data-cb="crit_US_124_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Mehrere Emoji-Reaktionen pro Nachricht moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_124_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Jeder Benutzer kann pro Emoji nur einmal reagieren (Toggle)</label>
+        <label><input type="checkbox" data-cb="crit_US_124_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Zaehler zeigt Gesamtanzahl der Reaktionen pro Emoji</label>
+        <label><input type="checkbox" data-cb="crit_US_124_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Eigene Reaktionen sind visuell hervorgehoben (userReacted)</label>
       </div>
     </div>
     <div class="story" id="story-US_125" data-story="US-125" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-125</span> <span class="story-title">Konversation stummschalten</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich eine Konversation stummschalten, damit ich keine Benachrichtigungen mehr erhalte.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Konversation existiert. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich eine Konversation stummschalten, damit ich keine Benachrichtigungen mehr erhalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Konversation existiert. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2539,19 +2539,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>&quot;Stummschaltung aufheben&quot;-Button auf der Profilseite klicken</td><td>Stummschaltung wird aufgehoben</td><td><input type="checkbox" data-cb="step_US_125_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_125_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Stummgeschaltete Konversation zeigt &quot;Stumm&quot;-Indikator in der Liste</label>
-        <label><input type="checkbox" data-cb="crit_US_125_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Keine Push-Benachrichtigungen fuer stummgeschaltete Konversationen</label>
-        <label><input type="checkbox" data-cb="crit_US_125_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Nachrichten werden weiterhin empfangen und im Chat angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_125_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Profilseite zeigt alle stummgeschalteten Chats mit Unmute-Buttons</label>
-        <label><input type="checkbox" data-cb="crit_US_125_4" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Stummschaltung ist fuer DMs und Gruppenchats moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_125_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Stummgeschaltete Konversation zeigt &quot;Stumm&quot;-Indikator in der Liste</label>
+        <label><input type="checkbox" data-cb="crit_US_125_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Keine Push-Benachrichtigungen fuer stummgeschaltete Konversationen</label>
+        <label><input type="checkbox" data-cb="crit_US_125_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Nachrichten werden weiterhin empfangen und im Chat angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_125_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Profilseite zeigt alle stummgeschalteten Chats mit Unmute-Buttons</label>
+        <label><input type="checkbox" data-cb="crit_US_125_4" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Stummschaltung ist fuer DMs und Gruppenchats moeglich</label>
       </div>
     </div>
     <div class="story" id="story-US_126" data-story="US-126" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-126</span> <span class="story-title">Kommunikationsregeln — Lehrer-Eltern immer erlaubt</span></div>
       </div>
-      <div class="story-als">Als System moechte ich sicherstellen, dass Lehrer und Eltern immer kommunizieren duerfen, damit die paedagogische Kommunikation nicht eingeschraenkt wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (TEACHER).</div>
+      <div class="story-als">Als System moechte ich sicherstellen, dass Lehrer und Eltern immer kommunizieren duerfen, damit die paedagogische Kommunikation nicht eingeschraenkt wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (TEACHER).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2563,18 +2563,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>&quot;Nachrichten&quot; oeffnen, &quot;Neue Konversation&quot; zu einem Lehrer starten</td><td>Konversation wird erfolgreich erstellt</td><td><input type="checkbox" data-cb="step_US_126_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_126_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Lehrer kann immer an Eltern schreiben (unabhaengig von Kommunikationsregeln)</label>
-        <label><input type="checkbox" data-cb="crit_US_126_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Eltern kann immer an Lehrer schreiben</label>
-        <label><input type="checkbox" data-cb="crit_US_126_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> SUPERADMIN, SECTION_ADMIN und TEACHER gelten als &quot;Staff&quot; und koennen an alle schreiben</label>
-        <label><input type="checkbox" data-cb="crit_US_126_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Diese Regel kann NICHT deaktiviert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_126_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Lehrer kann immer an Eltern schreiben (unabhaengig von Kommunikationsregeln)</label>
+        <label><input type="checkbox" data-cb="crit_US_126_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Eltern kann immer an Lehrer schreiben</label>
+        <label><input type="checkbox" data-cb="crit_US_126_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> SUPERADMIN, SECTION_ADMIN und TEACHER gelten als &quot;Staff&quot; und koennen an alle schreiben</label>
+        <label><input type="checkbox" data-cb="crit_US_126_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Diese Regel kann NICHT deaktiviert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_127" data-story="US-127" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-127</span> <span class="story-title">Kommunikationsregeln — Eltern-zu-Eltern konfigurierbar</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich die Eltern-zu-Eltern-Kommunikation ein-/ausschalten, damit ich die Kommunikationsregeln der Schule steuern kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local` (SUPERADMIN).</div>
+      <div class="story-als">Als Superadmin moechte ich die Eltern-zu-Eltern-Kommunikation ein-/ausschalten, damit ich die Kommunikationsregeln der Schule steuern kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local` (SUPERADMIN).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2588,18 +2588,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Logout, Login als Eltern, erneut Konversation mit anderem Eltern starten</td><td>Konversation wird erfolgreich erstellt</td><td><input type="checkbox" data-cb="step_US_127_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_127_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Standard: Eltern-zu-Eltern-Kommunikation ist DEAKTIVIERT</label>
-        <label><input type="checkbox" data-cb="crit_US_127_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Admin kann die Einstellung jederzeit aendern</label>
-        <label><input type="checkbox" data-cb="crit_US_127_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bei deaktivierter Einstellung: Fehlermeldung fuer Eltern beim Versuch</label>
-        <label><input type="checkbox" data-cb="crit_US_127_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bestehende Konversationen werden durch Aenderung NICHT betroffen</label>
+        <label><input type="checkbox" data-cb="crit_US_127_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Standard: Eltern-zu-Eltern-Kommunikation ist DEAKTIVIERT</label>
+        <label><input type="checkbox" data-cb="crit_US_127_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Admin kann die Einstellung jederzeit aendern</label>
+        <label><input type="checkbox" data-cb="crit_US_127_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bei deaktivierter Einstellung: Fehlermeldung fuer Eltern beim Versuch</label>
+        <label><input type="checkbox" data-cb="crit_US_127_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bestehende Konversationen werden durch Aenderung NICHT betroffen</label>
       </div>
     </div>
     <div class="story" id="story-US_128" data-story="US-128" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-128</span> <span class="story-title">Kommunikationsregeln — Schueler-zu-Schueler konfigurierbar</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich die Schueler-zu-Schueler-Kommunikation ein-/ausschalten, damit ich altersgerechte Kommunikation sicherstellen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
+      <div class="story-als">Als Superadmin moechte ich die Schueler-zu-Schueler-Kommunikation ein-/ausschalten, damit ich altersgerechte Kommunikation sicherstellen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2611,17 +2611,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Konversation zu Lehrer starten</td><td>Konversation wird erfolgreich erstellt (Schueler-Lehrer immer erlaubt)</td><td><input type="checkbox" data-cb="step_US_128_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_128_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Standard: Schueler-zu-Schueler-Kommunikation ist konfigurierbar</label>
-        <label><input type="checkbox" data-cb="crit_US_128_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Schueler koennen immer an Lehrkraefte schreiben</label>
-        <label><input type="checkbox" data-cb="crit_US_128_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Eltern-Schueler-Kommunikation (ausserhalb Staff) ist standardmaessig gesperrt</label>
+        <label><input type="checkbox" data-cb="crit_US_128_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Standard: Schueler-zu-Schueler-Kommunikation ist konfigurierbar</label>
+        <label><input type="checkbox" data-cb="crit_US_128_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Schueler koennen immer an Lehrkraefte schreiben</label>
+        <label><input type="checkbox" data-cb="crit_US_128_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Eltern-Schueler-Kommunikation (ausserhalb Staff) ist standardmaessig gesperrt</label>
       </div>
     </div>
     <div class="story" id="story-US_129" data-story="US-129" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-129</span> <span class="story-title">Ungelesene Nachrichten und Zaehler</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die Anzahl ungelesener Nachrichten sehen, damit ich weiss, ob neue Nachrichten vorliegen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als Benutzer mit mindestens einer Konversation.</div>
+      <div class="story-als">Als Benutzer moechte ich die Anzahl ungelesener Nachrichten sehen, damit ich weiss, ob neue Nachrichten vorliegen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als Benutzer mit mindestens einer Konversation.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2631,18 +2631,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Gesamt-Zaehler im Menue pruefen</td><td>Gesamt-Zaehler hat sich verringert</td><td><input type="checkbox" data-cb="step_US_129_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_129_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Ungelesen-Badge in der Hauptnavigation zeigt Gesamtanzahl</label>
-        <label><input type="checkbox" data-cb="crit_US_129_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Jede Konversation zeigt individuellen Ungelesen-Zaehler</label>
-        <label><input type="checkbox" data-cb="crit_US_129_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Oeffnen einer Konversation markiert alle Nachrichten als gelesen</label>
-        <label><input type="checkbox" data-cb="crit_US_129_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Zaehler aktualisiert sich in Echtzeit (WebSocket)</label>
+        <label><input type="checkbox" data-cb="crit_US_129_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Ungelesen-Badge in der Hauptnavigation zeigt Gesamtanzahl</label>
+        <label><input type="checkbox" data-cb="crit_US_129_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Jede Konversation zeigt individuellen Ungelesen-Zaehler</label>
+        <label><input type="checkbox" data-cb="crit_US_129_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Oeffnen einer Konversation markiert alle Nachrichten als gelesen</label>
+        <label><input type="checkbox" data-cb="crit_US_129_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Zaehler aktualisiert sich in Echtzeit (WebSocket)</label>
       </div>
     </div>
     <div class="story" id="story-US_130" data-story="US-130" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-130</span> <span class="story-title">WebSocket-Echtzeitnachrichten</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich neue Nachrichten in Echtzeit empfangen, damit ich ohne Seitenneuladen kommunizieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Zwei Benutzer sind gleichzeitig eingeloggt und haben eine gemeinsame Konversation.</div>
+      <div class="story-als">Als Benutzer moechte ich neue Nachrichten in Echtzeit empfangen, damit ich ohne Seitenneuladen kommunizieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Zwei Benutzer sind gleichzeitig eingeloggt und haben eine gemeinsame Konversation.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2653,18 +2653,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Benutzer B antwortet: &quot;Hallo A!&quot;</td><td>Nachricht erscheint sofort bei beiden Benutzern</td><td><input type="checkbox" data-cb="step_US_130_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_130_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Nachrichten erscheinen in Echtzeit ohne Seitenneuladen</label>
-        <label><input type="checkbox" data-cb="crit_US_130_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> WebSocket-Verbindung ueber `/ws/messages`</label>
-        <label><input type="checkbox" data-cb="crit_US_130_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bei Verbindungsabbruch: automatische Wiederverbindung</label>
-        <label><input type="checkbox" data-cb="crit_US_130_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Neue Nachrichten in nicht-geoeffneten Konversationen aktualisieren den Ungelesen-Zaehler</label>
+        <label><input type="checkbox" data-cb="crit_US_130_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Nachrichten erscheinen in Echtzeit ohne Seitenneuladen</label>
+        <label><input type="checkbox" data-cb="crit_US_130_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> WebSocket-Verbindung ueber STOMP-Endpoint `/ws` (Client abonniert `/user/queue/messages`)</label>
+        <label><input type="checkbox" data-cb="crit_US_130_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bei Verbindungsabbruch: automatische Wiederverbindung</label>
+        <label><input type="checkbox" data-cb="crit_US_130_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Neue Nachrichten in nicht-geoeffneten Konversationen aktualisieren den Ungelesen-Zaehler</label>
       </div>
     </div>
     <div class="story" id="story-US_131" data-story="US-131" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-131</span> <span class="story-title">Konversation loeschen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich eine Konversation aus meiner Liste entfernen, damit ich meine Nachrichtenueebersicht aufgeraeumt halten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Konversation existiert. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich eine Konversation aus meiner Liste entfernen, damit ich meine Nachrichtenueebersicht aufgeraeumt halten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Konversation existiert. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2674,18 +2674,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefen: anderer Teilnehmer sieht Konversation weiterhin</td><td>Konversation ist beim anderen Teilnehmer noch sichtbar</td><td><input type="checkbox" data-cb="step_US_131_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_131_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Loeschung entfernt Konversation nur fuer den aktuellen Benutzer</label>
-        <label><input type="checkbox" data-cb="crit_US_131_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Andere Teilnehmer behalten die Konversation</label>
-        <label><input type="checkbox" data-cb="crit_US_131_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
-        <label><input type="checkbox" data-cb="crit_US_131_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Geloeschte Konversation kann nicht wiederhergestellt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_131_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Loeschung entfernt Konversation nur fuer den aktuellen Benutzer</label>
+        <label><input type="checkbox" data-cb="crit_US_131_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Andere Teilnehmer behalten die Konversation</label>
+        <label><input type="checkbox" data-cb="crit_US_131_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
+        <label><input type="checkbox" data-cb="crit_US_131_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Geloeschte Konversation kann nicht wiederhergestellt werden</label>
       </div>
     </div>
     <div class="story" id="story-US_132" data-story="US-132" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-132</span> <span class="story-title">Datei-Anhaenge in Nachrichten</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich PDF-Dateien an Nachrichten anhaengen oder Raum-Dateien verlinken, damit ich Dokumente teilen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation existiert. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich PDF-Dateien an Nachrichten anhaengen oder Raum-Dateien verlinken, damit ich Dokumente teilen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation existiert. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2698,18 +2698,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Raum und Datei auswaehlen</td><td>Datei-Link wird in Nachricht eingebettet</td><td><input type="checkbox" data-cb="step_US_132_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_132_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> PDF-Dateien koennen direkt angehangen werden</label>
-        <label><input type="checkbox" data-cb="crit_US_132_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Raum-Dateien koennen verlinkt werden (FILE_LINK-Typ)</label>
-        <label><input type="checkbox" data-cb="crit_US_132_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Anhang zeigt Dateiname, Dateityp und Groesse</label>
-        <label><input type="checkbox" data-cb="crit_US_132_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Download des Anhangs funktioniert fuer alle Konversationsteilnehmer</label>
+        <label><input type="checkbox" data-cb="crit_US_132_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> PDF-Dateien koennen direkt angehangen werden</label>
+        <label><input type="checkbox" data-cb="crit_US_132_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Raum-Dateien koennen verlinkt werden (FILE_LINK-Typ)</label>
+        <label><input type="checkbox" data-cb="crit_US_132_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Anhang zeigt Dateiname, Dateityp und Groesse</label>
+        <label><input type="checkbox" data-cb="crit_US_132_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Download des Anhangs funktioniert fuer alle Konversationsteilnehmer</label>
       </div>
     </div>
     <div class="story" id="story-US_133" data-story="US-133" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-133</span> <span class="story-title">Messaging-Modul deaktiviert</span></div>
       </div>
-      <div class="story-als">Als System moechte ich das Messaging-Modul komplett ausblenden koennen, damit die Schule das Feature bei Bedarf abschalten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
+      <div class="story-als">Als System moechte ich das Messaging-Modul komplett ausblenden koennen, damit die Schule das Feature bei Bedarf abschalten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2720,18 +2720,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>API-Aufruf `GET /api/v1/messages/conversations`</td><td>HTTP 404 oder 503</td><td><input type="checkbox" data-cb="step_US_133_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_133_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bei deaktiviertem Modul: kein Menue-Eintrag &quot;Nachrichten&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_133_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Direkter URL-Zugriff wird abgefangen</label>
-        <label><input type="checkbox" data-cb="crit_US_133_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> API-Endpunkte sind nicht erreichbar</label>
-        <label><input type="checkbox" data-cb="crit_US_133_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Reaktivierung stellt alle Konversationen wieder her</label>
+        <label><input type="checkbox" data-cb="crit_US_133_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Bei deaktiviertem Modul: kein Menue-Eintrag &quot;Nachrichten&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_133_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Direkter URL-Zugriff wird abgefangen</label>
+        <label><input type="checkbox" data-cb="crit_US_133_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> API-Endpunkte sind nicht erreichbar</label>
+        <label><input type="checkbox" data-cb="crit_US_133_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Reaktivierung stellt alle Konversationen wieder her</label>
       </div>
     </div>
     <div class="story" id="story-US_134" data-story="US-134" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-134</span> <span class="story-title">Umfrage in Nachricht erstellen (Poll)</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich eine Umfrage in einer Konversation erstellen, damit ich schnell Meinungen einholen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation existiert. Login als beliebiger Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich eine Umfrage in einer Konversation erstellen, damit ich schnell Meinungen einholen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Konversation existiert. Login als beliebiger Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2745,11 +2745,11 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Ersteller schliesst die Umfrage</td><td>Umfrage wird als &quot;geschlossen&quot; markiert, keine weiteren Stimmen moeglich</td><td><input type="checkbox" data-cb="step_US_134_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_134_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Frage und mindestens 2 Optionen sind Pflicht</label>
-        <label><input type="checkbox" data-cb="crit_US_134_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Mehrfachauswahl kann aktiviert/deaktiviert werden</label>
-        <label><input type="checkbox" data-cb="crit_US_134_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Jeder Teilnehmer kann abstimmen (erneute Abstimmung aendert die Stimme)</label>
-        <label><input type="checkbox" data-cb="crit_US_134_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Stimmenanzahl und prozentuale Verteilung werden angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_134_4" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Nur Ersteller kann die Umfrage schliessen</label>
+        <label><input type="checkbox" data-cb="crit_US_134_0" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Frage und mindestens 2 Optionen sind Pflicht</label>
+        <label><input type="checkbox" data-cb="crit_US_134_1" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Mehrfachauswahl kann aktiviert/deaktiviert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_134_2" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Jeder Teilnehmer kann abstimmen (erneute Abstimmung aendert die Stimme)</label>
+        <label><input type="checkbox" data-cb="crit_US_134_3" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Stimmenanzahl und prozentuale Verteilung werden angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_134_4" data-crit="1" data-module="Nachrichten_Messaging" onchange="onCheck()"> Ersteller oder Personal (SUPERADMIN/SECTION_ADMIN/TEACHER) koennen die Umfrage schliessen</label>
       </div>
     </div>
   </div>
@@ -2767,8 +2767,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-140</span> <span class="story-title">Datei in Raum hochladen</span></div>
       </div>
-      <div class="story-als">Als Raummitglied moechte ich eine Datei in den Raum hochladen, damit ich Materialien mit anderen Mitgliedern teilen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raums. Login als `lehrer@monteweb.local`.</div>
+      <div class="story-als">Als Raummitglied moechte ich eine Datei in den Raum hochladen, damit ich Materialien mit anderen Mitgliedern teilen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raums. Login als `lehrer@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2780,18 +2780,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Upload abgeschlossen</td><td>Datei erscheint in der Dateiliste mit Name, Groesse, Hochlade-Datum</td><td><input type="checkbox" data-cb="step_US_140_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_140_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Datei wird in MinIO gespeichert</label>
-        <label><input type="checkbox" data-cb="crit_US_140_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Dateiliste zeigt: Dateiname, Dateityp (Content-Type), Groesse, Hochgeladen von, Datum</label>
-        <label><input type="checkbox" data-cb="crit_US_140_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Alle Raummitglieder koennen die Datei sehen (bei Audience &quot;Alle&quot;)</label>
-        <label><input type="checkbox" data-cb="crit_US_140_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Maximale Dateigroesse wird eingehalten (konfigurierbar in tenant_config.max_upload_size_mb, Standard 50 MB)</label>
+        <label><input type="checkbox" data-cb="crit_US_140_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Datei wird in MinIO gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_140_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Dateiliste zeigt: Dateiname, Dateityp (Content-Type), Groesse, Hochgeladen von, Datum</label>
+        <label><input type="checkbox" data-cb="crit_US_140_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Alle Raummitglieder koennen die Datei sehen (bei Audience &quot;Alle&quot;)</label>
+        <label><input type="checkbox" data-cb="crit_US_140_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Maximale Dateigroesse wird eingehalten (konfigurierbar in tenant_config.max_upload_size_mb, Standard 50 MB)</label>
       </div>
     </div>
     <div class="story" id="story-US_141" data-story="US-141" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-141</span> <span class="story-title">Datei herunterladen</span></div>
       </div>
-      <div class="story-als">Als Raummitglied moechte ich eine hochgeladene Datei herunterladen, damit ich auf geteilte Materialien zugreifen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Datei ist im Raum hochgeladen. Login als beliebiges Raummitglied.</div>
+      <div class="story-als">Als Raummitglied moechte ich eine hochgeladene Datei herunterladen, damit ich auf geteilte Materialien zugreifen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Datei ist im Raum hochgeladen. Login als beliebiges Raummitglied.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2800,18 +2800,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Heruntergeladene Datei pruefen</td><td>Datei ist intakt und hat den korrekten Inhalt</td><td><input type="checkbox" data-cb="step_US_141_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_141_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Download liefert die Originaldatei mit korrektem Content-Type</label>
-        <label><input type="checkbox" data-cb="crit_US_141_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Dateiname im Download entspricht dem Originalnamen</label>
-        <label><input type="checkbox" data-cb="crit_US_141_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nur Raummitglieder koennen Dateien herunterladen</label>
-        <label><input type="checkbox" data-cb="crit_US_141_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nicht-Mitglieder erhalten HTTP 403</label>
+        <label><input type="checkbox" data-cb="crit_US_141_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Download liefert die Originaldatei mit korrektem Content-Type</label>
+        <label><input type="checkbox" data-cb="crit_US_141_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Dateiname im Download entspricht dem Originalnamen</label>
+        <label><input type="checkbox" data-cb="crit_US_141_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nur Raummitglieder koennen Dateien herunterladen</label>
+        <label><input type="checkbox" data-cb="crit_US_141_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nicht-Mitglieder erhalten HTTP 403</label>
       </div>
     </div>
     <div class="story" id="story-US_142" data-story="US-142" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-142</span> <span class="story-title">Ordner erstellen und verwalten</span></div>
       </div>
-      <div class="story-als">Als Raummitglied moechte ich Ordner erstellen, damit ich Dateien organisieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raums. Login als `lehrer@monteweb.local`.</div>
+      <div class="story-als">Als Raummitglied moechte ich Ordner erstellen, damit ich Dateien organisieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied eines Raums. Login als `lehrer@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2824,18 +2824,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Datei in den Ordner hochladen</td><td>Datei erscheint im Ordner</td><td><input type="checkbox" data-cb="step_US_142_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_142_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner koennen in der Root-Ebene und als Unterordner erstellt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_142_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordnername ist Pflichtfeld</label>
-        <label><input type="checkbox" data-cb="crit_US_142_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner zeigt Sichtbarkeit (Alle/Nur Eltern/Nur Schueler)</label>
-        <label><input type="checkbox" data-cb="crit_US_142_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> KLASSE-Raeume erhalten automatisch einen Standard-Ordner bei Erstellung</label>
+        <label><input type="checkbox" data-cb="crit_US_142_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner koennen in der Root-Ebene und als Unterordner erstellt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_142_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordnername ist Pflichtfeld</label>
+        <label><input type="checkbox" data-cb="crit_US_142_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner zeigt Sichtbarkeit (Alle/Nur Eltern/Nur Schueler)</label>
+        <label><input type="checkbox" data-cb="crit_US_142_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> KLASSE-Raeume erhalten bei Erstellung automatisch drei Standard-Ordner: &quot;Eltern &amp; Lehrer&quot; (Nur Eltern), &quot;Schueler &amp; Lehrer&quot; (Nur Schueler) und &quot;Alle&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_143" data-story="US-143" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-143</span> <span class="story-title">Ordner-Audience — Nur Eltern</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft moechte ich einen Ordner erstellen, der nur fuer Eltern sichtbar ist, damit vertrauliche Elterninfos nicht fuer Schueler zugaenglich sind.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (LEADER in Raum mit Eltern und Schuelern).</div>
+      <div class="story-als">Als Lehrkraft moechte ich einen Ordner erstellen, der nur fuer Eltern sichtbar ist, damit vertrauliche Elterninfos nicht fuer Schueler zugaenglich sind.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (LEADER in Raum mit Eltern und Schuelern).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2850,18 +2850,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>9</td><td>Raum oeffnen, Tab &quot;Dateien&quot;</td><td>Ordner &quot;Vertraulich — Eltern&quot; ist sichtbar</td><td><input type="checkbox" data-cb="step_US_143_9" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_143_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner mit Audience &quot;Nur Eltern&quot; ist fuer STUDENT nicht sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_143_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner ist fuer PARENT, TEACHER, LEADER und SUPERADMIN sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_143_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Dateien innerhalb des Ordners erben die Sichtbarkeit</label>
-        <label><input type="checkbox" data-cb="crit_US_143_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> API-Zugriff auf geschuetzte Ordner durch Schueler wird abgelehnt</label>
+        <label><input type="checkbox" data-cb="crit_US_143_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner mit Audience &quot;Nur Eltern&quot; ist fuer STUDENT nicht sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_143_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner ist fuer PARENT, TEACHER, LEADER und SUPERADMIN sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_143_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Dateien innerhalb des Ordners erben die Sichtbarkeit</label>
+        <label><input type="checkbox" data-cb="crit_US_143_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> API-Zugriff auf geschuetzte Ordner durch Schueler wird abgelehnt</label>
       </div>
     </div>
     <div class="story" id="story-US_144" data-story="US-144" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-144</span> <span class="story-title">Ordner-Audience — Nur Schueler</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft moechte ich einen Ordner erstellen, der nur fuer Schueler sichtbar ist, damit Schueler-spezifische Materialien getrennt abgelegt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local`.</div>
+      <div class="story-als">Als Lehrkraft moechte ich einen Ordner erstellen, der nur fuer Schueler sichtbar ist, damit Schueler-spezifische Materialien getrennt abgelegt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2874,17 +2874,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Raum oeffnen, Tab &quot;Dateien&quot;</td><td>Ordner &quot;Aufgaben&quot; IST sichtbar fuer Schueler</td><td><input type="checkbox" data-cb="step_US_144_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_144_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner mit Audience &quot;Nur Schueler&quot; ist fuer PARENT nicht sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_144_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner ist fuer STUDENT, TEACHER, LEADER und SUPERADMIN sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_144_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Eltern-Erstellung von Ordnern setzt Audience automatisch auf &quot;Nur Eltern&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_144_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner mit Audience &quot;Nur Schueler&quot; ist fuer PARENT nicht sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_144_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ordner ist fuer STUDENT, TEACHER, LEADER und SUPERADMIN sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_144_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Eltern-Erstellung von Ordnern setzt Audience automatisch auf &quot;Nur Eltern&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_145" data-story="US-145" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-145</span> <span class="story-title">Datei loeschen</span></div>
       </div>
-      <div class="story-als">Als Raummitglied moechte ich eine von mir hochgeladene Datei loeschen, damit veraltete oder falsche Dateien entfernt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat eine Datei hochgeladen. Login als Uploader.</div>
+      <div class="story-als">Als Raummitglied moechte ich eine von mir hochgeladene Datei loeschen, damit veraltete oder falsche Dateien entfernt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat eine Datei hochgeladen. Login als Uploader.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2894,18 +2894,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>API: `GET /api/v1/rooms/{id}/files/{fileId}`</td><td>HTTP 404 — Datei nicht gefunden</td><td><input type="checkbox" data-cb="step_US_145_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_145_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nur der Uploader, LEADER oder SUPERADMIN kann eine Datei loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_145_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Datei wird aus MinIO und Datenbank entfernt</label>
-        <label><input type="checkbox" data-cb="crit_US_145_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
-        <label><input type="checkbox" data-cb="crit_US_145_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Geloeschte Datei ist sofort nicht mehr downloadbar</label>
+        <label><input type="checkbox" data-cb="crit_US_145_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nur der Uploader, LEADER oder SUPERADMIN kann eine Datei loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_145_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Datei wird aus MinIO und Datenbank entfernt</label>
+        <label><input type="checkbox" data-cb="crit_US_145_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
+        <label><input type="checkbox" data-cb="crit_US_145_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Geloeschte Datei ist sofort nicht mehr downloadbar</label>
       </div>
     </div>
     <div class="story" id="story-US_146" data-story="US-146" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-146</span> <span class="story-title">Ordner loeschen</span></div>
       </div>
-      <div class="story-als">Als Raummitglied moechte ich einen leeren Ordner loeschen, damit die Dateistruktur aufgeraeumt bleibt.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein leerer Ordner existiert. Login als Ersteller oder LEADER.</div>
+      <div class="story-als">Als Raummitglied moechte ich einen leeren Ordner loeschen, damit die Dateistruktur aufgeraeumt bleibt.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein leerer Ordner existiert. Login als Ersteller oder LEADER.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2915,17 +2915,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Versuch, einen Ordner mit Dateien zu loeschen</td><td>Fehlermeldung: Ordner muss leer sein, oder Dateien werden mitgeloescht</td><td><input type="checkbox" data-cb="step_US_146_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_146_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Leere Ordner koennen geloescht werden</label>
-        <label><input type="checkbox" data-cb="crit_US_146_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nur Ersteller, LEADER oder SUPERADMIN kann Ordner loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_146_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
+        <label><input type="checkbox" data-cb="crit_US_146_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Leere Ordner koennen geloescht werden</label>
+        <label><input type="checkbox" data-cb="crit_US_146_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nur Ersteller, LEADER oder SUPERADMIN kann Ordner loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_146_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
       </div>
     </div>
     <div class="story" id="story-US_147" data-story="US-147" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-147</span> <span class="story-title">WOPI/ONLYOFFICE — Dokument online bearbeiten</span></div>
       </div>
-      <div class="story-als">Als Raummitglied moechte ich ein Dokument direkt im Browser bearbeiten, damit ich ohne lokale Software Aenderungen vornehmen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> WOPI-Modul ist aktiviert (Admin &gt; Module &gt; WOPI). ONLYOFFICE Document Server laeuft. Dokument (DOCX, XLSX, PPTX) ist im Raum hochgeladen. Login als Raummitglied.</div>
+      <div class="story-als">Als Raummitglied moechte ich ein Dokument direkt im Browser bearbeiten, damit ich ohne lokale Software Aenderungen vornehmen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> WOPI-Modul ist aktiviert (Admin &gt; Module &gt; WOPI). ONLYOFFICE Document Server laeuft. Dokument (DOCX, XLSX, PPTX) ist im Raum hochgeladen. Login als Raummitglied.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2936,19 +2936,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Datei herunterladen und pruefen</td><td>Aenderungen sind in der heruntergeladenen Datei enthalten</td><td><input type="checkbox" data-cb="step_US_147_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_147_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> WOPI-Session wird mit gueltigem Token erstellt</label>
-        <label><input type="checkbox" data-cb="crit_US_147_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> ONLYOFFICE-Editor laedt das Dokument korrekt</label>
-        <label><input type="checkbox" data-cb="crit_US_147_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Aenderungen werden in MinIO gespeichert</label>
-        <label><input type="checkbox" data-cb="crit_US_147_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Button &quot;Online bearbeiten&quot; nur bei unterstuetzten Dateitypen sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_147_4" data-crit="1" data-module="Dateien" onchange="onCheck()"> Button nur sichtbar, wenn WOPI-Modul aktiviert ist</label>
+        <label><input type="checkbox" data-cb="crit_US_147_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> WOPI-Session wird mit gueltigem Token erstellt</label>
+        <label><input type="checkbox" data-cb="crit_US_147_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> ONLYOFFICE-Editor laedt das Dokument korrekt</label>
+        <label><input type="checkbox" data-cb="crit_US_147_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Aenderungen werden in MinIO gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_147_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Button &quot;Online bearbeiten&quot; nur bei unterstuetzten Dateitypen sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_147_4" data-crit="1" data-module="Dateien" onchange="onCheck()"> Button nur sichtbar, wenn WOPI-Modul aktiviert ist</label>
       </div>
     </div>
     <div class="story" id="story-US_148" data-story="US-148" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-148</span> <span class="story-title">WOPI-Modul deaktiviert — kein Online-Editor</span></div>
       </div>
-      <div class="story-als">Als System moechte ich den Online-Editor ausblenden, wenn WOPI deaktiviert ist, damit keine nicht verfuegbaren Funktionen angezeigt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
+      <div class="story-als">Als System moechte ich den Online-Editor ausblenden, wenn WOPI deaktiviert ist, damit keine nicht verfuegbaren Funktionen angezeigt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2958,17 +2958,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>API: `POST /api/v1/rooms/{id}/files/{fileId}/wopi-session`</td><td>HTTP 400: &quot;WOPI/ONLYOFFICE is not enabled&quot;</td><td><input type="checkbox" data-cb="step_US_148_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_148_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Kein &quot;Online bearbeiten&quot;-Button bei deaktiviertem WOPI</label>
-        <label><input type="checkbox" data-cb="crit_US_148_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> API lehnt WOPI-Session-Erstellung ab</label>
-        <label><input type="checkbox" data-cb="crit_US_148_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Dateien koennen weiterhin hoch-/heruntergeladen werden</label>
+        <label><input type="checkbox" data-cb="crit_US_148_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Kein &quot;Online bearbeiten&quot;-Button bei deaktiviertem WOPI</label>
+        <label><input type="checkbox" data-cb="crit_US_148_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> API lehnt WOPI-Session-Erstellung ab</label>
+        <label><input type="checkbox" data-cb="crit_US_148_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Dateien koennen weiterhin hoch-/heruntergeladen werden</label>
       </div>
     </div>
     <div class="story" id="story-US_149" data-story="US-149" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-149</span> <span class="story-title">ClamAV-Virenscan beim Upload</span></div>
       </div>
-      <div class="story-als">Als System moechte ich hochgeladene Dateien auf Viren scannen, damit schaedliche Dateien nicht verbreitet werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> ClamAV-Modul ist aktiviert. ClamAV-Server laeuft. Login als beliebiges Raummitglied.</div>
+      <div class="story-als">Als System moechte ich hochgeladene Dateien auf Viren scannen, damit schaedliche Dateien nicht verbreitet werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> ClamAV-Modul ist aktiviert. ClamAV-Server laeuft. Login als beliebiges Raummitglied.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -2978,19 +2978,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Dateiliste pruefen</td><td>Infizierte Datei ist NICHT in der Liste</td><td><input type="checkbox" data-cb="step_US_149_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_149_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Scan erfolgt automatisch bei jedem Upload (wenn ClamAV aktiviert)</label>
-        <label><input type="checkbox" data-cb="crit_US_149_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Saubere Dateien werden normal hochgeladen</label>
-        <label><input type="checkbox" data-cb="crit_US_149_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Infizierte Dateien werden abgelehnt mit verstaendlicher Fehlermeldung</label>
-        <label><input type="checkbox" data-cb="crit_US_149_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ohne ClamAV-Modul: Upload ohne Scan moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_149_4" data-crit="1" data-module="Dateien" onchange="onCheck()"> ClamAV nutzt INSTREAM-Protokoll (keine Datei auf Disk)</label>
+        <label><input type="checkbox" data-cb="crit_US_149_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Scan erfolgt automatisch bei jedem Upload (wenn ClamAV aktiviert)</label>
+        <label><input type="checkbox" data-cb="crit_US_149_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> Saubere Dateien werden normal hochgeladen</label>
+        <label><input type="checkbox" data-cb="crit_US_149_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Infizierte Dateien werden abgelehnt mit verstaendlicher Fehlermeldung</label>
+        <label><input type="checkbox" data-cb="crit_US_149_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Ohne ClamAV-Modul: Upload ohne Scan moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_149_4" data-crit="1" data-module="Dateien" onchange="onCheck()"> ClamAV nutzt INSTREAM-Protokoll (keine Datei auf Disk)</label>
       </div>
     </div>
     <div class="story" id="story-US_150" data-story="US-150" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-150</span> <span class="story-title">Dateien-Modul deaktiviert</span></div>
       </div>
-      <div class="story-als">Als System moechte ich das Dateien-Modul komplett abschalten koennen, damit die Schule bei Bedarf auf Dateiablage verzichten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
+      <div class="story-als">Als System moechte ich das Dateien-Modul komplett abschalten koennen, damit die Schule bei Bedarf auf Dateiablage verzichten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3001,18 +3001,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Modul wieder aktivieren</td><td>Tab &quot;Dateien&quot; erscheint wieder, vorhandene Dateien sind erhalten</td><td><input type="checkbox" data-cb="step_US_150_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_150_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Bei deaktiviertem Modul: kein Dateien-Tab in Raeumen</label>
-        <label><input type="checkbox" data-cb="crit_US_150_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> API-Endpunkte sind nicht erreichbar</label>
-        <label><input type="checkbox" data-cb="crit_US_150_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Reaktivierung stellt alle Dateien und Ordner wieder her</label>
-        <label><input type="checkbox" data-cb="crit_US_150_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Automatische Ordner-Erstellung bei Raumerstellung findet nicht statt</label>
+        <label><input type="checkbox" data-cb="crit_US_150_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Bei deaktiviertem Modul: kein Dateien-Tab in Raeumen</label>
+        <label><input type="checkbox" data-cb="crit_US_150_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> API-Endpunkte sind nicht erreichbar</label>
+        <label><input type="checkbox" data-cb="crit_US_150_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Reaktivierung stellt alle Dateien und Ordner wieder her</label>
+        <label><input type="checkbox" data-cb="crit_US_150_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Automatische Ordner-Erstellung bei Raumerstellung findet nicht statt</label>
       </div>
     </div>
     <div class="story" id="story-US_151" data-story="US-151" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-151</span> <span class="story-title">Zugriffsbeschraenkung — Nicht-Mitglieder</span></div>
       </div>
-      <div class="story-als">Als System moechte ich verhindern, dass Nicht-Mitglieder auf Raum-Dateien zugreifen, damit die Datensicherheit gewaehrleistet ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Raum mit Dateien existiert. Login als Benutzer, der NICHT Mitglied dieses Raums ist.</div>
+      <div class="story-als">Als System moechte ich verhindern, dass Nicht-Mitglieder auf Raum-Dateien zugreifen, damit die Datensicherheit gewaehrleistet ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Raum mit Dateien existiert. Login als Benutzer, der NICHT Mitglied dieses Raums ist.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3021,10 +3021,356 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>API: `POST /api/v1/rooms/{id}/files` (Upload-Versuch)</td><td>HTTP 403 — Zugriff verweigert</td><td><input type="checkbox" data-cb="step_US_151_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_151_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nur Raummitglieder haben Zugriff auf Dateien</label>
-        <label><input type="checkbox" data-cb="crit_US_151_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> SUPERADMIN hat Zugriff auf alle Raum-Dateien</label>
-        <label><input type="checkbox" data-cb="crit_US_151_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Fehlermeldung ist klar und verstaendlich</label>
-        <label><input type="checkbox" data-cb="crit_US_151_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Keine Information ueber Existenz der Dateien wird preisgegeben</label>
+        <label><input type="checkbox" data-cb="crit_US_151_0" data-crit="1" data-module="Dateien" onchange="onCheck()"> Nur Raummitglieder haben Zugriff auf Dateien</label>
+        <label><input type="checkbox" data-cb="crit_US_151_1" data-crit="1" data-module="Dateien" onchange="onCheck()"> SUPERADMIN hat Zugriff auf alle Raum-Dateien</label>
+        <label><input type="checkbox" data-cb="crit_US_151_2" data-crit="1" data-module="Dateien" onchange="onCheck()"> Fehlermeldung ist klar und verstaendlich</label>
+        <label><input type="checkbox" data-cb="crit_US_151_3" data-crit="1" data-module="Dateien" onchange="onCheck()"> Keine Information ueber Existenz der Dateien wird preisgegeben</label>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="module" data-module="Elternbriefe">
+  <div class="module-header" onclick="toggleModule('Elternbriefe')">
+    <h2><span class="chevron">&#9654;</span> Elternbriefe <span class="badge">16 Stories</span></h2>
+    <div>
+      <span class="progress-info" id="prog-Elternbriefe">0/61</span>
+      <div class="progress-bar" style="width:120px"><div class="progress-fill" id="bar-Elternbriefe" style="width:0%"></div></div>
+    </div>
+  </div>
+  <div class="module-body">
+    <div class="story" id="story-US_375" data-story="US-375" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-375</span> <span class="story-title">Elternbrief als Entwurf erstellen</span></div>
+      </div>
+      <div class="story-als">Als Raumleiter moechte ich einen Elternbrief als Entwurf erstellen, damit ich Eltern einer Klasse strukturiert informieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Login als `lehrer@monteweb.local` (LEADER eines KLASSE-Raums).</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>KLASSE-Raum oeffnen, Bereich &quot;Elternbriefe&quot; waehlen</td><td>Liste der Elternbriefe (oder leerer Zustand) wird angezeigt</td><td><input type="checkbox" data-cb="step_US_375_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Button &quot;Neuer Elternbrief&quot; klicken</td><td>Formular mit Titel, Inhalt, optionalem Sendedatum, Frist (deadline) und Erinnerungstagen oeffnet sich</td><td><input type="checkbox" data-cb="step_US_375_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Titel und Inhalt eingeben</td><td>Felder werden befuellt (Titel max. 300 Zeichen, Inhalt Pflicht)</td><td><input type="checkbox" data-cb="step_US_375_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>API: `POST /api/v1/parent-letters` mit `{roomId, title, content, sendDate?, deadline?, reminderDays?, studentIds?}`</td><td>HTTP 200, Brief mit Status `DRAFT` wird zurueckgegeben</td><td><input type="checkbox" data-cb="step_US_375_4" onchange="onCheck()"></td></tr>
+          <tr><td>5</td><td>API-Versuch fuer einen Nicht-KLASSE-Raum (z.B. FACHRAUM)</td><td>HTTP 403 — nur KLASSE-Raeume erlaubt</td><td><input type="checkbox" data-cb="step_US_375_5" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_375_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur LEADER des Raums oder SUPERADMIN koennen Briefe erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_375_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Elternbriefe sind nur fuer KLASSE-Raeume moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_375_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Neuer Brief erhaelt Status `DRAFT`</label>
+        <label><input type="checkbox" data-cb="crit_US_375_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> `reminderDays` ist optional; ohne Angabe wird der Standardwert 3 gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_375_4" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> `studentIds = null` adressiert die ganze Klasse, eine Auswahl beschraenkt die Empfaenger</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_376" data-story="US-376" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-376</span> <span class="story-title">Empfaengerliste ueber Familienverbund aufbauen</span></div>
+      </div>
+      <div class="story-als">Als Raumleiter moechte ich, dass die Empfaenger automatisch aus dem Familienverbund ermittelt werden, damit alle Eltern der betroffenen Kinder erreicht werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. KLASSE-Raum mit Schuelern, deren Familien Eltern-Mitglieder haben. Login als LEADER.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>Elternbrief ohne `studentIds` erstellen</td><td>Fuer jeden STUDENT des Raums werden Empfaenger erzeugt</td><td><input type="checkbox" data-cb="step_US_376_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Brief-Details abrufen</td><td>Empfaengerliste enthaelt pro Kind je einen Eintrag pro PARENT-Mitglied der zugehoerigen Familie(n)</td><td><input type="checkbox" data-cb="step_US_376_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Elternbrief mit `studentIds = [kindA, kindB]` erstellen</td><td>Nur die Eltern der ausgewaehlten Kinder werden als Empfaenger angelegt</td><td><input type="checkbox" data-cb="step_US_376_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Empfaengerstatus pruefen</td><td>Jeder Empfaengereintrag startet mit Status `OPEN`</td><td><input type="checkbox" data-cb="step_US_376_4" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_376_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Pro Kind werden alle PARENT-Mitglieder der zugehoerigen Familie(n) als Empfaenger erzeugt</label>
+        <label><input type="checkbox" data-cb="crit_US_376_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Ohne `studentIds`-Auswahl werden alle STUDENT-Mitglieder des KLASSE-Raums beruecksichtigt</label>
+        <label><input type="checkbox" data-cb="crit_US_376_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Doppelte Empfaenger (gleiche Kombination Brief + Elternteil + Kind) werden vermieden</label>
+        <label><input type="checkbox" data-cb="crit_US_376_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Jeder Empfaengereintrag haelt Kind-, Eltern- und Familien-Bezug</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_377" data-story="US-377" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-377</span> <span class="story-title">Eigene Elternbriefe auflisten</span></div>
+      </div>
+      <div class="story-als">Als Raumleiter moechte ich meine erstellten Elternbriefe paginiert sehen, damit ich den Ueberblick behalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Login als Ersteller mehrerer Briefe.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>API: `GET /api/v1/parent-letters/my?page=0&amp;size=20`</td><td>Paginierte Liste der selbst erstellten Briefe (nach `createdAt`)</td><td><input type="checkbox" data-cb="step_US_377_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Liste pruefen</td><td>Jeder Eintrag zeigt Titel, Status, Raumname, Empfaengerzahl und bestaetigte Anzahl</td><td><input type="checkbox" data-cb="step_US_377_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Als anderer Lehrer einloggen, Endpoint erneut aufrufen</td><td>Nur die eigenen Briefe des anderen Lehrers werden gelistet</td><td><input type="checkbox" data-cb="step_US_377_3" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_377_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur die vom angemeldeten Nutzer erstellten Briefe werden zurueckgegeben</label>
+        <label><input type="checkbox" data-cb="crit_US_377_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Antwort ist paginiert (Standard `size=20`, sortiert nach `createdAt`)</label>
+        <label><input type="checkbox" data-cb="crit_US_377_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Jeder Listeneintrag enthaelt Gesamt- und Bestaetigt-Empfaengerzahl</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_378" data-story="US-378" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-378</span> <span class="story-title">Elternbrief-Posteingang fuer Eltern</span></div>
+      </div>
+      <div class="story-als">Als Elternteil moechte ich alle an mich gesendeten Elternbriefe sehen, damit ich keine Information verpasse.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Login als `eltern@monteweb.local`, der Empfaenger gesendeter Briefe ist.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>API: `GET /api/v1/parent-letters/inbox?page=0&amp;size=20`</td><td>Paginierte Liste der Briefe, bei denen der Nutzer Empfaenger ist</td><td><input type="checkbox" data-cb="step_US_378_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Liste pruefen</td><td>Nur Briefe mit Status `SENT` oder `CLOSED` erscheinen</td><td><input type="checkbox" data-cb="step_US_378_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Geplanter Brief (zukuenftiges Sendedatum) pruefen</td><td>Brief erscheint NICHT im Posteingang, solange das Sendedatum nicht erreicht ist</td><td><input type="checkbox" data-cb="step_US_378_3" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_378_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur Briefe, bei denen der Nutzer Empfaenger ist, werden angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_378_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur Briefe mit Status `SENT` oder `CLOSED` erscheinen</label>
+        <label><input type="checkbox" data-cb="crit_US_378_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Briefe mit zukuenftigem `sendDate` werden bis zur Freigabe ausgeblendet</label>
+        <label><input type="checkbox" data-cb="crit_US_378_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Liste ist nach Erstellungsdatum absteigend sortiert und paginiert</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_379" data-story="US-379" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-379</span> <span class="story-title">Briefdetails mit rollenabhaengiger Sicht</span></div>
+      </div>
+      <div class="story-als">Als Nutzer moechte ich Briefdetails passend zu meiner Rolle sehen, damit ich nur die fuer mich relevanten Informationen erhalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Ein gesendeter Elternbrief existiert.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>Als Ersteller/LEADER/SUPERADMIN `GET /api/v1/parent-letters/{id}`</td><td>Vollansicht inkl. vollstaendiger Empfaengerliste mit Status</td><td><input type="checkbox" data-cb="step_US_379_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Als Eltern-Empfaenger denselben Endpoint aufrufen</td><td>Brief-Detail mit aufgeloestem Inhalt wird angezeigt</td><td><input type="checkbox" data-cb="step_US_379_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Empfaengerstatus nach dem Abruf durch das Elternteil pruefen</td><td>Offene (`OPEN`) Empfaengereintraege des Elternteils werden automatisch auf `READ` mit `readAt` gesetzt</td><td><input type="checkbox" data-cb="step_US_379_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Als nicht beteiligter Nutzer den Endpoint aufrufen</td><td>HTTP 403 — kein Zugriff</td><td><input type="checkbox" data-cb="step_US_379_4" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_379_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Ersteller, LEADER des Raums und SUPERADMIN sehen die Empfaengerliste</label>
+        <label><input type="checkbox" data-cb="crit_US_379_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Eltern-Empfaenger sehen den Brief; der Abruf markiert ihre offenen Eintraege als gelesen</label>
+        <label><input type="checkbox" data-cb="crit_US_379_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nutzer ohne Bezug zum Brief erhalten HTTP 403</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_380" data-story="US-380" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-380</span> <span class="story-title">Entwurf bearbeiten</span></div>
+      </div>
+      <div class="story-als">Als Raumleiter moechte ich einen Entwurf nachtraeglich bearbeiten, damit ich Inhalt und Empfaengerkreis vor dem Versand anpassen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Ein Brief im Status `DRAFT` existiert. Login als Ersteller/LEADER.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>API: `PUT /api/v1/parent-letters/{id}` mit geaendertem Titel/Inhalt und neuen `studentIds`</td><td>HTTP 200, Brief aktualisiert</td><td><input type="checkbox" data-cb="step_US_380_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Empfaengerliste pruefen</td><td>Alte Empfaenger werden entfernt und gemaess neuen `studentIds` neu aufgebaut</td><td><input type="checkbox" data-cb="step_US_380_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Bearbeitung eines bereits gesendeten Briefs (Status `SENT`) versuchen</td><td>HTTP 403 — nur `DRAFT` ist editierbar</td><td><input type="checkbox" data-cb="step_US_380_3" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_380_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur Briefe im Status `DRAFT` koennen bearbeitet werden</label>
+        <label><input type="checkbox" data-cb="crit_US_380_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur LEADER des Raums oder SUPERADMIN duerfen bearbeiten</label>
+        <label><input type="checkbox" data-cb="crit_US_380_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Beim Speichern wird die Empfaengerliste vollstaendig neu aufgebaut</label>
+        <label><input type="checkbox" data-cb="crit_US_380_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> `reminderDays` wird nur ueberschrieben, wenn ein Wert uebergeben wird</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_381" data-story="US-381" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-381</span> <span class="story-title">Elternbrief versenden oder terminiert planen</span></div>
+      </div>
+      <div class="story-als">Als Raumleiter moechte ich einen Brief sofort versenden oder fuer ein Datum planen, damit Eltern zum richtigen Zeitpunkt informiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Ein Brief im Status `DRAFT` existiert. Login als Ersteller/LEADER.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>Brief ohne Sendedatum: `POST /api/v1/parent-letters/{id}/send`</td><td>Status wechselt auf `SENT`, Benachrichtigungen werden ausgeloest</td><td><input type="checkbox" data-cb="step_US_381_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Empfaenger pruefen</td><td>Jeder Empfaenger erhaelt eine Benachrichtigung vom Typ `PARENT_LETTER` (einmal pro Elternteil)</td><td><input type="checkbox" data-cb="step_US_381_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Brief mit zukuenftigem `sendDate` versenden</td><td>Status wechselt auf `SCHEDULED`, noch keine Benachrichtigung</td><td><input type="checkbox" data-cb="step_US_381_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Versand eines bereits gesendeten Briefs erneut versuchen</td><td>HTTP 403 — nur `DRAFT` kann versendet werden</td><td><input type="checkbox" data-cb="step_US_381_4" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_381_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur LEADER des Raums oder SUPERADMIN koennen versenden</label>
+        <label><input type="checkbox" data-cb="crit_US_381_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Liegt `sendDate` in der Zukunft, wird der Status `SCHEDULED` (kein Sofortversand)</label>
+        <label><input type="checkbox" data-cb="crit_US_381_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Andernfalls Status `SENT` mit Benachrichtigung (`PARENT_LETTER`) und `ParentLetterSentEvent`</label>
+        <label><input type="checkbox" data-cb="crit_US_381_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Pro Elternteil wird nur eine Benachrichtigung erzeugt, auch bei mehreren Kindern</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_382" data-story="US-382" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-382</span> <span class="story-title">Terminierte Briefe automatisch versenden</span></div>
+      </div>
+      <div class="story-als">Als System moechte ich geplante Elternbriefe automatisch zustellen, damit kein manueller Versand noetig ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Mindestens ein Brief mit Status `SCHEDULED` und erreichtem `sendDate`.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>Geplanter Scheduler `dispatchScheduledLetters` laeuft taeglich um 07:00</td><td>Faellige `SCHEDULED`-Briefe werden gefunden</td><td><input type="checkbox" data-cb="step_US_382_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Verarbeitung pruefen</td><td>Status wechselt auf `SENT`, Benachrichtigungen und `ParentLetterSentEvent` werden ausgeloest</td><td><input type="checkbox" data-cb="step_US_382_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Brief mit noch nicht erreichtem `sendDate`</td><td>Bleibt unveraendert `SCHEDULED`</td><td><input type="checkbox" data-cb="step_US_382_3" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_382_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Scheduler laeuft taeglich um 07:00 (`cron 0 0 7 * * *`)</label>
+        <label><input type="checkbox" data-cb="crit_US_382_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur `SCHEDULED`-Briefe mit erreichtem `sendDate` werden zugestellt</label>
+        <label><input type="checkbox" data-cb="crit_US_382_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Beim Versand werden Empfaenger benachrichtigt und das Sent-Event publiziert</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_383" data-story="US-383" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-383</span> <span class="story-title">Erinnerungs-Benachrichtigungen vor Fristablauf</span></div>
+      </div>
+      <div class="story-als">Als Elternteil moechte ich vor Ablauf der Frist erinnert werden, damit ich die Kenntnisnahme nicht vergesse.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Ein `SENT`-Brief mit gesetzter `deadline` und offenen Empfaengern.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>Scheduler `sendReminders` laeuft taeglich um 07:05</td><td>Briefe im Erinnerungsfenster werden ermittelt</td><td><input type="checkbox" data-cb="step_US_383_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Erinnerungsfenster pruefen</td><td>Erinnerung wird gesendet, sobald `deadline - reminderDays &lt;= jetzt`</td><td><input type="checkbox" data-cb="step_US_383_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Empfaengerbenachrichtigung pruefen</td><td>Nur noch offene (`OPEN`) Empfaenger erhalten eine `PARENT_LETTER_REMINDER`-Benachrichtigung</td><td><input type="checkbox" data-cb="step_US_383_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Erneuter Scheduler-Lauf am Folgetag</td><td>Keine erneute Erinnerung — `reminderSent`-Flag verhindert Doppelversand</td><td><input type="checkbox" data-cb="step_US_383_4" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_383_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Scheduler laeuft taeglich um 07:05 (`cron 0 5 7 * * *`)</label>
+        <label><input type="checkbox" data-cb="crit_US_383_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Erinnerung greift, sobald `deadline - reminderDays` erreicht ist</label>
+        <label><input type="checkbox" data-cb="crit_US_383_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur noch offene Empfaenger erhalten die Erinnerung</label>
+        <label><input type="checkbox" data-cb="crit_US_383_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Pro Brief wird die Erinnerung nur einmal ausgeloest (`reminderSent`-Flag)</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_384" data-story="US-384" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-384</span> <span class="story-title">Kenntnisnahme bestaetigen</span></div>
+      </div>
+      <div class="story-als">Als Elternteil moechte ich die Kenntnisnahme eines Elternbriefs pro Kind bestaetigen, damit die Lehrkraft den Ruecklauf nachvollziehen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Login als Eltern-Empfaenger eines gesendeten Briefs.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>API: `POST /api/v1/parent-letters/{id}/confirm/{studentId}`</td><td>Empfaengereintrag wechselt auf Status `CONFIRMED`</td><td><input type="checkbox" data-cb="step_US_384_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Empfaengerdaten pruefen</td><td>`confirmedAt` und `confirmedBy` werden gesetzt</td><td><input type="checkbox" data-cb="step_US_384_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Erneute Bestaetigung desselben Eintrags</td><td>Idempotent — bereits bestaetigter Eintrag wird unveraendert zurueckgegeben</td><td><input type="checkbox" data-cb="step_US_384_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Bestaetigung fuer ein fremdes Kind/Eltern-Kombination versuchen</td><td>HTTP 404 — kein passender Empfaengereintrag</td><td><input type="checkbox" data-cb="step_US_384_4" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_384_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Bestaetigung erfolgt pro Kind (`studentId`) separat</label>
+        <label><input type="checkbox" data-cb="crit_US_384_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Status wechselt auf `CONFIRMED` mit `confirmedAt`/`confirmedBy`</label>
+        <label><input type="checkbox" data-cb="crit_US_384_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Wiederholte Bestaetigung ist idempotent</label>
+        <label><input type="checkbox" data-cb="crit_US_384_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur der zugeordnete Elternteil kann seinen Empfaengereintrag bestaetigen</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_385" data-story="US-385" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-385</span> <span class="story-title">Brief explizit als gelesen markieren</span></div>
+      </div>
+      <div class="story-als">Als Elternteil moechte ich einen Brief als gelesen markieren koennen, damit mein Lesestatus erfasst wird, auch ohne Bestaetigung.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Login als Eltern-Empfaenger mit offenem (`OPEN`) Eintrag.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>API: `POST /api/v1/parent-letters/{id}/read`</td><td>Offene Empfaengereintraege des Nutzers wechseln auf `READ`</td><td><input type="checkbox" data-cb="step_US_385_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Empfaengerdaten pruefen</td><td>`readAt` wird gesetzt</td><td><input type="checkbox" data-cb="step_US_385_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Bereits bestaetigten (`CONFIRMED`) Eintrag pruefen</td><td>Status bleibt `CONFIRMED` — nur `OPEN`-Eintraege werden auf `READ` gesetzt</td><td><input type="checkbox" data-cb="step_US_385_3" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_385_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur eigene Empfaengereintraege im Status `OPEN` werden auf `READ` gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_385_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> `readAt`-Zeitstempel wird gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_385_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Das Oeffnen der Detailansicht (`GET /{id}`) markiert den Brief ebenfalls als gelesen</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_386" data-story="US-386" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-386</span> <span class="story-title">Variablen/Platzhalter im Briefinhalt</span></div>
+      </div>
+      <div class="story-als">Als Raumleiter moechte ich Platzhalter im Brief verwenden, damit Inhalte je Kind/Familie personalisiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Ein Brief mit Platzhaltern im Inhalt existiert.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>Inhalt mit `{Familie}`, `{NameKind}`, `{Anrede}`, `{LehrerName}` erstellen</td><td>Platzhalter werden im Entwurf gespeichert</td><td><input type="checkbox" data-cb="step_US_386_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>API: `GET /api/v1/parent-letters/{id}/pdf?studentId={kind}`</td><td>Platzhalter werden fuer das angegebene Kind aufgeloest</td><td><input type="checkbox" data-cb="step_US_386_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Aufloesung pruefen</td><td>`{Familie}` = Familienname, `{NameKind}` = Vorname des Kindes, `{LehrerName}` = Anzeigename der Lehrkraft</td><td><input type="checkbox" data-cb="step_US_386_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>`{Anrede}` ohne ermittelbares Elternteil</td><td>Faellt auf &quot;Sehr geehrte Eltern&quot; zurueck</td><td><input type="checkbox" data-cb="step_US_386_4" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_386_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Unterstuetzte Platzhalter: `{Familie}`, `{NameKind}`, `{Anrede}`, `{LehrerName}`</label>
+        <label><input type="checkbox" data-cb="crit_US_386_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Aufloesung erfolgt pro Kind (ueber `studentId`)</label>
+        <label><input type="checkbox" data-cb="crit_US_386_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Ohne `studentId` wird der Rohinhalt mit unaufgeloesten Platzhaltern ausgegeben</label>
+        <label><input type="checkbox" data-cb="crit_US_386_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> `{Anrede}` nutzt &quot;Sehr geehrte/r &lt;Anzeigename&gt;&quot; bzw. den Fallback &quot;Sehr geehrte Eltern&quot;</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_387" data-story="US-387" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-387</span> <span class="story-title">Brief und Ruecklaufliste als PDF</span></div>
+      </div>
+      <div class="story-als">Als Raumleiter moechte ich den Brief und die Ruecklaufliste als PDF herunterladen, damit ich sie drucken oder archivieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Ein Brief mit Empfaengern existiert. Login als Ersteller/LEADER/SUPERADMIN.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>API: `GET /api/v1/parent-letters/{id}/pdf`</td><td>PDF des Briefs (Dateiname `Elternbrief-&lt;Titel&gt;.pdf`) wird geliefert</td><td><input type="checkbox" data-cb="step_US_387_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>PDF mit `?studentId=` abrufen</td><td>Platzhalter sind fuer das gewaehlte Kind aufgeloest</td><td><input type="checkbox" data-cb="step_US_387_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>API: `GET /api/v1/parent-letters/{id}/tracking-pdf`</td><td>Ruecklaufliste mit Bestaetigungsstatus aller Empfaenger (Dateiname `Ruecklauf-&lt;Titel&gt;.pdf`)</td><td><input type="checkbox" data-cb="step_US_387_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Als nicht berechtigter Nutzer PDF abrufen</td><td>HTTP 403 — kein Zugriff</td><td><input type="checkbox" data-cb="step_US_387_4" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_387_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Brief-PDF wird mit `Content-Type: application/pdf` und sprechendem Dateinamen geliefert</label>
+        <label><input type="checkbox" data-cb="crit_US_387_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Mit `studentId` werden die Platzhalter im Brief-PDF aufgeloest</label>
+        <label><input type="checkbox" data-cb="crit_US_387_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Tracking-PDF listet den Bestaetigungsstatus aller Empfaenger</label>
+        <label><input type="checkbox" data-cb="crit_US_387_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> PDF-Abruf erfordert Detail-Zugriff (Ersteller/LEADER/SUPERADMIN)</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_388" data-story="US-388" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-388</span> <span class="story-title">Datei-Anhaenge verwalten</span></div>
+      </div>
+      <div class="story-als">Als Raumleiter moechte ich Dateien an einen Elternbrief anhaengen, damit Eltern zusaetzliche Dokumente erhalten.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Ein Brief im Status `DRAFT` existiert. Login als Ersteller/LEADER.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>API: `POST /api/v1/parent-letters/{id}/attachments` mit Dateien</td><td>Anhaenge werden in MinIO gespeichert und gelistet</td><td><input type="checkbox" data-cb="step_US_388_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Mehr als 5 Anhaenge bzw. Datei &gt; 10 MB hochladen</td><td>HTTP 403 — Limit ueberschritten</td><td><input type="checkbox" data-cb="step_US_388_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>API: `GET /api/v1/parent-letters/{id}/attachments`</td><td>Anhangsliste; auch fuer Eltern-Empfaenger zugaenglich</td><td><input type="checkbox" data-cb="step_US_388_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>API: `GET /api/v1/parent-letters/{id}/attachments/{attachmentId}`</td><td>Einzelner Anhang wird heruntergeladen (mit Pruefung der Brief-Zugehoerigkeit)</td><td><input type="checkbox" data-cb="step_US_388_4" onchange="onCheck()"></td></tr>
+          <tr><td>5</td><td>API: `DELETE /api/v1/parent-letters/{id}/attachments/{attachmentId}` an `DRAFT`-Brief</td><td>Anhang wird geloescht</td><td><input type="checkbox" data-cb="step_US_388_5" onchange="onCheck()"></td></tr>
+          <tr><td>6</td><td>Anhang aus einem gesendeten Brief loeschen</td><td>HTTP 403 — nur aus `DRAFT` moeglich</td><td><input type="checkbox" data-cb="step_US_388_6" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_388_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Maximal 5 Anhaenge pro Brief, jeweils maximal 10 MB</label>
+        <label><input type="checkbox" data-cb="crit_US_388_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Anhaenge werden in MinIO gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_388_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Liste und Download stehen autorisierten Nutzern inkl. Eltern-Empfaengern offen</label>
+        <label><input type="checkbox" data-cb="crit_US_388_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Anhaenge koennen nur aus `DRAFT`-Briefen durch LEADER/SUPERADMIN geloescht werden</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_389" data-story="US-389" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-389</span> <span class="story-title">Brief schliessen und Entwurf loeschen</span></div>
+      </div>
+      <div class="story-als">Als Raumleiter moechte ich Briefe schliessen oder Entwuerfe loeschen, damit ich den Ruecklauf beenden bzw. Fehlerstuecke entfernen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Login als Ersteller/LEADER/SUPERADMIN.</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>API: `POST /api/v1/parent-letters/{id}/close` bei `SENT`/`SCHEDULED`-Brief</td><td>Status wechselt auf `CLOSED`</td><td><input type="checkbox" data-cb="step_US_389_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Nach dem Schliessen Bestaetigung versuchen</td><td>Keine weiteren Bestaetigungen werden erwartet (Brief abgeschlossen)</td><td><input type="checkbox" data-cb="step_US_389_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Schliessen eines `DRAFT`- oder bereits `CLOSED`-Briefs versuchen</td><td>HTTP 403 — nur `SENT`/`SCHEDULED` koennen geschlossen werden</td><td><input type="checkbox" data-cb="step_US_389_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>API: `DELETE /api/v1/parent-letters/{id}` bei `DRAFT`-Brief</td><td>Brief und seine Empfaengereintraege werden geloescht</td><td><input type="checkbox" data-cb="step_US_389_4" onchange="onCheck()"></td></tr>
+          <tr><td>5</td><td>Loeschen eines gesendeten Briefs versuchen</td><td>HTTP 403 — nur `DRAFT` ist loeschbar</td><td><input type="checkbox" data-cb="step_US_389_5" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_389_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur `SENT`- oder `SCHEDULED`-Briefe koennen geschlossen werden (Status `CLOSED`)</label>
+        <label><input type="checkbox" data-cb="crit_US_389_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Nur `DRAFT`-Briefe koennen geloescht werden (inkl. Empfaengereintraege)</label>
+        <label><input type="checkbox" data-cb="crit_US_389_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Aktionen sind LEADER des Raums oder SUPERADMIN vorbehalten</label>
+      </div>
+    </div>
+    <div class="story" id="story-US_390" data-story="US-390" data-roles="">
+      <div class="story-header">
+        <div><span class="story-id">US-390</span> <span class="story-title">Konfiguration, Statistik und DSGVO-Bereinigung</span></div>
+      </div>
+      <div class="story-als">Als Administrator moechte ich Elternbrief-Einstellungen pflegen, Statistiken sehen und die DSGVO-Loeschung sicherstellen, damit das Modul rechtskonform und konfigurierbar bleibt.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Modul `parentletter` ist aktiv. Login als SUPERADMIN (bzw. SECTION_ADMIN fuer den eigenen Bereich).</div>
+      <table>
+        <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>API: `GET /api/v1/parent-letter-config?sectionId=`</td><td>Bereichs-Config (Briefkopf-Pfad, Signatur-Template, Erinnerungstage) mit Fallback auf globale Config</td><td><input type="checkbox" data-cb="step_US_390_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>API: `PUT /api/v1/parent-letter-config` mit `{signatureTemplate, reminderDays}`</td><td>Config aktualisiert; `reminderDays` nur 1–30 erlaubt</td><td><input type="checkbox" data-cb="step_US_390_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>API: `POST /api/v1/parent-letter-config/letterhead` (jpeg/png/svg/pdf)</td><td>Briefkopf hochgeladen; vorhandener Briefkopf wird ersetzt</td><td><input type="checkbox" data-cb="step_US_390_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>API: `DELETE /api/v1/parent-letter-config/letterhead`</td><td>Briefkopf wird entfernt</td><td><input type="checkbox" data-cb="step_US_390_4" onchange="onCheck()"></td></tr>
+          <tr><td>5</td><td>Als Lehrkraft/Eltern Config-Endpoints aufrufen</td><td>HTTP 403 — nur SUPERADMIN/SECTION_ADMIN</td><td><input type="checkbox" data-cb="step_US_390_5" onchange="onCheck()"></td></tr>
+          <tr><td>6</td><td>API: `GET /api/v1/parent-letters/stats`</td><td>Statistik: aktive Briefe, Empfaenger gesamt, bestaetigt, gelesen, ueberfaellig</td><td><input type="checkbox" data-cb="step_US_390_6" onchange="onCheck()"></td></tr>
+          <tr><td>7</td><td>Nutzer loeschen (DSGVO): `UserDeletionExecutedEvent`</td><td>Ersteller wird anonymisiert, Empfaengereintraege (als Elternteil und als Kind) werden entfernt</td><td><input type="checkbox" data-cb="step_US_390_7" onchange="onCheck()"></td></tr>
+        </tbody></table>
+      <div class="criteria"><h4>Akzeptanzkriterien:</h4>
+        <label><input type="checkbox" data-cb="crit_US_390_0" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Config wird pro Bereich gelesen/geschrieben, mit Fallback auf die globale Config</label>
+        <label><input type="checkbox" data-cb="crit_US_390_1" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> `reminderDays` ist auf 1–30 begrenzt; nur SUPERADMIN/SECTION_ADMIN duerfen die Config aendern</label>
+        <label><input type="checkbox" data-cb="crit_US_390_2" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Briefkopf-Upload akzeptiert image/jpeg, image/png, image/svg+xml, application/pdf und ersetzt den vorhandenen Briefkopf</label>
+        <label><input type="checkbox" data-cb="crit_US_390_3" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Statistik basiert auf den `SENT`-Briefen des Nutzers (Empfaenger, bestaetigt, gelesen, ueberfaellig)</label>
+        <label><input type="checkbox" data-cb="crit_US_390_4" data-crit="1" data-module="Elternbriefe" onchange="onCheck()"> Bei DSGVO-Loeschung wird der Ersteller anonymisiert und alle Empfaengereintraege des Nutzers entfernt; `exportUserData` liefert erstellte Briefe und Empfaengereintraege</label>
       </div>
     </div>
   </div>
@@ -3042,8 +3388,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-160</span> <span class="story-title">Umfrage erstellen (Raum-Scope, LEADER)</span></div>
       </div>
-      <div class="story-als">Als Raumleiter moechte ich eine Umfrage fuer meinen Raum erstellen, damit ich Meinungen der Raummitglieder einholen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER in einem Raum. Login als `lehrer@monteweb.local`.</div>
+      <div class="story-als">Als Raumleiter moechte ich eine Umfrage fuer meinen Raum erstellen, damit ich Meinungen der Raummitglieder einholen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER in einem Raum. Login als `lehrer@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3063,19 +3409,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>14</td><td>Button &quot;Als Entwurf speichern&quot; klicken</td><td>Toast &quot;Formular gespeichert&quot;, Status ist &quot;Entwurf&quot;</td><td><input type="checkbox" data-cb="step_US_160_14" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_160_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Formular wird mit Status &quot;Entwurf&quot; erstellt</label>
-        <label><input type="checkbox" data-cb="crit_US_160_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Alle Fragetypen verfuegbar: Freitext, Einfachauswahl, Mehrfachauswahl, Bewertung, Ja/Nein</label>
-        <label><input type="checkbox" data-cb="crit_US_160_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Mindestens eine Frage muss vorhanden sein</label>
-        <label><input type="checkbox" data-cb="crit_US_160_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Optionen sind Pflicht fuer Einfach-/Mehrfachauswahl</label>
-        <label><input type="checkbox" data-cb="crit_US_160_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Reihenfolge der Fragen kann per Drag &amp; Drop geaendert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_160_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Formular wird mit Status &quot;Entwurf&quot; erstellt</label>
+        <label><input type="checkbox" data-cb="crit_US_160_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Alle Fragetypen verfuegbar: Freitext, Einfachauswahl, Mehrfachauswahl, Bewertung, Ja/Nein</label>
+        <label><input type="checkbox" data-cb="crit_US_160_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Mindestens eine Frage muss vorhanden sein</label>
+        <label><input type="checkbox" data-cb="crit_US_160_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Optionen sind Pflicht fuer Einfach-/Mehrfachauswahl</label>
+        <label><input type="checkbox" data-cb="crit_US_160_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Reihenfolge der Fragen kann per Drag &amp; Drop geaendert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_161" data-story="US-161" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-161</span> <span class="story-title">Einverstaendniserklaerung erstellen (CONSENT)</span></div>
       </div>
-      <div class="story-als">Als Raumleiter moechte ich eine Einverstaendniserklaerung erstellen, damit Eltern fuer Aktivitaeten zustimmen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (LEADER).</div>
+      <div class="story-als">Als Raumleiter moechte ich eine Einverstaendniserklaerung erstellen, damit Eltern fuer Aktivitaeten zustimmen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (LEADER).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3088,18 +3434,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>&quot;Als Entwurf speichern&quot; klicken</td><td>Formular gespeichert</td><td><input type="checkbox" data-cb="step_US_161_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_161_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Typ &quot;Einverstaendnis&quot; (CONSENT) ist auswahlbar neben &quot;Umfrage&quot; (SURVEY)</label>
-        <label><input type="checkbox" data-cb="crit_US_161_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ja/Nein-Fragetyp zeigt &quot;Ja&quot; und &quot;Nein&quot; als einzige Optionen</label>
-        <label><input type="checkbox" data-cb="crit_US_161_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Einverstaendnis-Formulare funktionieren identisch zu Umfragen</label>
-        <label><input type="checkbox" data-cb="crit_US_161_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Typ kann nach Erstellung nicht mehr geaendert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_161_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Typ &quot;Einverstaendnis&quot; (CONSENT) ist auswahlbar neben &quot;Umfrage&quot; (SURVEY)</label>
+        <label><input type="checkbox" data-cb="crit_US_161_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ja/Nein-Fragetyp zeigt &quot;Ja&quot; und &quot;Nein&quot; als einzige Optionen</label>
+        <label><input type="checkbox" data-cb="crit_US_161_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Einverstaendnis-Formulare funktionieren identisch zu Umfragen</label>
+        <label><input type="checkbox" data-cb="crit_US_161_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Typ kann nach Erstellung nicht mehr geaendert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_162" data-story="US-162" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-162</span> <span class="story-title">Formular veroeffentlichen</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich ein Entwurfsformular veroeffentlichen, damit die Zielgruppe es ausfuellen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular im Status &quot;Entwurf&quot; existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Formularersteller moechte ich ein Entwurfsformular veroeffentlichen, damit die Zielgruppe es ausfuellen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular im Status &quot;Entwurf&quot; existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3111,19 +3457,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>&quot;Formulare&quot; oeffnen, Tab &quot;Verfuegbar&quot;</td><td>Veroeffentlichtes Formular erscheint in der Liste</td><td><input type="checkbox" data-cb="step_US_162_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_162_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Status wechselt von &quot;Entwurf&quot; auf &quot;Veroeffentlicht&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_162_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Veroeffentlichungszeitpunkt wird gespeichert (publishedAt)</label>
-        <label><input type="checkbox" data-cb="crit_US_162_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Veroeffentlichtes Formular ist fuer die Zielgruppe sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_162_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Fragen koennen nach Veroeffentlichung NICHT mehr bearbeitet werden</label>
-        <label><input type="checkbox" data-cb="crit_US_162_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Dashboard-Widget &quot;Offene Formulare&quot; zeigt das Formular an</label>
+        <label><input type="checkbox" data-cb="crit_US_162_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Status wechselt von &quot;Entwurf&quot; auf &quot;Veroeffentlicht&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_162_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Veroeffentlichungszeitpunkt wird gespeichert (publishedAt)</label>
+        <label><input type="checkbox" data-cb="crit_US_162_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Veroeffentlichtes Formular ist fuer die Zielgruppe sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_162_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Fragen koennen nach Veroeffentlichung NICHT mehr bearbeitet werden</label>
+        <label><input type="checkbox" data-cb="crit_US_162_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Dashboard-Widget &quot;Offene Formulare&quot; zeigt das Formular an</label>
       </div>
     </div>
     <div class="story" id="story-US_163" data-story="US-163" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-163</span> <span class="story-title">Formular ausfuellen (Antwort abgeben)</span></div>
       </div>
-      <div class="story-als">Als Raummitglied moechte ich ein veroeffentlichtes Formular ausfuellen, damit meine Meinung oder Einverstaendnis erfasst wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein veroeffentlichtes Formular existiert. Login als Zielgruppen-Benutzer (z.B. `eltern@monteweb.local`).</div>
+      <div class="story-als">Als Raummitglied moechte ich ein veroeffentlichtes Formular ausfuellen, damit meine Meinung oder Einverstaendnis erfasst wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein veroeffentlichtes Formular existiert. Login als Zielgruppen-Benutzer (z.B. `eltern@monteweb.local`).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3134,19 +3480,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Formular erneut oeffnen</td><td>Meldung &quot;Sie haben dieses Formular bereits beantwortet.&quot; mit eigenen Antworten</td><td><input type="checkbox" data-cb="step_US_163_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_163_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Pflichtfragen muessen beantwortet werden (Validierung)</label>
-        <label><input type="checkbox" data-cb="crit_US_163_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Optional-Fragen koennen uebersprungen werden</label>
-        <label><input type="checkbox" data-cb="crit_US_163_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nach Absenden wird Bestaetigung angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_163_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Benutzer kann seine Antwort sehen (bei nicht-anonymen Formularen bearbeiten)</label>
-        <label><input type="checkbox" data-cb="crit_US_163_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Zaehler &quot;Antworten&quot; im Formular erhoet sich</label>
+        <label><input type="checkbox" data-cb="crit_US_163_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Pflichtfragen muessen beantwortet werden (Validierung)</label>
+        <label><input type="checkbox" data-cb="crit_US_163_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Optional-Fragen koennen uebersprungen werden</label>
+        <label><input type="checkbox" data-cb="crit_US_163_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nach Absenden wird Bestaetigung angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_163_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Benutzer kann seine Antwort sehen (bei nicht-anonymen Formularen bearbeiten)</label>
+        <label><input type="checkbox" data-cb="crit_US_163_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Zaehler &quot;Antworten&quot; im Formular erhoet sich</label>
       </div>
     </div>
     <div class="story" id="story-US_164" data-story="US-164" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-164</span> <span class="story-title">Antwort bearbeiten (nicht-anonym)</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich meine Antwort auf ein nicht-anonymes Formular bearbeiten, damit ich Korrekturen vornehmen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat ein nicht-anonymes Formular beantwortet. Formular ist noch &quot;Veroeffentlicht&quot;.</div>
+      <div class="story-als">Als Benutzer moechte ich meine Antwort auf ein nicht-anonymes Formular bearbeiten, damit ich Korrekturen vornehmen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat ein nicht-anonymes Formular beantwortet. Formular ist noch &quot;Veroeffentlicht&quot;.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3156,18 +3502,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>&quot;Antwort aktualisieren&quot; klicken</td><td>Toast &quot;Antwort aktualisiert&quot;</td><td><input type="checkbox" data-cb="step_US_164_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_164_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bearbeiten nur moeglich, solange Formular &quot;Veroeffentlicht&quot; ist</label>
-        <label><input type="checkbox" data-cb="crit_US_164_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bei geschlossenem Formular: keine Bearbeitung moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_164_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Anonyme Antworten koennen NICHT bearbeitet werden (&quot;Anonyme Antworten koennen nicht bearbeitet werden&quot;)</label>
-        <label><input type="checkbox" data-cb="crit_US_164_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bearbeitbare Frist wird ggf. angezeigt (&quot;Bearbeitbar bis&quot;)</label>
+        <label><input type="checkbox" data-cb="crit_US_164_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bearbeiten nur moeglich, solange Formular &quot;Veroeffentlicht&quot; ist</label>
+        <label><input type="checkbox" data-cb="crit_US_164_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bei geschlossenem Formular: keine Bearbeitung moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_164_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Anonyme Antworten koennen NICHT bearbeitet werden (&quot;Anonyme Antworten koennen nicht bearbeitet werden&quot;)</label>
+        <label><input type="checkbox" data-cb="crit_US_164_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bearbeitbare Frist wird ggf. angezeigt (&quot;Bearbeitbar bis&quot;)</label>
       </div>
     </div>
     <div class="story" id="story-US_165" data-story="US-165" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-165</span> <span class="story-title">Formular schliessen</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich ein Formular schliessen, damit keine weiteren Antworten eingehen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein veroeffentlichtes Formular mit Antworten existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Formularersteller moechte ich ein Formular schliessen, damit keine weiteren Antworten eingehen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein veroeffentlichtes Formular mit Antworten existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3178,19 +3524,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Formular oeffnen</td><td>Formular zeigt Antworten an, aber &quot;Antwort absenden&quot;-Button ist deaktiviert</td><td><input type="checkbox" data-cb="step_US_165_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_165_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Status wechselt auf &quot;Geschlossen&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_165_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Keine neuen Antworten moeglich nach Schliessung</label>
-        <label><input type="checkbox" data-cb="crit_US_165_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bestehende Antworten bleiben erhalten</label>
-        <label><input type="checkbox" data-cb="crit_US_165_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Benutzer, die bereits geantwortet haben, koennen ihre Antwort sehen</label>
-        <label><input type="checkbox" data-cb="crit_US_165_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ergebnisse sind nach Schliessung fuer Respondenten sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_165_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Status wechselt auf &quot;Geschlossen&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_165_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Keine neuen Antworten moeglich nach Schliessung</label>
+        <label><input type="checkbox" data-cb="crit_US_165_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bestehende Antworten bleiben erhalten</label>
+        <label><input type="checkbox" data-cb="crit_US_165_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Benutzer, die bereits geantwortet haben, koennen ihre Antwort sehen</label>
+        <label><input type="checkbox" data-cb="crit_US_165_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ergebnisse sind nach Schliessung fuer Respondenten sichtbar</label>
       </div>
     </div>
     <div class="story" id="story-US_166" data-story="US-166" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-166</span> <span class="story-title">Formular archivieren</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich ein geschlossenes Formular archivieren, damit es aus der aktiven Uebersicht verschwindet.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein geschlossenes Formular existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Formularersteller moechte ich ein geschlossenes Formular archivieren, damit es aus der aktiven Uebersicht verschwindet.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein geschlossenes Formular existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3199,18 +3545,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Formularuebersicht pruefen</td><td>Archiviertes Formular ist nicht mehr unter &quot;Verfuegbar&quot; sichtbar</td><td><input type="checkbox" data-cb="step_US_166_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_166_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Status wechselt auf &quot;Archiviert&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_166_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Archiviertes Formular wird aus der Hauptliste entfernt</label>
-        <label><input type="checkbox" data-cb="crit_US_166_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ergebnisse sind weiterhin abrufbar ueber direkten Link</label>
-        <label><input type="checkbox" data-cb="crit_US_166_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur geschlossene Formulare koennen archiviert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_166_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Status wechselt auf &quot;Archiviert&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_166_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Archiviertes Formular wird aus der Hauptliste entfernt</label>
+        <label><input type="checkbox" data-cb="crit_US_166_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ergebnisse sind weiterhin abrufbar ueber direkten Link</label>
+        <label><input type="checkbox" data-cb="crit_US_166_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur geschlossene Formulare koennen archiviert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_167" data-story="US-167" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-167</span> <span class="story-title">Formularergebnisse ansehen</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich die Ergebnisse meines Formulars einsehen, damit ich die Antworten auswerten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular mit Antworten existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Formularersteller moechte ich die Ergebnisse meines Formulars einsehen, damit ich die Antworten auswerten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular mit Antworten existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3223,20 +3569,20 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Tab &quot;Einzelantworten&quot; klicken</td><td>Individuelle Antworten pro Benutzer (bei nicht-anonymen Formularen)</td><td><input type="checkbox" data-cb="step_US_167_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_167_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Zusammenfassung zeigt Ruecklaufquote (Antworten / Zielgruppe)</label>
-        <label><input type="checkbox" data-cb="crit_US_167_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Pro Frage: passende Visualisierung (Balken, Durchschnitt, Textliste)</label>
-        <label><input type="checkbox" data-cb="crit_US_167_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Einzelantworten zeigen Benutzername und Einreichungsdatum</label>
-        <label><input type="checkbox" data-cb="crit_US_167_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bei anonymen Formularen: keine Benutzernamen sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_167_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann Ergebnisse sehen (bei veroeffentlichten Formularen)</label>
-        <label><input type="checkbox" data-cb="crit_US_167_5" data-crit="1" data-module="Formulare" onchange="onCheck()"> Respondenten koennen Ergebnisse geschlossener/archivierter Formulare sehen</label>
+        <label><input type="checkbox" data-cb="crit_US_167_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Zusammenfassung zeigt Ruecklaufquote (Antworten / Zielgruppe)</label>
+        <label><input type="checkbox" data-cb="crit_US_167_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Pro Frage: passende Visualisierung (Balken, Durchschnitt, Textliste)</label>
+        <label><input type="checkbox" data-cb="crit_US_167_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Einzelantworten zeigen Benutzername und Einreichungsdatum</label>
+        <label><input type="checkbox" data-cb="crit_US_167_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bei anonymen Formularen: keine Benutzernamen sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_167_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann Ergebnisse sehen (bei veroeffentlichten Formularen)</label>
+        <label><input type="checkbox" data-cb="crit_US_167_5" data-crit="1" data-module="Formulare" onchange="onCheck()"> Respondenten koennen Ergebnisse geschlossener/archivierter Formulare sehen</label>
       </div>
     </div>
     <div class="story" id="story-US_168" data-story="US-168" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-168</span> <span class="story-title">CSV-Export der Ergebnisse</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich die Ergebnisse als CSV exportieren, damit ich sie in Excel oder anderen Tools weiterverarbeiten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular mit Antworten existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Formularersteller moechte ich die Ergebnisse als CSV exportieren, damit ich sie in Excel oder anderen Tools weiterverarbeiten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular mit Antworten existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3245,18 +3591,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>CSV-Datei in Tabellenprogramm oeffnen</td><td>Daten sind korrekt formatiert mit Spalten pro Frage</td><td><input type="checkbox" data-cb="step_US_168_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_168_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> CSV enthaelt alle Antworten mit Spaltenkoepfen (Fragentexte)</label>
-        <label><input type="checkbox" data-cb="crit_US_168_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bei anonymen Formularen: keine Benutzernamen im CSV</label>
-        <label><input type="checkbox" data-cb="crit_US_168_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> CSV-Encoding ist UTF-8 (Umlaute korrekt)</label>
-        <label><input type="checkbox" data-cb="crit_US_168_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann exportieren</label>
+        <label><input type="checkbox" data-cb="crit_US_168_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> CSV enthaelt alle Antworten mit Spaltenkoepfen (Fragentexte)</label>
+        <label><input type="checkbox" data-cb="crit_US_168_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bei anonymen Formularen: keine Benutzernamen im CSV</label>
+        <label><input type="checkbox" data-cb="crit_US_168_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> CSV-Encoding ist UTF-8 (Umlaute korrekt)</label>
+        <label><input type="checkbox" data-cb="crit_US_168_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann exportieren</label>
       </div>
     </div>
     <div class="story" id="story-US_169" data-story="US-169" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-169</span> <span class="story-title">PDF-Export der Ergebnisse</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich die Ergebnisse als PDF exportieren, damit ich sie ausdrucken oder archivieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular mit Antworten existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Formularersteller moechte ich die Ergebnisse als PDF exportieren, damit ich sie ausdrucken oder archivieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular mit Antworten existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3265,19 +3611,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>PDF oeffnen und pruefen</td><td>Formulartitel, Zusammenfassung und Ergebnisse pro Frage sind enthalten</td><td><input type="checkbox" data-cb="step_US_169_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_169_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> PDF enthaelt Formulartitel, Beschreibung und Erstellungsdatum</label>
-        <label><input type="checkbox" data-cb="crit_US_169_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Zusammenfassung mit Ruecklaufquote</label>
-        <label><input type="checkbox" data-cb="crit_US_169_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Pro Frage: Ergebnisse mit Zahlen/Prozenten</label>
-        <label><input type="checkbox" data-cb="crit_US_169_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> PDF ist druckoptimiert</label>
-        <label><input type="checkbox" data-cb="crit_US_169_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann exportieren</label>
+        <label><input type="checkbox" data-cb="crit_US_169_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> PDF enthaelt Formulartitel, Beschreibung und Erstellungsdatum</label>
+        <label><input type="checkbox" data-cb="crit_US_169_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Zusammenfassung mit Ruecklaufquote</label>
+        <label><input type="checkbox" data-cb="crit_US_169_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Pro Frage: Ergebnisse mit Zahlen/Prozenten</label>
+        <label><input type="checkbox" data-cb="crit_US_169_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> PDF ist druckoptimiert</label>
+        <label><input type="checkbox" data-cb="crit_US_169_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann exportieren</label>
       </div>
     </div>
     <div class="story" id="story-US_170" data-story="US-170" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-170</span> <span class="story-title">Bereichs-Formular erstellen (SECTION-Scope)</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft moechte ich ein Formular fuer einen Schulbereich erstellen, damit alle Benutzer des Bereichs es ausfuellen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (TEACHER).</div>
+      <div class="story-als">Als Lehrkraft moechte ich ein Formular fuer einen Schulbereich erstellen, damit alle Benutzer des Bereichs es ausfuellen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` (TEACHER).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3288,17 +3634,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Fragen hinzufuegen und Formular speichern</td><td>Formular wird erstellt</td><td><input type="checkbox" data-cb="step_US_170_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_170_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur TEACHER, SECTION_ADMIN und SUPERADMIN koennen Bereichs-Formulare erstellen</label>
-        <label><input type="checkbox" data-cb="crit_US_170_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> PARENT und STUDENT koennen KEINE Bereichs-Formulare erstellen</label>
-        <label><input type="checkbox" data-cb="crit_US_170_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Formular ist fuer alle Benutzer des gewaehlten Bereichs sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_170_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur TEACHER, SECTION_ADMIN und SUPERADMIN koennen Bereichs-Formulare erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_170_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> PARENT und STUDENT koennen KEINE Bereichs-Formulare erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_170_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Formular ist fuer alle Benutzer des gewaehlten Bereichs sichtbar</label>
       </div>
     </div>
     <div class="story" id="story-US_171" data-story="US-171" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-171</span> <span class="story-title">Multi-Section-Formular erstellen</span></div>
       </div>
-      <div class="story-als">Als Lehrkraft moechte ich ein Formular fuer mehrere Schulbereiche gleichzeitig erstellen, damit ich bereichsuebergreifende Umfragen durchfuehren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` oder `admin@monteweb.local`.</div>
+      <div class="story-als">Als Lehrkraft moechte ich ein Formular fuer mehrere Schulbereiche gleichzeitig erstellen, damit ich bereichsuebergreifende Umfragen durchfuehren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `lehrer@monteweb.local` oder `admin@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3313,18 +3659,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>9</td><td>Login als Benutzer aus Bereich 3 (nicht gewaehlt)</td><td>Formular ist NICHT sichtbar</td><td><input type="checkbox" data-cb="step_US_171_9" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_171_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Mehrere Schulbereiche koennen gleichzeitig ausgewaehlt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_171_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Formular zeigt alle gewaehlten Bereichsnamen an (sectionNames)</label>
-        <label><input type="checkbox" data-cb="crit_US_171_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Benutzer der ausgewaehlten Bereiche sehen das Formular</label>
-        <label><input type="checkbox" data-cb="crit_US_171_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> section_ids werden als UUID-Array (mit GIN-Index) gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_171_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Mehrere Schulbereiche koennen gleichzeitig ausgewaehlt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_171_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Formular zeigt alle gewaehlten Bereichsnamen an (sectionNames)</label>
+        <label><input type="checkbox" data-cb="crit_US_171_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Benutzer der ausgewaehlten Bereiche sehen das Formular</label>
+        <label><input type="checkbox" data-cb="crit_US_171_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> section_ids werden als UUID-Array (mit GIN-Index) gespeichert</label>
       </div>
     </div>
     <div class="story" id="story-US_172" data-story="US-172" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-172</span> <span class="story-title">Schulweites Formular erstellen (SCHOOL-Scope, SA)</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich ein schulweites Formular erstellen, damit alle Benutzer der Schule es ausfuellen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local` (SUPERADMIN).</div>
+      <div class="story-als">Als Superadmin moechte ich ein schulweites Formular erstellen, damit alle Benutzer der Schule es ausfuellen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local` (SUPERADMIN).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3336,17 +3682,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Login als beliebiger Benutzer (SA, T, P, S)</td><td>Formular ist fuer alle sichtbar</td><td><input type="checkbox" data-cb="step_US_172_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_172_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur SUPERADMIN kann schulweite Formulare erstellen</label>
-        <label><input type="checkbox" data-cb="crit_US_172_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Schulweites Formular ist fuer ALLE Benutzer sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_172_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> targetCount zeigt Gesamtzahl aller Benutzer</label>
+        <label><input type="checkbox" data-cb="crit_US_172_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur SUPERADMIN kann schulweite Formulare erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_172_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Schulweites Formular ist fuer ALLE Benutzer sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_172_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> targetCount zeigt Gesamtzahl aller Benutzer</label>
       </div>
     </div>
     <div class="story" id="story-US_173" data-story="US-173" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-173</span> <span class="story-title">Berechtigungspruefung — Eltern/Schueler koennen keine Formulare erstellen</span></div>
       </div>
-      <div class="story-als">Als System moechte ich verhindern, dass Eltern oder Schueler Formulare erstellen, damit nur autorisierte Rollen Umfragen anlegen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `eltern@monteweb.local` (PARENT).</div>
+      <div class="story-als">Als System moechte ich verhindern, dass Eltern oder Schueler Formulare erstellen, damit nur autorisierte Rollen Umfragen anlegen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `eltern@monteweb.local` (PARENT).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3357,18 +3703,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Pruefen, ob Button &quot;Formular erstellen&quot; sichtbar ist</td><td>Button ist NICHT sichtbar fuer STUDENT</td><td><input type="checkbox" data-cb="step_US_173_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_173_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> PARENT sieht keinen &quot;Formular erstellen&quot;-Button</label>
-        <label><input type="checkbox" data-cb="crit_US_173_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> STUDENT sieht keinen &quot;Formular erstellen&quot;-Button</label>
-        <label><input type="checkbox" data-cb="crit_US_173_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> API lehnt Erstellung durch nicht-autorisierte Rollen ab</label>
-        <label><input type="checkbox" data-cb="crit_US_173_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Berechtigungsmatrix: LEADER (Raum), TEACHER/SECADMIN (Bereich), SA (Schulweit)</label>
+        <label><input type="checkbox" data-cb="crit_US_173_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> PARENT sieht keinen &quot;Formular erstellen&quot;-Button</label>
+        <label><input type="checkbox" data-cb="crit_US_173_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> STUDENT sieht keinen &quot;Formular erstellen&quot;-Button</label>
+        <label><input type="checkbox" data-cb="crit_US_173_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> API lehnt Erstellung durch nicht-autorisierte Rollen ab</label>
+        <label><input type="checkbox" data-cb="crit_US_173_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Berechtigungsmatrix: LEADER (Raum), TEACHER/SECADMIN (Bereich), SA (Schulweit)</label>
       </div>
     </div>
     <div class="story" id="story-US_174" data-story="US-174" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-174</span> <span class="story-title">Formular loeschen</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich ein Formular loeschen, damit fehlerhafte oder nicht mehr benoetigte Formulare entfernt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular existiert (beliebiger Status). Login als Ersteller.</div>
+      <div class="story-als">Als Formularersteller moechte ich ein Formular loeschen, damit fehlerhafte oder nicht mehr benoetigte Formulare entfernt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular existiert (beliebiger Status). Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3378,18 +3724,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Formularuebersicht pruefen</td><td>Formular ist nicht mehr vorhanden</td><td><input type="checkbox" data-cb="step_US_174_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_174_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ersteller kann eigene Formulare loeschen (jeder Status)</label>
-        <label><input type="checkbox" data-cb="crit_US_174_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> SUPERADMIN kann jedes Formular loeschen (unabhaengig vom Ersteller und Status)</label>
-        <label><input type="checkbox" data-cb="crit_US_174_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Alle zugehoerigen Antworten werden mitgeloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_174_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
+        <label><input type="checkbox" data-cb="crit_US_174_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ersteller kann eigene Formulare loeschen (jeder Status)</label>
+        <label><input type="checkbox" data-cb="crit_US_174_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> SUPERADMIN kann jedes Formular loeschen (unabhaengig vom Ersteller und Status)</label>
+        <label><input type="checkbox" data-cb="crit_US_174_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Alle zugehoerigen Antworten werden mitgeloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_174_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bestaetigungsdialog vor Loeschung</label>
       </div>
     </div>
     <div class="story" id="story-US_175" data-story="US-175" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-175</span> <span class="story-title">Dashboard-Widget — Offene Formulare</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich auf dem Dashboard sehen, welche Formulare ich noch ausfuellen muss, damit ich keine Fristen verpasse.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Veroeffentlichte Formulare existieren, die der Benutzer noch nicht beantwortet hat. Login als Zielgruppen-Benutzer.</div>
+      <div class="story-als">Als Benutzer moechte ich auf dem Dashboard sehen, welche Formulare ich noch ausfuellen muss, damit ich keine Fristen verpasse.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Veroeffentlichte Formulare existieren, die der Benutzer noch nicht beantwortet hat. Login als Zielgruppen-Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3399,19 +3745,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Formular ausfuellen und absenden</td><td>Formular verschwindet aus dem Dashboard-Widget</td><td><input type="checkbox" data-cb="step_US_175_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_175_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Widget zeigt nur Formulare, die der Benutzer noch NICHT beantwortet hat</label>
-        <label><input type="checkbox" data-cb="crit_US_175_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Widget zeigt Formulartitel und ggf. Frist</label>
-        <label><input type="checkbox" data-cb="crit_US_175_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Abgelaufene Fristen werden markiert (&quot;Frist abgelaufen&quot;)</label>
-        <label><input type="checkbox" data-cb="crit_US_175_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Klick fuehrt direkt zum Formular</label>
-        <label><input type="checkbox" data-cb="crit_US_175_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Widget wird auf dem Dashboard angezeigt (wenn Formulare-Modul aktiv)</label>
+        <label><input type="checkbox" data-cb="crit_US_175_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Widget zeigt nur Formulare, die der Benutzer noch NICHT beantwortet hat</label>
+        <label><input type="checkbox" data-cb="crit_US_175_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Widget zeigt Formulartitel und ggf. Frist</label>
+        <label><input type="checkbox" data-cb="crit_US_175_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Abgelaufene Fristen werden markiert (&quot;Frist abgelaufen&quot;)</label>
+        <label><input type="checkbox" data-cb="crit_US_175_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Klick fuehrt direkt zum Formular</label>
+        <label><input type="checkbox" data-cb="crit_US_175_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Widget wird auf dem Dashboard angezeigt (wenn Formulare-Modul aktiv)</label>
       </div>
     </div>
     <div class="story" id="story-US_176" data-story="US-176" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-176</span> <span class="story-title">Formulartypen — Alle Fragetypen testen</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich alle verfuegbaren Fragetypen nutzen, damit ich flexible Umfragen gestalten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als Benutzer mit Erstellberechtigung.</div>
+      <div class="story-als">Als Formularersteller moechte ich alle verfuegbaren Fragetypen nutzen, damit ich flexible Umfragen gestalten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als Benutzer mit Erstellberechtigung.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3426,19 +3772,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>9</td><td>Ergebnisse pruefen</td><td>Jeder Fragetyp hat passende Auswertung</td><td><input type="checkbox" data-cb="step_US_176_9" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_176_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Freitext: Freies Eingabefeld, Ergebnis zeigt alle Textantworten</label>
-        <label><input type="checkbox" data-cb="crit_US_176_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Einfachauswahl: Genau eine Option waehlbar, Ergebnis zeigt Balkendiagramm</label>
-        <label><input type="checkbox" data-cb="crit_US_176_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Mehrfachauswahl: Mehrere Optionen waehlbar, Ergebnis zeigt Balkendiagramm</label>
-        <label><input type="checkbox" data-cb="crit_US_176_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bewertung: Sternebewertung, Ergebnis zeigt Durchschnitt und Verteilung</label>
-        <label><input type="checkbox" data-cb="crit_US_176_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ja/Nein: Zwei Optionen, Ergebnis zeigt Ja/Nein-Zaehler</label>
+        <label><input type="checkbox" data-cb="crit_US_176_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Freitext: Freies Eingabefeld, Ergebnis zeigt alle Textantworten</label>
+        <label><input type="checkbox" data-cb="crit_US_176_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Einfachauswahl: Genau eine Option waehlbar, Ergebnis zeigt Balkendiagramm</label>
+        <label><input type="checkbox" data-cb="crit_US_176_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Mehrfachauswahl: Mehrere Optionen waehlbar, Ergebnis zeigt Balkendiagramm</label>
+        <label><input type="checkbox" data-cb="crit_US_176_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bewertung: Sternebewertung, Ergebnis zeigt Durchschnitt und Verteilung</label>
+        <label><input type="checkbox" data-cb="crit_US_176_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ja/Nein: Zwei Optionen, Ergebnis zeigt Ja/Nein-Zaehler</label>
       </div>
     </div>
     <div class="story" id="story-US_177" data-story="US-177" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-177</span> <span class="story-title">Formular mit Frist — Fristablauf</span></div>
       </div>
-      <div class="story-als">Als System moechte ich nach Fristablauf keine Antworten mehr annehmen, damit Fristen eingehalten werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular mit Frist in der Vergangenheit existiert. Login als Zielgruppen-Benutzer.</div>
+      <div class="story-als">Als System moechte ich nach Fristablauf keine Antworten mehr annehmen, damit Fristen eingehalten werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular mit Frist in der Vergangenheit existiert. Login als Zielgruppen-Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3447,18 +3793,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>API: `POST /api/v1/forms/{id}/responses`</td><td>HTTP 400 — Frist abgelaufen</td><td><input type="checkbox" data-cb="step_US_177_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_177_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nach Fristablauf: keine neuen Antworten moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_177_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Visueller Hinweis &quot;Frist abgelaufen&quot; auf dem Formular</label>
-        <label><input type="checkbox" data-cb="crit_US_177_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bestehende Antworten bleiben erhalten</label>
-        <label><input type="checkbox" data-cb="crit_US_177_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ersteller kann Formular trotz Fristablauf schliessen/archivieren</label>
+        <label><input type="checkbox" data-cb="crit_US_177_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nach Fristablauf: keine neuen Antworten moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_177_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Visueller Hinweis &quot;Frist abgelaufen&quot; auf dem Formular</label>
+        <label><input type="checkbox" data-cb="crit_US_177_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bestehende Antworten bleiben erhalten</label>
+        <label><input type="checkbox" data-cb="crit_US_177_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ersteller kann Formular trotz Fristablauf schliessen/archivieren</label>
       </div>
     </div>
     <div class="story" id="story-US_178" data-story="US-178" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-178</span> <span class="story-title">Formulare-Modul deaktiviert</span></div>
       </div>
-      <div class="story-als">Als System moechte ich das Formulare-Modul komplett abschalten koennen, damit die Schule bei Bedarf auf Umfragen verzichten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
+      <div class="story-als">Als System moechte ich das Formulare-Modul komplett abschalten koennen, damit die Schule bei Bedarf auf Umfragen verzichten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als `admin@monteweb.local`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3470,18 +3816,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Modul wieder aktivieren</td><td>Alle Formulare und Antworten sind wiederhergestellt</td><td><input type="checkbox" data-cb="step_US_178_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_178_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Kein Menue-Eintrag &quot;Formulare&quot; bei deaktiviertem Modul</label>
-        <label><input type="checkbox" data-cb="crit_US_178_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Dashboard-Widget verschwindet</label>
-        <label><input type="checkbox" data-cb="crit_US_178_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> API-Endpunkte nicht erreichbar</label>
-        <label><input type="checkbox" data-cb="crit_US_178_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Reaktivierung stellt alle Daten wieder her</label>
+        <label><input type="checkbox" data-cb="crit_US_178_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Kein Menue-Eintrag &quot;Formulare&quot; bei deaktiviertem Modul</label>
+        <label><input type="checkbox" data-cb="crit_US_178_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Dashboard-Widget verschwindet</label>
+        <label><input type="checkbox" data-cb="crit_US_178_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> API-Endpunkte nicht erreichbar</label>
+        <label><input type="checkbox" data-cb="crit_US_178_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Reaktivierung stellt alle Daten wieder her</label>
       </div>
     </div>
     <div class="story" id="story-US_179" data-story="US-179" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-179</span> <span class="story-title">Einzelantworten einsehen (nicht-anonymes Formular)</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich die Einzelantworten einsehen, damit ich sehen kann, wer was geantwortet hat.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein nicht-anonymes Formular mit mehreren Antworten existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Formularersteller moechte ich die Einzelantworten einsehen, damit ich sehen kann, wer was geantwortet hat.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein nicht-anonymes Formular mit mehreren Antworten existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3491,18 +3837,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Einreichungsdatum pruefen</td><td>&quot;Eingereicht am&quot; mit Datum und Uhrzeit</td><td><input type="checkbox" data-cb="step_US_179_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_179_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Einzelantworten zeigen Benutzername und Einreichungszeitpunkt</label>
-        <label><input type="checkbox" data-cb="crit_US_179_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Alle Fragen und Antworten des Benutzers werden angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_179_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bei anonymen Formularen: Benutzername ist &quot;Anonym&quot;</label>
-        <label><input type="checkbox" data-cb="crit_US_179_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann Einzelantworten einsehen</label>
+        <label><input type="checkbox" data-cb="crit_US_179_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Einzelantworten zeigen Benutzername und Einreichungszeitpunkt</label>
+        <label><input type="checkbox" data-cb="crit_US_179_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Alle Fragen und Antworten des Benutzers werden angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_179_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Bei anonymen Formularen: Benutzername ist &quot;Anonym&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_179_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nur Ersteller oder SUPERADMIN kann Einzelantworten einsehen</label>
       </div>
     </div>
     <div class="story" id="story-US_180" data-story="US-180" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-180</span> <span class="story-title">Formular bearbeiten (im Entwurf)</span></div>
       </div>
-      <div class="story-als">Als Formularersteller moechte ich ein Entwurfsformular bearbeiten, damit ich Fragen vor der Veroeffentlichung anpassen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular im Status &quot;Entwurf&quot; existiert. Login als Ersteller.</div>
+      <div class="story-als">Als Formularersteller moechte ich ein Entwurfsformular bearbeiten, damit ich Fragen vor der Veroeffentlichung anpassen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Formular im Status &quot;Entwurf&quot; existiert. Login als Ersteller.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3515,19 +3861,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Aenderungen speichern</td><td>Toast &quot;Formular gespeichert&quot;</td><td><input type="checkbox" data-cb="step_US_180_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_180_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Im Entwurfsstatus: alle Felder editierbar (Titel, Beschreibung, Frist, Fragen)</label>
-        <label><input type="checkbox" data-cb="crit_US_180_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Fragen koennen hinzugefuegt, entfernt und umsortiert werden</label>
-        <label><input type="checkbox" data-cb="crit_US_180_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Optionen bei Auswahlfragen koennen angepasst werden</label>
-        <label><input type="checkbox" data-cb="crit_US_180_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nach Veroeffentlichung: nur noch Titel, Beschreibung und Frist editierbar</label>
-        <label><input type="checkbox" data-cb="crit_US_180_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Fragen koennen nach Veroeffentlichung NICHT mehr geaendert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_180_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Im Entwurfsstatus: alle Felder editierbar (Titel, Beschreibung, Frist, Fragen)</label>
+        <label><input type="checkbox" data-cb="crit_US_180_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Fragen koennen hinzugefuegt, entfernt und umsortiert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_180_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Optionen bei Auswahlfragen koennen angepasst werden</label>
+        <label><input type="checkbox" data-cb="crit_US_180_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Nach Veroeffentlichung: nur noch Titel, Beschreibung und Frist editierbar</label>
+        <label><input type="checkbox" data-cb="crit_US_180_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Fragen koennen nach Veroeffentlichung NICHT mehr geaendert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_181" data-story="US-181" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-181</span> <span class="story-title">Negativtest — Formular ohne Fragen erstellen</span></div>
       </div>
-      <div class="story-als">Als System moechte ich verhindern, dass ein Formular ohne Fragen veroeffentlicht wird, damit nur sinnvolle Formulare erstellt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als Benutzer mit Erstellberechtigung.</div>
+      <div class="story-als">Als System moechte ich verhindern, dass ein Formular ohne Fragen veroeffentlicht wird, damit nur sinnvolle Formulare erstellt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Login als Benutzer mit Erstellberechtigung.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3538,19 +3884,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Formular ohne Titel speichern</td><td>Fehlermeldung — Titel ist Pflichtfeld</td><td><input type="checkbox" data-cb="step_US_181_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_181_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierung: mindestens eine Frage erforderlich</label>
-        <label><input type="checkbox" data-cb="crit_US_181_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierung: Titel ist Pflichtfeld</label>
-        <label><input type="checkbox" data-cb="crit_US_181_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierung: Einfach-/Mehrfachauswahl benoetigt mindestens 2 Optionen</label>
-        <label><input type="checkbox" data-cb="crit_US_181_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierung: Pflichtfeld &quot;Fragetext&quot; bei jeder Frage</label>
-        <label><input type="checkbox" data-cb="crit_US_181_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierungsfehler werden als verstaendliche Fehlermeldungen angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_181_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierung: mindestens eine Frage erforderlich</label>
+        <label><input type="checkbox" data-cb="crit_US_181_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierung: Titel ist Pflichtfeld</label>
+        <label><input type="checkbox" data-cb="crit_US_181_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierung: Einfach-/Mehrfachauswahl benoetigt mindestens 2 Optionen</label>
+        <label><input type="checkbox" data-cb="crit_US_181_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierung: Pflichtfeld &quot;Fragetext&quot; bei jeder Frage</label>
+        <label><input type="checkbox" data-cb="crit_US_181_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Validierungsfehler werden als verstaendliche Fehlermeldungen angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_182" data-story="US-182" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-182</span> <span class="story-title">Formular-Scope-Berechtigungen im Ueberblick</span></div>
       </div>
-      <div class="story-als">Als System moechte ich sicherstellen, dass alle Scope-Berechtigungen korrekt durchgesetzt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Verschiedene Benutzer mit verschiedenen Rollen.</div>
+      <div class="story-als">Als System moechte ich sicherstellen, dass alle Scope-Berechtigungen korrekt durchgesetzt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Verschiedene Benutzer mit verschiedenen Rollen.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3564,11 +3910,11 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Login als SUPERADMIN — beliebiges Formular loeschen</td><td>Erfolgreich (unabhaengig vom Ersteller)</td><td><input type="checkbox" data-cb="step_US_182_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_182_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> ROOM-Scope: nur LEADER des Raums oder SUPERADMIN</label>
-        <label><input type="checkbox" data-cb="crit_US_182_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> SECTION-Scope: nur TEACHER, SECTION_ADMIN oder SUPERADMIN</label>
-        <label><input type="checkbox" data-cb="crit_US_182_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> SCHOOL-Scope: nur SUPERADMIN</label>
-        <label><input type="checkbox" data-cb="crit_US_182_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> SUPERADMIN kann jedes Formular verwalten und loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_182_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ersteller kann sein eigenes Formular immer verwalten</label>
+        <label><input type="checkbox" data-cb="crit_US_182_0" data-crit="1" data-module="Formulare" onchange="onCheck()"> ROOM-Scope: nur LEADER des Raums oder SUPERADMIN</label>
+        <label><input type="checkbox" data-cb="crit_US_182_1" data-crit="1" data-module="Formulare" onchange="onCheck()"> SECTION-Scope: nur TEACHER, SECTION_ADMIN oder SUPERADMIN</label>
+        <label><input type="checkbox" data-cb="crit_US_182_2" data-crit="1" data-module="Formulare" onchange="onCheck()"> SCHOOL-Scope: nur SUPERADMIN</label>
+        <label><input type="checkbox" data-cb="crit_US_182_3" data-crit="1" data-module="Formulare" onchange="onCheck()"> SUPERADMIN kann jedes Formular verwalten und loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_182_4" data-crit="1" data-module="Formulare" onchange="onCheck()"> Ersteller kann sein eigenes Formular immer verwalten</label>
       </div>
     </div>
   </div>
@@ -3586,8 +3932,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-200</span> <span class="story-title">Job erstellen als Elternteil</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich einen neuen Job in der Jobboerse erstellen, damit andere Eltern sich fuer die Aufgabe bewerben koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `eltern@monteweb.local` eingeloggt. Modul Jobboard ist aktiviert (`monteweb.modules.jobboard.enabled=true`). Benutzer gehoert einem Familienverbund an.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich einen neuen Job in der Jobboerse erstellen, damit andere Eltern sich fuer die Aufgabe bewerben koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `eltern@monteweb.local` eingeloggt. Modul Jobboard ist aktiviert (`monteweb.modules.jobboard.enabled=true`). Benutzer gehoert einem Familienverbund an.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3598,19 +3944,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Pruefe die Job-Detailansicht</td><td>Alle eingegebenen Daten werden korrekt angezeigt, Ersteller ist der eingeloggte Benutzer</td><td><input type="checkbox" data-cb="step_US_200_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_200_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Job wird mit Status `OPEN` und Sichtbarkeit `PUBLIC` erstellt</label>
-        <label><input type="checkbox" data-cb="crit_US_200_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Titel (max 300 Zeichen), Beschreibung, Kategorie (max 100 Zeichen), Ort (max 200 Zeichen) werden gespeichert</label>
-        <label><input type="checkbox" data-cb="crit_US_200_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Geschaetzte Stunden (BigDecimal, Precision 5, Scale 2) werden korrekt gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_200_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `createdBy` wird automatisch auf den eingeloggten Benutzer gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_200_4" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `createdAt` und `updatedAt` werden automatisch gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_200_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Job wird mit Status `OPEN` und Sichtbarkeit `PUBLIC` erstellt</label>
+        <label><input type="checkbox" data-cb="crit_US_200_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Titel (max 300 Zeichen), Beschreibung, Kategorie (max 100 Zeichen), Ort (max 200 Zeichen) werden gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_200_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Geschaetzte Stunden (BigDecimal, Precision 5, Scale 2) werden korrekt gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_200_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `createdBy` wird automatisch auf den eingeloggten Benutzer gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_200_4" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `createdAt` und `updatedAt` werden automatisch gesetzt</label>
       </div>
     </div>
     <div class="story" id="story-US_201" data-story="US-201" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-201</span> <span class="story-title">Student kann keinen Job erstellen</span></div>
       </div>
-      <div class="story-als">Als Schueler (S) moechte ich sicherstellen, dass ich keine Jobs erstellen kann, damit die Jobboerse nur von berechtigten Rollen genutzt wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `schueler@monteweb.local` eingeloggt.</div>
+      <div class="story-als">Als Schueler (S) moechte ich sicherstellen, dass ich keine Jobs erstellen kann, damit die Jobboerse nur von berechtigten Rollen genutzt wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `schueler@monteweb.local` eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3618,16 +3964,16 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Versuche einen Job ueber POST /api/v1/jobs zu erstellen</td><td>HTTP 403 Forbidden: &quot;Students cannot create jobs&quot;</td><td><input type="checkbox" data-cb="step_US_201_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_201_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Schueler erhalten beim Versuch, einen Job zu erstellen, einen 403-Fehler</label>
-        <label><input type="checkbox" data-cb="crit_US_201_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Der Button &quot;Job erstellen&quot; ist fuer Schueler im Frontend nicht sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_201_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Schueler erhalten beim Versuch, einen Job zu erstellen, einen 403-Fehler</label>
+        <label><input type="checkbox" data-cb="crit_US_201_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Der Button &quot;Job erstellen&quot; ist fuer Schueler im Frontend nicht sichtbar</label>
       </div>
     </div>
     <div class="story" id="story-US_202" data-story="US-202" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-202</span> <span class="story-title">Privaten Job erstellen mit Auto-Zuweisung</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich einen privaten Job (PRIVATE) erstellen, damit die Stunden direkt meiner Familie gutgeschrieben werden, ohne dass andere sich bewerben muessen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `eltern@monteweb.local` eingeloggt und gehoert einem Familienverbund an.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich einen privaten Job (PRIVATE) erstellen, damit die Stunden direkt meiner Familie gutgeschrieben werden, ohne dass andere sich bewerben muessen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `eltern@monteweb.local` eingeloggt und gehoert einem Familienverbund an.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3637,18 +3983,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefe `maxAssignees`</td><td>Wurde automatisch auf 1 gesetzt, unabhaengig vom eingegebenen Wert</td><td><input type="checkbox" data-cb="step_US_202_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_202_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei PRIVATE-Sichtbarkeit wird `maxAssignees` automatisch auf 1 gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_202_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Eine automatische Zuweisung (Assignment) fuer den Ersteller wird angelegt</label>
-        <label><input type="checkbox" data-cb="crit_US_202_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Job-Status wird sofort auf `ASSIGNED` gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_202_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Die `familyId` der Zuweisung entspricht dem ersten Familienverbund des Erstellers</label>
+        <label><input type="checkbox" data-cb="crit_US_202_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei PRIVATE-Sichtbarkeit wird `maxAssignees` automatisch auf 1 gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_202_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Eine automatische Zuweisung (Assignment) fuer den Ersteller wird angelegt</label>
+        <label><input type="checkbox" data-cb="crit_US_202_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Job-Status wird sofort auf `ASSIGNED` gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_202_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Die `familyId` der Zuweisung entspricht dem ersten Familienverbund des Erstellers</label>
       </div>
     </div>
     <div class="story" id="story-US_203" data-story="US-203" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-203</span> <span class="story-title">Draft-Job erstellen und genehmigen</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich einen Job als Entwurf (DRAFT) erstellen, damit ein Admin ihn vor Veroeffentlichung pruefen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `eltern@monteweb.local` eingeloggt. Ein SUPERADMIN oder JOBBOARD_ADMIN steht zur Genehmigung bereit.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich einen Job als Entwurf (DRAFT) erstellen, damit ein Admin ihn vor Veroeffentlichung pruefen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `eltern@monteweb.local` eingeloggt. Ein SUPERADMIN oder JOBBOARD_ADMIN steht zur Genehmigung bereit.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3660,17 +4006,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Pruefe als Elternteil die Jobboerse erneut</td><td>Der genehmigte Job ist jetzt in der Liste sichtbar</td><td><input type="checkbox" data-cb="step_US_203_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_203_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur DRAFT-Jobs koennen genehmigt werden (Fehler bei bereits PUBLIC-Jobs)</label>
-        <label><input type="checkbox" data-cb="crit_US_203_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur SUPERADMIN, SECTION_ADMIN oder Benutzer mit specialRole JOBBOARD_ADMIN koennen genehmigen</label>
-        <label><input type="checkbox" data-cb="crit_US_203_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nach Genehmigung: `visibility=PUBLIC`, `approvedBy` und `approvedAt` werden gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_203_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur DRAFT-Jobs koennen genehmigt werden (Fehler bei bereits PUBLIC-Jobs)</label>
+        <label><input type="checkbox" data-cb="crit_US_203_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur SUPERADMIN, SECTION_ADMIN oder Benutzer mit specialRole JOBBOARD_ADMIN koennen genehmigen</label>
+        <label><input type="checkbox" data-cb="crit_US_203_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nach Genehmigung: `visibility=PUBLIC`, `approvedBy` und `approvedAt` werden gesetzt</label>
       </div>
     </div>
     <div class="story" id="story-US_204" data-story="US-204" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-204</span> <span class="story-title">Fuer einen Job bewerben</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich mich fuer einen offenen Job bewerben, damit ich Elternstunden sammeln kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Job mit Status OPEN existiert. Benutzer ist als `eltern@monteweb.local` eingeloggt und gehoert einem Familienverbund an.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich mich fuer einen offenen Job bewerben, damit ich Elternstunden sammeln kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Job mit Status OPEN existiert. Benutzer ist als `eltern@monteweb.local` eingeloggt und gehoert einem Familienverbund an.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3680,19 +4026,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefe den Job-Status</td><td>Bei maxAssignees=1: Status wechselt zu `ASSIGNED`. Bei maxAssignees&gt;1: Status wechselt zu `PARTIALLY_ASSIGNED`</td><td><input type="checkbox" data-cb="step_US_204_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_204_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur Eltern koennen sich bewerben (SUPERADMIN, SECTION_ADMIN, TEACHER werden mit 403 abgelehnt: &quot;This role does not perform parent hours&quot;)</label>
-        <label><input type="checkbox" data-cb="crit_US_204_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Doppelte Bewerbung wird verhindert (&quot;You have already applied for this job&quot;)</label>
-        <label><input type="checkbox" data-cb="crit_US_204_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei Erreichen von maxAssignees wird der Job-Status zu ASSIGNED</label>
-        <label><input type="checkbox" data-cb="crit_US_204_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bewerber muss einem Familienverbund angehoeren (&quot;You must belong to a family to apply for jobs&quot;)</label>
-        <label><input type="checkbox" data-cb="crit_US_204_4" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Pessimistic Lock verhindert Race Conditions bei gleichzeitigen Bewerbungen</label>
+        <label><input type="checkbox" data-cb="crit_US_204_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur Eltern koennen sich bewerben (SUPERADMIN, SECTION_ADMIN, TEACHER werden mit 403 abgelehnt: &quot;This role does not perform parent hours&quot;)</label>
+        <label><input type="checkbox" data-cb="crit_US_204_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Doppelte Bewerbung wird verhindert (&quot;You have already applied for this job&quot;)</label>
+        <label><input type="checkbox" data-cb="crit_US_204_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei Erreichen von maxAssignees wird der Job-Status zu ASSIGNED</label>
+        <label><input type="checkbox" data-cb="crit_US_204_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bewerber muss einem Familienverbund angehoeren (&quot;You must belong to a family to apply for jobs&quot;)</label>
+        <label><input type="checkbox" data-cb="crit_US_204_4" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Pessimistic Lock verhindert Race Conditions bei gleichzeitigen Bewerbungen</label>
       </div>
     </div>
     <div class="story" id="story-US_205" data-story="US-205" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-205</span> <span class="story-title">Stunden starten, abschliessen und bestaetigen (manuell)</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich meine zugewiesenen Stunden starten und nach Erledigung abschliessen, damit ein Verantwortlicher die Stunden bestaetigen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Zuweisung mit Status `ASSIGNED` existiert fuer den Benutzer. `tenant_config.require_assignment_confirmation = true`.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich meine zugewiesenen Stunden starten und nach Erledigung abschliessen, damit ein Verantwortlicher die Stunden bestaetigen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Zuweisung mit Status `ASSIGNED` existiert fuer den Benutzer. `tenant_config.require_assignment_confirmation = true`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3706,20 +4052,20 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Pruefe das Familien-Stundenkonto</td><td>Die bestaetigten Stunden (2.5h) werden dem Familienverbund gutgeschrieben</td><td><input type="checkbox" data-cb="step_US_205_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_205_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur der Zugewiesene kann seine eigene Zuweisung starten und abschliessen</label>
-        <label><input type="checkbox" data-cb="crit_US_205_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Status-Uebergaenge: ASSIGNED -&gt; IN_PROGRESS -&gt; COMPLETED</label>
-        <label><input type="checkbox" data-cb="crit_US_205_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Abschliessen ist auch direkt aus ASSIGNED moeglich (ohne vorheriges Starten)</label>
-        <label><input type="checkbox" data-cb="crit_US_205_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur COMPLETED-Zuweisungen koennen bestaetigt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_205_4" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nach Bestaetigung wird ein `JobCompletedEvent` publiziert</label>
-        <label><input type="checkbox" data-cb="crit_US_205_5" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bereits bestaetigte Zuweisungen koennen nicht erneut bestaetigt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_205_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur der Zugewiesene kann seine eigene Zuweisung starten und abschliessen</label>
+        <label><input type="checkbox" data-cb="crit_US_205_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Status-Uebergaenge: ASSIGNED -&gt; IN_PROGRESS -&gt; COMPLETED</label>
+        <label><input type="checkbox" data-cb="crit_US_205_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Abschliessen ist auch direkt aus ASSIGNED moeglich (ohne vorheriges Starten)</label>
+        <label><input type="checkbox" data-cb="crit_US_205_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur COMPLETED-Zuweisungen koennen bestaetigt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_205_4" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nach Bestaetigung wird ein `JobCompletedEvent` publiziert</label>
+        <label><input type="checkbox" data-cb="crit_US_205_5" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bereits bestaetigte Zuweisungen koennen nicht erneut bestaetigt werden</label>
       </div>
     </div>
     <div class="story" id="story-US_206" data-story="US-206" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-206</span> <span class="story-title">Auto-Bestaetigung bei deaktivierter Konfiguration</span></div>
       </div>
-      <div class="story-als">Als Administrator (SA) moechte ich die automatische Bestaetigung konfigurieren, damit abgeschlossene Stunden ohne manuelle Pruefung gutgeschrieben werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> `tenant_config.require_assignment_confirmation = false`. Eine Zuweisung mit Status ASSIGNED oder IN_PROGRESS existiert.</div>
+      <div class="story-als">Als Administrator (SA) moechte ich die automatische Bestaetigung konfigurieren, damit abgeschlossene Stunden ohne manuelle Pruefung gutgeschrieben werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> `tenant_config.require_assignment_confirmation = false`. Eine Zuweisung mit Status ASSIGNED oder IN_PROGRESS existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3731,17 +4077,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Pruefe ob ein `JobCompletedEvent` publiziert wurde</td><td>Event wurde sofort beim Abschliessen ausgeloest</td><td><input type="checkbox" data-cb="step_US_206_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_206_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei `require_assignment_confirmation=false` wird die Zuweisung beim Abschliessen automatisch bestaetigt</label>
-        <label><input type="checkbox" data-cb="crit_US_206_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `confirmedBy` wird auf den abschliessenden Benutzer gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_206_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `JobCompletedEvent` wird sofort publiziert (nicht erst bei manueller Bestaetigung)</label>
+        <label><input type="checkbox" data-cb="crit_US_206_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei `require_assignment_confirmation=false` wird die Zuweisung beim Abschliessen automatisch bestaetigt</label>
+        <label><input type="checkbox" data-cb="crit_US_206_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `confirmedBy` wird auf den abschliessenden Benutzer gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_206_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `JobCompletedEvent` wird sofort publiziert (nicht erst bei manueller Bestaetigung)</label>
       </div>
     </div>
     <div class="story" id="story-US_207" data-story="US-207" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-207</span> <span class="story-title">Zuweisung ablehnen (Reject)</span></div>
       </div>
-      <div class="story-als">Als Lehrer (T) moechte ich eine abgeschlossene Zuweisung ablehnen, damit nicht korrekt geleistete Stunden nicht gutgeschrieben werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Zuweisung mit Status `COMPLETED` existiert, die noch nicht bestaetigt ist (`confirmed=false`).</div>
+      <div class="story-als">Als Lehrer (T) moechte ich eine abgeschlossene Zuweisung ablehnen, damit nicht korrekt geleistete Stunden nicht gutgeschrieben werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Zuweisung mit Status `COMPLETED` existiert, die noch nicht bestaetigt ist (`confirmed=false`).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3752,18 +4098,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Versuche, eine bereits bestaetigte Zuweisung abzulehnen</td><td>Fehler: &quot;Cannot reject a confirmed assignment&quot;</td><td><input type="checkbox" data-cb="step_US_207_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_207_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur TEACHER, SECTION_ADMIN und SUPERADMIN koennen ablehnen</label>
-        <label><input type="checkbox" data-cb="crit_US_207_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur COMPLETED (nicht bestaetigte) Zuweisungen koennen abgelehnt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_207_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei Ablehnung wird der Job ggf. wieder geoeffnet</label>
-        <label><input type="checkbox" data-cb="crit_US_207_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bestaetigte Zuweisungen koennen nicht abgelehnt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_207_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur TEACHER, SECTION_ADMIN und SUPERADMIN koennen ablehnen</label>
+        <label><input type="checkbox" data-cb="crit_US_207_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur COMPLETED (nicht bestaetigte) Zuweisungen koennen abgelehnt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_207_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei Ablehnung wird der Job ggf. wieder geoeffnet</label>
+        <label><input type="checkbox" data-cb="crit_US_207_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bestaetigte Zuweisungen koennen nicht abgelehnt werden</label>
       </div>
     </div>
     <div class="story" id="story-US_208" data-story="US-208" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-208</span> <span class="story-title">Zuweisung stornieren durch Zugewiesenen</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich meine eigene Zuweisung stornieren, damit ich eine Aufgabe absagen kann, die ich nicht wahrnehmen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Zuweisung mit Status `ASSIGNED` oder `IN_PROGRESS` existiert fuer den Benutzer.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich meine eigene Zuweisung stornieren, damit ich eine Aufgabe absagen kann, die ich nicht wahrnehmen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Zuweisung mit Status `ASSIGNED` oder `IN_PROGRESS` existiert fuer den Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3773,41 +4119,41 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Versuche, eine bestaetigte COMPLETED-Zuweisung zu stornieren</td><td>Fehler: &quot;Cannot cancel a confirmed assignment&quot;</td><td><input type="checkbox" data-cb="step_US_208_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_208_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur der Zugewiesene selbst kann seine Zuweisung stornieren</label>
-        <label><input type="checkbox" data-cb="crit_US_208_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bestaetigte COMPLETED-Zuweisungen koennen nicht storniert werden</label>
-        <label><input type="checkbox" data-cb="crit_US_208_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei Stornierung wird der Job-Status korrekt zurueckgesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_208_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur der Zugewiesene selbst kann seine Zuweisung stornieren</label>
+        <label><input type="checkbox" data-cb="crit_US_208_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bestaetigte COMPLETED-Zuweisungen koennen nicht storniert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_208_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bei Stornierung wird der Job-Status korrekt zurueckgesetzt</label>
       </div>
     </div>
     <div class="story" id="story-US_209" data-story="US-209" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-209</span> <span class="story-title">Familien-Stundenkonto einsehen</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich das Stundenkonto meiner Familie einsehen, damit ich weiss, wie viele Stunden noch zu leisten sind.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer gehoert einem Familienverbund an. Es existieren bestaetigte Zuweisungen fuer die Familie.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich das Stundenkonto meiner Familie einsehen, damit ich weiss, wie viele Stunden noch zu leisten sind.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer gehoert einem Familienverbund an. Es existieren bestaetigte Zuweisungen fuer die Familie.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
-          <tr><td>1</td><td>Navigiere zum Familien-Stundenkonto (GET /api/v1/jobs/family-hours/{familyId})</td><td>Stundenuebersicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_209_1" onchange="onCheck()"></td></tr>
+          <tr><td>1</td><td>Navigiere zum Familien-Stundenkonto (GET /api/v1/jobs/family/{familyId}/hours)</td><td>Stundenuebersicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_209_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Pruefe die angezeigten Werte</td><td>`targetHours` (Zielstunden), `completedHours` (bestaetigte Elternstunden), `cleaningHours` (Putzstunden), `totalHours`, `remainingHours`, `pendingHours` werden korrekt angezeigt</td><td><input type="checkbox" data-cb="step_US_209_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Pruefe die Ampel-Farbe (trafficLight)</td><td>Gruen (&gt;= Ziel), Gelb (teilweise erfuellt), Rot (weit unter Ziel)</td><td><input type="checkbox" data-cb="step_US_209_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Pruefe das Putz-Sonder-Unterkonto</td><td>`cleaningHours` zeigt separat die Stunden aus Reinigungskategorie + QR-Putzstunden</td><td><input type="checkbox" data-cb="step_US_209_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Pruefe `cleaningTrafficLight`</td><td>Separate Ampelfarbe fuer Putzstunden basierend auf `targetCleaningHours`</td><td><input type="checkbox" data-cb="step_US_209_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_209_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Stundenkonto ist familienverbund-basiert (nicht benutzerbasiert)</label>
-        <label><input type="checkbox" data-cb="crit_US_209_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `completedHours` enthaelt nur bestaetigte, nicht-Reinigungs-Zuweisungen</label>
-        <label><input type="checkbox" data-cb="crit_US_209_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `cleaningHours` ist die Summe aus Reinigungs-Job-Stunden und QR-Check-in-Putzstunden</label>
-        <label><input type="checkbox" data-cb="crit_US_209_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `totalHours = completedHours + cleaningHours`</label>
-        <label><input type="checkbox" data-cb="crit_US_209_4" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `remainingHours = max(0, targetHours - totalHours)`</label>
-        <label><input type="checkbox" data-cb="crit_US_209_5" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Ampelfarben werden korrekt berechnet</label>
+        <label><input type="checkbox" data-cb="crit_US_209_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Stundenkonto ist familienverbund-basiert (nicht benutzerbasiert)</label>
+        <label><input type="checkbox" data-cb="crit_US_209_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `completedHours` enthaelt nur bestaetigte, nicht-Reinigungs-Zuweisungen</label>
+        <label><input type="checkbox" data-cb="crit_US_209_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `cleaningHours` ist die Summe aus Reinigungs-Job-Stunden und QR-Check-in-Putzstunden</label>
+        <label><input type="checkbox" data-cb="crit_US_209_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `totalHours = completedHours + cleaningHours`</label>
+        <label><input type="checkbox" data-cb="crit_US_209_4" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `remainingHours = max(0, targetHours - totalHours)`</label>
+        <label><input type="checkbox" data-cb="crit_US_209_5" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Ampelfarben werden korrekt berechnet</label>
       </div>
     </div>
     <div class="story" id="story-US_210" data-story="US-210" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-210</span> <span class="story-title">Stunden-Befreiung fuer Familien</span></div>
       </div>
-      <div class="story-als">Als Administrator (SA) moechte ich eine Familie von den Elternstunden befreien, damit Sonderfaelle (z.B. Alleinerziehende) beruecksichtigt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Familie existiert mit `is_hours_exempt = false`.</div>
+      <div class="story-als">Als Administrator (SA) moechte ich eine Familie von den Elternstunden befreien, damit Sonderfaelle (z.B. Alleinerziehende) beruecksichtigt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Familie existiert mit `is_hours_exempt = false`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3817,17 +4163,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefe den Gesamtbericht (GET /api/v1/jobs/report/summary)</td><td>Die befreite Familie wird bei der Ampel-Zaehlung (greenCount, yellowCount, redCount) NICHT mitgezaehlt</td><td><input type="checkbox" data-cb="step_US_210_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_210_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Befreite Familien erhalten immer `trafficLight=GREEN` und alle Stunden auf 0</label>
-        <label><input type="checkbox" data-cb="crit_US_210_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Befreite Familien werden im Report-Summary NICHT in der Ampel-Zaehlung beruecksichtigt</label>
-        <label><input type="checkbox" data-cb="crit_US_210_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Die Befreiung kann jederzeit aktiviert und deaktiviert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_210_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Befreite Familien erhalten immer `trafficLight=GREEN` und alle Stunden auf 0</label>
+        <label><input type="checkbox" data-cb="crit_US_210_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Befreite Familien werden im Report-Summary NICHT in der Ampel-Zaehlung beruecksichtigt</label>
+        <label><input type="checkbox" data-cb="crit_US_210_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Die Befreiung kann jederzeit aktiviert und deaktiviert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_211" data-story="US-211" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-211</span> <span class="story-title">Jahresabrechnung erstellen und abschliessen</span></div>
       </div>
-      <div class="story-als">Als Administrator (SA) moechte ich eine Jahresabrechnung (Billing Period) erstellen und abschliessen, damit die Elternstunden periodenweise abgerechnet werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `admin@monteweb.local` eingeloggt.</div>
+      <div class="story-als">Als Administrator (SA) moechte ich eine Jahresabrechnung (Billing Period) erstellen und abschliessen, damit die Elternstunden periodenweise abgerechnet werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist als `admin@monteweb.local` eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3838,18 +4184,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Pruefe die geschlossene Periode</td><td>`reportData` enthaelt den Bericht als JSONB-Snapshot</td><td><input type="checkbox" data-cb="step_US_211_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_211_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur ein Abrechnungszeitraum kann gleichzeitig ACTIVE sein</label>
-        <label><input type="checkbox" data-cb="crit_US_211_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Beim Abschliessen wird der aktuelle Stundenbericht als JSONB-Snapshot in `reportData` gespeichert</label>
-        <label><input type="checkbox" data-cb="crit_US_211_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `closedBy` wird auf den abschliessenden Admin gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_211_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Abgeschlossene Perioden koennen nicht erneut geschlossen werden</label>
+        <label><input type="checkbox" data-cb="crit_US_211_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur ein Abrechnungszeitraum kann gleichzeitig ACTIVE sein</label>
+        <label><input type="checkbox" data-cb="crit_US_211_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Beim Abschliessen wird der aktuelle Stundenbericht als JSONB-Snapshot in `reportData` gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_211_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `closedBy` wird auf den abschliessenden Admin gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_211_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Abgeschlossene Perioden koennen nicht erneut geschlossen werden</label>
       </div>
     </div>
     <div class="story" id="story-US_212" data-story="US-212" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-212</span> <span class="story-title">PDF-Export des Stundenberichts</span></div>
       </div>
-      <div class="story-als">Als Administrator (SA) moechte ich den Familien-Stundenbericht als PDF exportieren, damit ich ihn ausdrucken oder archivieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Bestaetigte Zuweisungen existieren fuer mehrere Familien.</div>
+      <div class="story-als">Als Administrator (SA) moechte ich den Familien-Stundenbericht als PDF exportieren, damit ich ihn ausdrucken oder archivieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Bestaetigte Zuweisungen existieren fuer mehrere Familien.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3859,18 +4205,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Exportiere als CSV (GET /api/v1/jobs/report/export)</td><td>CSV-Datei &quot;familien-stundenbericht.csv&quot; mit Semikolon-Trennung, UTF-8 BOM, Ampel-Uebersetzung (GREEN-&gt;Gruen, YELLOW-&gt;Gelb, RED-&gt;Rot)</td><td><input type="checkbox" data-cb="step_US_212_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_212_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> PDF-Export: Content-Type `application/pdf`, Content-Disposition mit Dateiname</label>
-        <label><input type="checkbox" data-cb="crit_US_212_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> CSV-Export: Semikolon-getrennt, UTF-8 mit BOM (fuer Excel-Kompatibilitaet)</label>
-        <label><input type="checkbox" data-cb="crit_US_212_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> CSV-Spalten: Familie, Zielstunden, Elternstunden, Putzstunden, Gesamt, Ausstehend, Verbleibend, Ampel</label>
-        <label><input type="checkbox" data-cb="crit_US_212_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Ampelfarben werden ins Deutsche uebersetzt (Gruen/Gelb/Rot)</label>
+        <label><input type="checkbox" data-cb="crit_US_212_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> PDF-Export: Content-Type `application/pdf`, Content-Disposition mit Dateiname</label>
+        <label><input type="checkbox" data-cb="crit_US_212_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> CSV-Export: Semikolon-getrennt, UTF-8 mit BOM (fuer Excel-Kompatibilitaet)</label>
+        <label><input type="checkbox" data-cb="crit_US_212_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> CSV-Spalten: Familie, Zielstunden, Elternstunden, Putzstunden, Gesamt, Ausstehend, Verbleibend, Ampel</label>
+        <label><input type="checkbox" data-cb="crit_US_212_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Ampelfarben werden ins Deutsche uebersetzt (Gruen/Gelb/Rot)</label>
       </div>
     </div>
     <div class="story" id="story-US_213" data-story="US-213" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-213</span> <span class="story-title">Billing-Perioden-PDF-Export (Jahresabrechnung)</span></div>
       </div>
-      <div class="story-als">Als Administrator (SA) moechte ich den PDF-Export einer Abrechnungsperiode herunterladen, damit ich die Jahresabrechnung archivieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Abrechnungsperiode existiert (aktiv oder geschlossen).</div>
+      <div class="story-als">Als Administrator (SA) moechte ich den PDF-Export einer Abrechnungsperiode herunterladen, damit ich die Jahresabrechnung archivieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Abrechnungsperiode existiert (aktiv oder geschlossen).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3879,37 +4225,37 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Pruefe den PDF-Inhalt</td><td>Periodenname, Zeitraum, alle Familien mit Stundendetails</td><td><input type="checkbox" data-cb="step_US_213_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_213_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Content-Type `application/pdf`</label>
-        <label><input type="checkbox" data-cb="crit_US_213_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Content-Disposition: `attachment; filename=&quot;jahresabrechnung.pdf&quot;`</label>
-        <label><input type="checkbox" data-cb="crit_US_213_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> PDF enthaelt den Schulnamen aus der Tenant-Konfiguration</label>
+        <label><input type="checkbox" data-cb="crit_US_213_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Content-Type `application/pdf`</label>
+        <label><input type="checkbox" data-cb="crit_US_213_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Content-Disposition: `attachment; filename=&quot;jahresabrechnung.pdf&quot;`</label>
+        <label><input type="checkbox" data-cb="crit_US_213_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> PDF enthaelt den Schulnamen aus der Tenant-Konfiguration</label>
       </div>
     </div>
     <div class="story" id="story-US_214" data-story="US-214" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-214</span> <span class="story-title">Admin-Gesamtuebersicht (Report Summary)</span></div>
       </div>
-      <div class="story-als">Als Administrator (SA) moechte ich eine Zusammenfassung aller Jobs und Familienstunden sehen, damit ich den Ueberblick ueber die Elternstunden behalte.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Jobs in verschiedenen Status existieren. Mehrere Familien haben Stunden gesammelt.</div>
+      <div class="story-als">Als Administrator (SA) moechte ich eine Zusammenfassung aller Jobs und Familienstunden sehen, damit ich den Ueberblick ueber die Elternstunden behalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Jobs in verschiedenen Status existieren. Mehrere Familien haben Stunden gesammelt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Rufe die Gesamtuebersicht auf (GET /api/v1/jobs/report/summary)</td><td>Zusammenfassung wird angezeigt</td><td><input type="checkbox" data-cb="step_US_214_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Pruefe die Job-Zaehler</td><td>`openJobs`, `activeJobs` (IN_PROGRESS), `completedJobs` werden korrekt gezaehlt</td><td><input type="checkbox" data-cb="step_US_214_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Pruefe die Ampel-Zaehler</td><td>`greenCount`, `yellowCount`, `redCount` fuer alle nicht-befreiten Familien</td><td><input type="checkbox" data-cb="step_US_214_3" onchange="onCheck()"></td></tr>
-          <tr><td>4</td><td>Pruefe die Sortierung im Gesamtbericht (GET /api/v1/jobs/report/all)</td><td>Familien sind sortiert: Rot zuerst, dann Gelb, dann Gruen. Innerhalb gleicher Ampel alphabetisch</td><td><input type="checkbox" data-cb="step_US_214_4" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Pruefe die Sortierung im Gesamtbericht (GET /api/v1/jobs/report)</td><td>Familien sind sortiert: Rot zuerst, dann Gelb, dann Gruen. Innerhalb gleicher Ampel alphabetisch</td><td><input type="checkbox" data-cb="step_US_214_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_214_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Befreite Familien (`hoursExempt=true`) werden bei den Ampelzaehlern ausgeschlossen</label>
-        <label><input type="checkbox" data-cb="crit_US_214_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Sortierung: Rot (hoechste Prioritaet) &gt; Gelb &gt; Gruen</label>
-        <label><input type="checkbox" data-cb="crit_US_214_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Innerhalb gleicher Ampelfarbe: alphabetisch nach Familienname (case-insensitive)</label>
+        <label><input type="checkbox" data-cb="crit_US_214_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Befreite Familien (`hoursExempt=true`) werden bei den Ampelzaehlern ausgeschlossen</label>
+        <label><input type="checkbox" data-cb="crit_US_214_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Sortierung: Rot (hoechste Prioritaet) &gt; Gelb &gt; Gruen</label>
+        <label><input type="checkbox" data-cb="crit_US_214_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Innerhalb gleicher Ampelfarbe: alphabetisch nach Familienname (case-insensitive)</label>
       </div>
     </div>
     <div class="story" id="story-US_215" data-story="US-215" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-215</span> <span class="story-title">Job-Anhaenge hochladen und herunterladen</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich Dateien an einen Job anhaengen, damit zusaetzliche Informationen (z.B. Einladung, Anfahrt) bereitgestellt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Job existiert, der vom Benutzer erstellt wurde.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich Dateien an einen Job anhaengen, damit zusaetzliche Informationen (z.B. Einladung, Anfahrt) bereitgestellt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Job existiert, der vom Benutzer erstellt wurde.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3920,17 +4266,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Klicke auf &quot;Loeschen&quot; (DELETE /api/v1/jobs/{id}/attachments/{attachmentId})</td><td>Anhang wird aus MinIO und Datenbank entfernt</td><td><input type="checkbox" data-cb="step_US_215_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_215_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur der Ersteller oder Admins koennen Anhaenge hochladen und loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_215_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Dateien werden in MinIO gespeichert</label>
-        <label><input type="checkbox" data-cb="crit_US_215_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Dateiname, Dateityp, Dateigroesse und `uploaded_by` werden in der DB gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_215_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur der Ersteller oder Admins koennen Anhaenge hochladen und loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_215_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Dateien werden in MinIO gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_215_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Dateiname, Dateityp, Dateigroesse und `uploaded_by` werden in der DB gespeichert</label>
       </div>
     </div>
     <div class="story" id="story-US_216" data-story="US-216" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-216</span> <span class="story-title">Job loeschen vs. stornieren</span></div>
       </div>
-      <div class="story-als">Als Ersteller eines Jobs moechte ich einen Job stornieren oder permanent loeschen, damit nicht mehr benoetigte Jobs aus dem System entfernt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Job mit Status OPEN existiert, erstellt vom Benutzer.</div>
+      <div class="story-als">Als Ersteller eines Jobs moechte ich einen Job stornieren oder permanent loeschen, damit nicht mehr benoetigte Jobs aus dem System entfernt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Job mit Status OPEN existiert, erstellt vom Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3940,17 +4286,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Versuche als fremder Benutzer einen Job zu loeschen</td><td>Fehler: &quot;Only the creator or administrators can delete this job&quot;</td><td><input type="checkbox" data-cb="step_US_216_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_216_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Stornieren (`permanent=false`): Status -&gt; CANCELLED, Job bleibt in DB</label>
-        <label><input type="checkbox" data-cb="crit_US_216_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Loeschen (`permanent=true`): Job und Zuweisungen werden permanent geloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_216_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur Ersteller, SUPERADMIN oder SECTION_ADMIN koennen stornieren/loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_216_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Stornieren (`permanent=false`): Status -&gt; CANCELLED, Job bleibt in DB</label>
+        <label><input type="checkbox" data-cb="crit_US_216_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Loeschen (`permanent=true`): Job und Zuweisungen werden permanent geloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_216_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur Ersteller, SUPERADMIN oder SECTION_ADMIN koennen stornieren/loeschen</label>
       </div>
     </div>
     <div class="story" id="story-US_217" data-story="US-217" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-217</span> <span class="story-title">Job mit Kalender-Event verknuepfen</span></div>
       </div>
-      <div class="story-als">Als Lehrer (T) oder Elternteil (P) moechte ich einen Job mit einem Kalender-Event verknuepfen, damit Events direkt mit Helfer-Jobs verbunden sind.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Job und ein Kalender-Event existieren.</div>
+      <div class="story-als">Als Lehrer (T) oder Elternteil (P) moechte ich einen Job mit einem Kalender-Event verknuepfen, damit Events direkt mit Helfer-Jobs verbunden sind.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Job und ein Kalender-Event existieren.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3958,17 +4304,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Rufe Jobs nach Event ab (GET /api/v1/jobs/by-event/{eventId})</td><td>Der verknuepfte Job wird zurueckgegeben</td><td><input type="checkbox" data-cb="step_US_217_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_217_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur Ersteller, Lehrer, SECTION_ADMIN, SUPERADMIN oder Benutzer mit specialRole ELTERNBEIRAT koennen verknuepfen</label>
-        <label><input type="checkbox" data-cb="crit_US_217_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Event-Ersteller kann ebenfalls verknuepfen</label>
-        <label><input type="checkbox" data-cb="crit_US_217_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Das verknuepfte Event muss existieren (Validierung ueber CalendarModuleApi)</label>
+        <label><input type="checkbox" data-cb="crit_US_217_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur Ersteller, Lehrer, SECTION_ADMIN, SUPERADMIN oder Benutzer mit specialRole ELTERNBEIRAT koennen verknuepfen</label>
+        <label><input type="checkbox" data-cb="crit_US_217_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Event-Ersteller kann ebenfalls verknuepfen</label>
+        <label><input type="checkbox" data-cb="crit_US_217_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Das verknuepfte Event muss existieren (Validierung ueber CalendarModuleApi)</label>
       </div>
     </div>
     <div class="story" id="story-US_218" data-story="US-218" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-218</span> <span class="story-title">Putzaktion erzeugt automatisch einen Job</span></div>
       </div>
-      <div class="story-als">Als System moechte ich bei Erstellung einer Putzaktion automatisch einen Job in der Jobboerse anlegen, damit Putzstunden ueber das Stundenkonto erfasst werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Cleaning- und Jobboard-Module sind aktiviert. Eine Putzaktion wird erstellt.</div>
+      <div class="story-als">Als System moechte ich bei Erstellung einer Putzaktion automatisch einen Job in der Jobboerse anlegen, damit Putzstunden ueber das Stundenkonto erfasst werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Cleaning- und Jobboard-Module sind aktiviert. Eine Putzaktion wird erstellt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3978,18 +4324,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefe die Verknuepfung</td><td>`eventId` des Jobs zeigt auf das Kalender-Event der Putzaktion. Die Cleaning-Config hat die `jobId` des neuen Jobs</td><td><input type="checkbox" data-cb="step_US_218_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_218_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `PutzaktionCreatedEvent` wird vom Cleaning-Modul publiziert</label>
-        <label><input type="checkbox" data-cb="crit_US_218_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Jobboard-Modul reagiert via `@ApplicationModuleListener` auf das Event</label>
-        <label><input type="checkbox" data-cb="crit_US_218_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Job wird mit Kategorie &quot;Reinigung&quot;, Status OPEN erstellt</label>
-        <label><input type="checkbox" data-cb="crit_US_218_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bidirektionale Verknuepfung: Job hat `eventId`, CleaningConfig hat `jobId`</label>
+        <label><input type="checkbox" data-cb="crit_US_218_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> `PutzaktionCreatedEvent` wird vom Cleaning-Modul publiziert</label>
+        <label><input type="checkbox" data-cb="crit_US_218_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Jobboard-Modul reagiert via `@ApplicationModuleListener` auf das Event</label>
+        <label><input type="checkbox" data-cb="crit_US_218_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Job wird mit Kategorie &quot;Reinigung&quot;, Status OPEN erstellt</label>
+        <label><input type="checkbox" data-cb="crit_US_218_3" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Bidirektionale Verknuepfung: Job hat `eventId`, CleaningConfig hat `jobId`</label>
       </div>
     </div>
     <div class="story" id="story-US_219" data-story="US-219" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-219</span> <span class="story-title">Familien-Zuweisungen abrufen</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich alle bestaetigten Zuweisungen meiner Familie sehen, damit ich die Stundenhistorie nachvollziehen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Bestaetigte Zuweisungen existieren fuer die Familie des Benutzers.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich alle bestaetigten Zuweisungen meiner Familie sehen, damit ich die Stundenhistorie nachvollziehen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Bestaetigte Zuweisungen existieren fuer die Familie des Benutzers.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -3998,9 +4344,9 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Pruefe die Sortierung</td><td>Neueste zuerst (absteigend nach completedAt)</td><td><input type="checkbox" data-cb="step_US_219_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_219_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur bestaetigte COMPLETED-Zuweisungen werden zurueckgegeben</label>
-        <label><input type="checkbox" data-cb="crit_US_219_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Sortierung absteigend nach `completedAt`</label>
-        <label><input type="checkbox" data-cb="crit_US_219_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur Familienmitglieder oder Admins koennen die Familien-Zuweisungen abrufen</label>
+        <label><input type="checkbox" data-cb="crit_US_219_0" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur bestaetigte COMPLETED-Zuweisungen werden zurueckgegeben</label>
+        <label><input type="checkbox" data-cb="crit_US_219_1" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Sortierung absteigend nach `completedAt`</label>
+        <label><input type="checkbox" data-cb="crit_US_219_2" data-crit="1" data-module="Jobboard___Elternstunden" onchange="onCheck()"> Nur Familienmitglieder oder Admins koennen die Familien-Zuweisungen abrufen</label>
       </div>
     </div>
   </div>
@@ -4009,7 +4355,7 @@ td:last-child { width: 40px; text-align: center; }
   <div class="module-header" onclick="toggleModule('Putz_Orga___Cleaning')">
     <h2><span class="chevron">&#9654;</span> Putz-Orga / Cleaning <span class="badge">19 Stories</span></h2>
     <div>
-      <span class="progress-info" id="prog-Putz_Orga___Cleaning">0/63</span>
+      <span class="progress-info" id="prog-Putz_Orga___Cleaning">0/64</span>
       <div class="progress-bar" style="width:120px"><div class="progress-fill" id="bar-Putz_Orga___Cleaning" style="width:0%"></div></div>
     </div>
   </div>
@@ -4018,30 +4364,30 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-220</span> <span class="story-title">Putzaktion erstellen (wiederkehrend)</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich eine wiederkehrende Putzaktion konfigurieren, damit woechentlich automatisch Slots generiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat die Rolle SA, SECADMIN oder die spezielle Rolle PUTZORGA. Cleaning-Modul ist aktiviert.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich eine wiederkehrende Putzaktion konfigurieren, damit woechentlich automatisch Slots generiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat die Rolle SA, SECADMIN oder die spezielle Rolle PUTZORGA. Cleaning-Modul ist aktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
-          <tr><td>1</td><td>Navigiere zur Putz-Orga-Verwaltung (GET /api/v1/cleaning/admin/configs)</td><td>Putz-Konfigurations-Uebersicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_220_1" onchange="onCheck()"></td></tr>
-          <tr><td>2</td><td>Erstelle eine neue Konfiguration (POST /api/v1/cleaning/admin/configs) mit: Titel &quot;Wochenputz Sonnengruppe&quot;, Wochentag 3 (Mittwoch), 14:00-16:00, min 2, max 5, 2.0 Stunden-Gutschrift, ohne specificDate</td><td>Konfiguration wird erstellt</td><td><input type="checkbox" data-cb="step_US_220_2" onchange="onCheck()"></td></tr>
+          <tr><td>1</td><td>Navigiere zur Putz-Orga-Verwaltung (GET /api/v1/cleaning/configs)</td><td>Putz-Konfigurations-Uebersicht wird angezeigt</td><td><input type="checkbox" data-cb="step_US_220_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Erstelle eine neue Konfiguration (POST /api/v1/cleaning/configs) mit: Titel &quot;Wochenputz Sonnengruppe&quot;, Wochentag 3 (Mittwoch), 14:00-16:00, min 2, max 5, 2.0 Stunden-Gutschrift, ohne specificDate</td><td>Konfiguration wird erstellt</td><td><input type="checkbox" data-cb="step_US_220_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Pruefe die Konfiguration</td><td>`dayOfWeek=3`, `startTime=14:00`, `endTime=16:00`, `specificDate=null` (wiederkehrend), `active=true`</td><td><input type="checkbox" data-cb="step_US_220_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Pruefe `participantCircle`</td><td>Standard: &quot;SECTION&quot;</td><td><input type="checkbox" data-cb="step_US_220_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_220_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `specificDate = null` kennzeichnet eine wiederkehrende Putzaktion</label>
-        <label><input type="checkbox" data-cb="crit_US_220_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `dayOfWeek` bestimmt den Wochentag (1=Montag, 7=Sonntag)</label>
-        <label><input type="checkbox" data-cb="crit_US_220_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `hoursCredit` (BigDecimal) definiert die Stundengutschrift</label>
-        <label><input type="checkbox" data-cb="crit_US_220_3" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `minParticipants` und `maxParticipants` definieren die Teilnehmergrenzen</label>
-        <label><input type="checkbox" data-cb="crit_US_220_4" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Cleaning-Admins (SA, SECADMIN mit passendem Bereich, oder Benutzer mit PUTZORGA-Rolle) koennen erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_220_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `specificDate = null` kennzeichnet eine wiederkehrende Putzaktion</label>
+        <label><input type="checkbox" data-cb="crit_US_220_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `dayOfWeek` bestimmt den Wochentag (1=Montag, 7=Sonntag)</label>
+        <label><input type="checkbox" data-cb="crit_US_220_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `hoursCredit` (BigDecimal) definiert die Stundengutschrift</label>
+        <label><input type="checkbox" data-cb="crit_US_220_3" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `minParticipants` und `maxParticipants` definieren die Teilnehmergrenzen</label>
+        <label><input type="checkbox" data-cb="crit_US_220_4" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Cleaning-Admins (SA, SECADMIN mit passendem Bereich, oder Benutzer mit PUTZORGA-Rolle) koennen erstellen</label>
       </div>
     </div>
     <div class="story" id="story-US_221" data-story="US-221" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-221</span> <span class="story-title">Putzaktion erstellen (einmalig)</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich eine einmalige Putzaktion fuer ein bestimmtes Datum erstellen, damit Sonderaktionen (z.B. Fruehjahrsputz) geplant werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat Putz-Admin-Rechte.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich eine einmalige Putzaktion fuer ein bestimmtes Datum erstellen, damit Sonderaktionen (z.B. Fruehjahrsputz) geplant werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat Putz-Admin-Rechte.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4050,38 +4396,38 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Generiere Slots fuer den Zeitraum 2026-04-01 bis 2026-04-30</td><td>Nur EIN Slot fuer den 15. April wird generiert (nicht fuer jeden Mittwoch)</td><td><input type="checkbox" data-cb="step_US_221_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_221_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `specificDate` ist gesetzt: Putzaktion gilt nur fuer dieses eine Datum</label>
-        <label><input type="checkbox" data-cb="crit_US_221_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Bei Slot-Generierung wird nur fuer das `specificDate` ein Slot erstellt</label>
-        <label><input type="checkbox" data-cb="crit_US_221_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Ein `PutzaktionCreatedEvent` wird publiziert (erzeugt Kalender-Event und Job)</label>
+        <label><input type="checkbox" data-cb="crit_US_221_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `specificDate` ist gesetzt: Putzaktion gilt nur fuer dieses eine Datum</label>
+        <label><input type="checkbox" data-cb="crit_US_221_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Bei Slot-Generierung wird nur fuer das `specificDate` ein Slot erstellt</label>
+        <label><input type="checkbox" data-cb="crit_US_221_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Ein `PutzaktionCreatedEvent` wird publiziert (erzeugt Kalender-Event und Job)</label>
       </div>
     </div>
     <div class="story" id="story-US_222" data-story="US-222" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-222</span> <span class="story-title">Slots generieren fuer einen Zeitraum</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich Putzslots fuer einen bestimmten Zeitraum generieren, damit Eltern sich registrieren koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine wiederkehrende Putzaktion (ohne specificDate) existiert mit dayOfWeek=3 (Mittwoch).</div>
+      <div class="story-als">Als Putz-Administrator moechte ich Putzslots fuer einen bestimmten Zeitraum generieren, damit Eltern sich registrieren koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine wiederkehrende Putzaktion (ohne specificDate) existiert mit dayOfWeek=3 (Mittwoch).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
-          <tr><td>1</td><td>Generiere Slots (POST /api/v1/cleaning/admin/configs/{id}/generate) fuer 2026-03-01 bis 2026-03-31</td><td>Slots werden fuer jeden Mittwoch im Maerz generiert</td><td><input type="checkbox" data-cb="step_US_222_1" onchange="onCheck()"></td></tr>
+          <tr><td>1</td><td>Generiere Slots (POST /api/v1/cleaning/configs/{id}/generate) fuer 2026-03-01 bis 2026-03-31</td><td>Slots werden fuer jeden Mittwoch im Maerz generiert</td><td><input type="checkbox" data-cb="step_US_222_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Pruefe die generierten Slots</td><td>Slots existieren fuer 04.03., 11.03., 18.03., 25.03.</td><td><input type="checkbox" data-cb="step_US_222_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Pruefe die Slot-Details</td><td>Jeder Slot hat `configId`, `sectionId`, `slotDate`, `startTime`, `endTime`, `minParticipants`, `maxParticipants`, `status=OPEN`</td><td><input type="checkbox" data-cb="step_US_222_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Generiere nochmals fuer denselben Zeitraum</td><td>Bereits existierende Slots werden nicht dupliziert</td><td><input type="checkbox" data-cb="step_US_222_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_222_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Slots werden nur fuer den korrekten Wochentag generiert</label>
-        <label><input type="checkbox" data-cb="crit_US_222_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Feiertage und Schulferien werden NICHT automatisch uebersprungen (Anzeige im DatePicker)</label>
-        <label><input type="checkbox" data-cb="crit_US_222_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Doppelte Generierung fuer dasselbe Datum wird verhindert</label>
-        <label><input type="checkbox" data-cb="crit_US_222_3" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Jeder Slot erhaelt einen eindeutigen QR-Token</label>
+        <label><input type="checkbox" data-cb="crit_US_222_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Slots werden nur fuer den korrekten Wochentag generiert</label>
+        <label><input type="checkbox" data-cb="crit_US_222_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Feiertage und Schulferien werden NICHT automatisch uebersprungen (Anzeige im DatePicker)</label>
+        <label><input type="checkbox" data-cb="crit_US_222_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Doppelte Generierung fuer dasselbe Datum wird verhindert</label>
+        <label><input type="checkbox" data-cb="crit_US_222_3" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Jeder Slot erhaelt einen eindeutigen QR-Token</label>
       </div>
     </div>
     <div class="story" id="story-US_223" data-story="US-223" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-223</span> <span class="story-title">Feiertage und Schulferien im DatePicker</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich Feiertage (rot) und Schulferien (orange) im DatePicker sehen, damit ich keine Putzaktionen auf freie Tage lege.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> `tenant_config.bundesland = 'BY'` (Bayern). Schulferien sind in `tenant_config.school_vacations` konfiguriert.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich Feiertage (rot) und Schulferien (orange) im DatePicker sehen, damit ich keine Putzaktionen auf freie Tage lege.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> `tenant_config.bundesland = 'BY'` (Bayern). Schulferien sind in `tenant_config.school_vacations` konfiguriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4091,19 +4437,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Aendere das Bundesland auf 'NW' (Nordrhein-Westfalen)</td><td>Andere Feiertage werden angezeigt (z.B. Fronleichnam in BY, aber nicht in HH)</td><td><input type="checkbox" data-cb="step_US_223_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_223_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Feiertage werden je `bundesland` korrekt berechnet (Gauss-Osteralgorithmus fuer bewegliche Feiertage)</label>
-        <label><input type="checkbox" data-cb="crit_US_223_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Alle 16 Bundeslaender werden unterstuetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_223_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Schulferien stammen aus `tenant_config.school_vacations` (JSONB: `{name, from, to}`)</label>
-        <label><input type="checkbox" data-cb="crit_US_223_3" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Feiertage: rote Markierung, Schulferien: orange Markierung</label>
-        <label><input type="checkbox" data-cb="crit_US_223_4" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `useHolidays.ts` Composable berechnet Feiertage clientseitig</label>
+        <label><input type="checkbox" data-cb="crit_US_223_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Feiertage werden je `bundesland` korrekt berechnet (Gauss-Osteralgorithmus fuer bewegliche Feiertage)</label>
+        <label><input type="checkbox" data-cb="crit_US_223_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Alle 16 Bundeslaender werden unterstuetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_223_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Schulferien stammen aus `tenant_config.school_vacations` (JSONB: `{name, from, to}`)</label>
+        <label><input type="checkbox" data-cb="crit_US_223_3" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Feiertage: rote Markierung, Schulferien: orange Markierung</label>
+        <label><input type="checkbox" data-cb="crit_US_223_4" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `useHolidays.ts` Composable berechnet Feiertage clientseitig</label>
       </div>
     </div>
     <div class="story" id="story-US_224" data-story="US-224" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-224</span> <span class="story-title">Putzslots anzeigen und filtern</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich die verfuegbaren Putzslots sehen, damit ich mich fuer einen passenden Termin registrieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Putzslots existieren fuer den aktuellen und naechsten Monat.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich die verfuegbaren Putzslots sehen, damit ich mich fuer einen passenden Termin registrieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Putzslots existieren fuer den aktuellen und naechsten Monat.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4113,17 +4459,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefe die Status-Anzeige</td><td>OPEN (Plaetze frei), FULL (voll), IN_PROGRESS, COMPLETED, CANCELLED</td><td><input type="checkbox" data-cb="step_US_224_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_224_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur zukuenftige Slots werden in der &quot;upcoming&quot;-Ansicht angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_224_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Slot-Status: OPEN, FULL, IN_PROGRESS, COMPLETED, CANCELLED</label>
-        <label><input type="checkbox" data-cb="crit_US_224_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Teilnehmer-Zaehlung wird live aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_224_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur zukuenftige Slots werden in der &quot;upcoming&quot;-Ansicht angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_224_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Slot-Status: OPEN, FULL, IN_PROGRESS, COMPLETED, CANCELLED</label>
+        <label><input type="checkbox" data-cb="crit_US_224_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Teilnehmer-Zaehlung wird live aktualisiert</label>
       </div>
     </div>
     <div class="story" id="story-US_225" data-story="US-225" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-225</span> <span class="story-title">Fuer Putzslot registrieren</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich mich fuer einen Putzslot registrieren, damit ich am Putzen teilnehmen und Stunden sammeln kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein offener Putzslot existiert. Benutzer gehoert einem Familienverbund an.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich mich fuer einen Putzslot registrieren, damit ich am Putzen teilnehmen und Stunden sammeln kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein offener Putzslot existiert. Benutzer gehoert einem Familienverbund an.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4134,17 +4480,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Versuche, sich ein zweites Mal zu registrieren</td><td>Fehler: Doppelregistrierung wird verhindert</td><td><input type="checkbox" data-cb="step_US_225_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_225_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Registrierung enthaelt `userId`, `familyId`, `userName`, `slotId`</label>
-        <label><input type="checkbox" data-cb="crit_US_225_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Bei vollen Slots (maxParticipants erreicht) ist keine weitere Registrierung moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_225_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `noShow=false`, `swapOffered=false` als Standardwerte</label>
+        <label><input type="checkbox" data-cb="crit_US_225_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Registrierung enthaelt `userId`, `familyId`, `userName`, `slotId`</label>
+        <label><input type="checkbox" data-cb="crit_US_225_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Bei vollen Slots (maxParticipants erreicht) ist keine weitere Registrierung moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_225_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `noShow=false`, `swapOffered=false` als Standardwerte</label>
       </div>
     </div>
     <div class="story" id="story-US_226" data-story="US-226" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-226</span> <span class="story-title">Von Putzslot abmelden</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich mich von einem Putzslot abmelden, damit der Platz fuer andere frei wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist fuer einen zukuenftigen Putzslot registriert.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich mich von einem Putzslot abmelden, damit der Platz fuer andere frei wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist fuer einen zukuenftigen Putzslot registriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4154,17 +4500,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Versuche, sich nach bereits erfolgtem Check-in abzumelden</td><td>Fehler: Abmeldung nach Check-in nicht moeglich</td><td><input type="checkbox" data-cb="step_US_226_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_226_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Abmeldung ist nur VOR dem Check-in moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_226_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Bei Abmeldung wird der Slot-Status ggf. von FULL auf OPEN zurueckgesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_226_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Abmeldung loescht die Registrierung aus der Datenbank</label>
+        <label><input type="checkbox" data-cb="crit_US_226_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Abmeldung ist nur VOR dem Check-in moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_226_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Bei Abmeldung wird der Slot-Status ggf. von FULL auf OPEN zurueckgesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_226_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Abmeldung loescht die Registrierung aus der Datenbank</label>
       </div>
     </div>
     <div class="story" id="story-US_227" data-story="US-227" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-227</span> <span class="story-title">QR-Code-Check-in</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich mich per QR-Code am Putztag einchecken, damit meine Anwesenheit dokumentiert wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist fuer einen heutigen Putzslot registriert. Ein QR-Code mit dem `qrToken` des Slots liegt vor.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich mich per QR-Code am Putztag einchecken, damit meine Anwesenheit dokumentiert wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist fuer einen heutigen Putzslot registriert. Ein QR-Code mit dem `qrToken` des Slots liegt vor.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4175,18 +4521,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Versuche Check-in mit falschem QR-Token</td><td>Fehler: Ungueltiger Token</td><td><input type="checkbox" data-cb="step_US_227_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_227_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> QR-Token wird gegen den gespeicherten `qrToken` des Slots validiert</label>
-        <label><input type="checkbox" data-cb="crit_US_227_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `checkInAt` wird als `Instant` (Zeitstempel) gespeichert</label>
-        <label><input type="checkbox" data-cb="crit_US_227_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Doppeltes Check-in wird verhindert</label>
-        <label><input type="checkbox" data-cb="crit_US_227_3" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Falscher/abgelaufener Token fuehrt zu einem Fehler</label>
+        <label><input type="checkbox" data-cb="crit_US_227_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> QR-Token wird gegen den gespeicherten `qrToken` des Slots validiert</label>
+        <label><input type="checkbox" data-cb="crit_US_227_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `checkInAt` wird als `Instant` (Zeitstempel) gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_227_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Doppeltes Check-in wird verhindert</label>
+        <label><input type="checkbox" data-cb="crit_US_227_3" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Falscher/abgelaufener Token fuehrt zu einem Fehler</label>
       </div>
     </div>
     <div class="story" id="story-US_228" data-story="US-228" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-228</span> <span class="story-title">QR-Code-Check-out</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich mich nach dem Putzen per Check-out abmelden, damit meine tatsaechliche Putzzeit erfasst wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat bereits eingecheckt (`checkedIn=true`).</div>
+      <div class="story-als">Als Elternteil (P) moechte ich mich nach dem Putzen per Check-out abmelden, damit meine tatsaechliche Putzzeit erfasst wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat bereits eingecheckt (`checkedIn=true`).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4195,36 +4541,37 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Versuche ein Check-out ohne vorheriges Check-in</td><td>Fehler: Erst einchecken</td><td><input type="checkbox" data-cb="step_US_228_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_228_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Check-out ist nur nach vorherigem Check-in moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_228_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `actualMinutes` wird aus der Check-in/Check-out-Differenz berechnet</label>
-        <label><input type="checkbox" data-cb="crit_US_228_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `checkOutAt` wird als Zeitstempel gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_228_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Check-out ist nur nach vorherigem Check-in moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_228_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `actualMinutes` wird aus der Check-in/Check-out-Differenz berechnet</label>
+        <label><input type="checkbox" data-cb="crit_US_228_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `checkOutAt` wird als Zeitstempel gespeichert</label>
       </div>
     </div>
     <div class="story" id="story-US_229" data-story="US-229" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-229</span> <span class="story-title">QR-Codes generieren und exportieren</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich QR-Codes fuer Putzslots generieren und als PDF exportieren, damit sie vor Ort ausgehaengt werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Putzslots existieren fuer den Bereich.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich QR-Codes fuer Putzslots generieren und als PDF exportieren, damit sie vor Ort ausgehaengt werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Putzslots existieren fuer den Bereich.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
-          <tr><td>1</td><td>Rufe den QR-Token fuer einen Slot ab (GET /api/v1/cleaning/admin/slots/{id}/qr-token)</td><td>QR-Token wird zurueckgegeben</td><td><input type="checkbox" data-cb="step_US_229_1" onchange="onCheck()"></td></tr>
-          <tr><td>2</td><td>Exportiere QR-Codes als PDF (GET /api/v1/cleaning/admin/qr-codes/pdf)</td><td>PDF mit QR-Codes wird generiert</td><td><input type="checkbox" data-cb="step_US_229_2" onchange="onCheck()"></td></tr>
+          <tr><td>1</td><td>Rufe den QR-Token fuer einen Slot ab (GET /api/v1/cleaning/slots/{id}/qr)</td><td>QR-Token wird zurueckgegeben</td><td><input type="checkbox" data-cb="step_US_229_1" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Exportiere QR-Codes als PDF (GET /api/v1/cleaning/configs/{id}/qr-codes?from=&amp;to=)</td><td>PDF mit QR-Codes fuer die Slots der Konfiguration im angegebenen Zeitraum wird generiert</td><td><input type="checkbox" data-cb="step_US_229_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Pruefe den PDF-Inhalt</td><td>Jeder QR-Code enthaelt den Slot-spezifischen Token, Datum und Uhrzeit</td><td><input type="checkbox" data-cb="step_US_229_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_229_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Jeder Slot hat einen eindeutigen `qrToken`</label>
-        <label><input type="checkbox" data-cb="crit_US_229_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> PDF enthaelt druckbare QR-Codes mit Slot-Informationen (Datum, Uhrzeit)</label>
-        <label><input type="checkbox" data-cb="crit_US_229_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins koennen QR-Codes abrufen</label>
+        <label><input type="checkbox" data-cb="crit_US_229_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Jeder Slot hat einen eindeutigen `qrToken`</label>
+        <label><input type="checkbox" data-cb="crit_US_229_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> PDF-Export ist konfigurations-gebunden und akzeptiert `from`/`to`-Datumsparameter</label>
+        <label><input type="checkbox" data-cb="crit_US_229_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> PDF enthaelt druckbare QR-Codes mit Slot-Informationen (Datum, Uhrzeit)</label>
+        <label><input type="checkbox" data-cb="crit_US_229_3" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins koennen QR-Codes abrufen</label>
       </div>
     </div>
     <div class="story" id="story-US_230" data-story="US-230" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-230</span> <span class="story-title">Swap-Angebot erstellen</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich meinen Putztermin zum Tausch anbieten, damit ein anderer Elternteil meinen Platz uebernehmen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist fuer einen zukuenftigen Putzslot registriert.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich meinen Putztermin zum Tausch anbieten, damit ein anderer Elternteil meinen Platz uebernehmen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist fuer einen zukuenftigen Putzslot registriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4234,17 +4581,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Ein anderer Elternteil uebernimmt das Angebot</td><td>Registrierung wird auf den neuen Benutzer uebertragen</td><td><input type="checkbox" data-cb="step_US_230_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_230_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `swapOffered=true` markiert die Registrierung als Tauschangebot</label>
-        <label><input type="checkbox" data-cb="crit_US_230_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur der registrierte Benutzer kann seinen Platz anbieten</label>
-        <label><input type="checkbox" data-cb="crit_US_230_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Swap-Angebote sind fuer andere Eltern des gleichen Bereichs sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_230_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `swapOffered=true` markiert die Registrierung als Tauschangebot</label>
+        <label><input type="checkbox" data-cb="crit_US_230_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur der registrierte Benutzer kann seinen Platz anbieten</label>
+        <label><input type="checkbox" data-cb="crit_US_230_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Swap-Angebote sind fuer andere Eltern des gleichen Bereichs sichtbar</label>
       </div>
     </div>
     <div class="story" id="story-US_231" data-story="US-231" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-231</span> <span class="story-title">Putzstunden bestaetigen (Admin)</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich die Putzstunden eines Teilnehmers bestaetigen, damit die Stunden dem Familienverbund gutgeschrieben werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Teilnehmer hat eingecheckt und ausgecheckt.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich die Putzstunden eines Teilnehmers bestaetigen, damit die Stunden dem Familienverbund gutgeschrieben werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Teilnehmer hat eingecheckt und ausgecheckt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4254,17 +4601,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Lehne eine Registrierung ab (POST /api/v1/cleaning/registrations/{id}/reject)</td><td>Registrierung wird als abgelehnt markiert</td><td><input type="checkbox" data-cb="step_US_231_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_231_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins koennen Stunden bestaetigen/ablehnen</label>
-        <label><input type="checkbox" data-cb="crit_US_231_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Bestaetigte Stunden fliessen in das Familien-Stundenkonto (Putz-Sonder-Unterkonto)</label>
-        <label><input type="checkbox" data-cb="crit_US_231_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `CleaningCompletedEvent` wird publiziert</label>
+        <label><input type="checkbox" data-cb="crit_US_231_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins koennen Stunden bestaetigen/ablehnen</label>
+        <label><input type="checkbox" data-cb="crit_US_231_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Bestaetigte Stunden fliessen in das Familien-Stundenkonto (Putz-Sonder-Unterkonto)</label>
+        <label><input type="checkbox" data-cb="crit_US_231_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `CleaningCompletedEvent` wird publiziert</label>
       </div>
     </div>
     <div class="story" id="story-US_232" data-story="US-232" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-232</span> <span class="story-title">Putzminuten manuell anpassen</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich die tatsaechlichen Putzminuten manuell korrigieren, damit Fehler bei Check-in/Check-out korrigiert werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Registrierung mit Check-in und Check-out existiert.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich die tatsaechlichen Putzminuten manuell korrigieren, damit Fehler bei Check-in/Check-out korrigiert werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine Registrierung mit Check-in und Check-out existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4273,17 +4620,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Pruefe die Stundengutschrift</td><td>Die neuen Minuten werden fuer die Berechnung verwendet</td><td><input type="checkbox" data-cb="step_US_232_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_232_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins koennen Minuten anpassen</label>
-        <label><input type="checkbox" data-cb="crit_US_232_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `durationConfirmed=true` markiert die manuell bestaetigte Dauer</label>
-        <label><input type="checkbox" data-cb="crit_US_232_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Die angepassten Minuten wirken sich auf die Stundengutschrift aus</label>
+        <label><input type="checkbox" data-cb="crit_US_232_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins koennen Minuten anpassen</label>
+        <label><input type="checkbox" data-cb="crit_US_232_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `durationConfirmed=true` markiert die manuell bestaetigte Dauer</label>
+        <label><input type="checkbox" data-cb="crit_US_232_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Die angepassten Minuten wirken sich auf die Stundengutschrift aus</label>
       </div>
     </div>
     <div class="story" id="story-US_233" data-story="US-233" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-233</span> <span class="story-title">Putzslot stornieren</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich einen Putzslot stornieren, damit ausgefallene Termine korrekt behandelt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Putzslot mit Registrierungen existiert.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich einen Putzslot stornieren, damit ausgefallene Termine korrekt behandelt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Putzslot mit Registrierungen existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4292,17 +4639,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Versuche, sich fuer einen stornierten Slot zu registrieren</td><td>Fehler: Slot ist storniert</td><td><input type="checkbox" data-cb="step_US_233_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_233_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `cancelled=true` und `cancelReason` werden gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_233_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Slot-Status wird auf CANCELLED gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_233_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Keine neuen Registrierungen fuer stornierte Slots moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_233_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `cancelled=true` und `cancelReason` werden gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_233_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Slot-Status wird auf CANCELLED gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_233_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Keine neuen Registrierungen fuer stornierte Slots moeglich</label>
       </div>
     </div>
     <div class="story" id="story-US_234" data-story="US-234" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-234</span> <span class="story-title">Putz-Dashboard (Admin-Uebersicht)</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich ein Dashboard mit Kennzahlen sehen, damit ich den Putz-Status meines Bereichs ueberblicke.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Putzslots in verschiedenen Status existieren fuer den Bereich.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich ein Dashboard mit Kennzahlen sehen, damit ich den Putz-Status meines Bereichs ueberblicke.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Putzslots in verschiedenen Status existieren fuer den Bereich.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4311,17 +4658,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Aendere den Zeitraum</td><td>Kennzahlen werden fuer den neuen Zeitraum berechnet</td><td><input type="checkbox" data-cb="step_US_234_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_234_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Dashboard zeigt: Gesamtzahl Slots, abgeschlossene Slots, No-Shows, Slots die noch Teilnehmer brauchen</label>
-        <label><input type="checkbox" data-cb="crit_US_234_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Filterbar nach Bereich (`sectionId`) und Zeitraum (`from`, `to`)</label>
-        <label><input type="checkbox" data-cb="crit_US_234_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins des jeweiligen Bereichs haben Zugriff</label>
+        <label><input type="checkbox" data-cb="crit_US_234_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Dashboard zeigt: Gesamtzahl Slots, abgeschlossene Slots, No-Shows, Slots die noch Teilnehmer brauchen</label>
+        <label><input type="checkbox" data-cb="crit_US_234_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Filterbar nach Bereich (`sectionId`) und Zeitraum (`from`, `to`)</label>
+        <label><input type="checkbox" data-cb="crit_US_234_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins des jeweiligen Bereichs haben Zugriff</label>
       </div>
     </div>
     <div class="story" id="story-US_235" data-story="US-235" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-235</span> <span class="story-title">Putzaktion mit Raum-Scope</span></div>
       </div>
-      <div class="story-als">Als Raumleiter (LEADER) moechte ich eine Putzaktion fuer meinen Raum erstellen, damit nur Raum-Mitglieder sich registrieren koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines Raums.</div>
+      <div class="story-als">Als Raumleiter (LEADER) moechte ich eine Putzaktion fuer meinen Raum erstellen, damit nur Raum-Mitglieder sich registrieren koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines Raums.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4330,17 +4677,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Pruefe die Slot-Generierung</td><td>Slots werden mit der `roomId` generiert</td><td><input type="checkbox" data-cb="step_US_235_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_235_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Raumleiter koennen Putzaktionen fuer ihren Raum erstellen</label>
-        <label><input type="checkbox" data-cb="crit_US_235_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `participantCircle` und `participantCircleId` steuern den Teilnehmerkreis</label>
-        <label><input type="checkbox" data-cb="crit_US_235_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Mitglieder des definierten Kreises koennen sich registrieren</label>
+        <label><input type="checkbox" data-cb="crit_US_235_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Raumleiter koennen Putzaktionen fuer ihren Raum erstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_235_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `participantCircle` und `participantCircleId` steuern den Teilnehmerkreis</label>
+        <label><input type="checkbox" data-cb="crit_US_235_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Mitglieder des definierten Kreises koennen sich registrieren</label>
       </div>
     </div>
     <div class="story" id="story-US_236" data-story="US-236" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-236</span> <span class="story-title">Putzaktion Kalender-Event-Verknuepfung</span></div>
       </div>
-      <div class="story-als">Als System moechte ich bei Erstellung einer Putzaktion automatisch ein Kalender-Event erstellen, damit der Putztermin im Schulkalender sichtbar ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Cleaning- und Calendar-Module sind aktiviert.</div>
+      <div class="story-als">Als System moechte ich bei Erstellung einer Putzaktion automatisch ein Kalender-Event erstellen, damit der Putztermin im Schulkalender sichtbar ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Cleaning- und Calendar-Module sind aktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4349,46 +4696,46 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Pruefe die Verknuepfung</td><td>`cleaning_configs.calendar_event_id` zeigt auf das neue Event</td><td><input type="checkbox" data-cb="step_US_236_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_236_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Putzaktion erstellt automatisch ein Kalender-Event</label>
-        <label><input type="checkbox" data-cb="crit_US_236_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `calendarEventId` in der CleaningConfig wird gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_236_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Event ist im Kalender als Putz-Event erkennbar</label>
+        <label><input type="checkbox" data-cb="crit_US_236_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Putzaktion erstellt automatisch ein Kalender-Event</label>
+        <label><input type="checkbox" data-cb="crit_US_236_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> `calendarEventId` in der CleaningConfig wird gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_236_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Event ist im Kalender als Putz-Event erkennbar</label>
       </div>
     </div>
     <div class="story" id="story-US_237" data-story="US-237" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-237</span> <span class="story-title">Putzslot bearbeiten</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich einen einzelnen Putzslot bearbeiten, damit Zeiten oder Teilnehmergrenzen angepasst werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Putzslot existiert.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich einen einzelnen Putzslot bearbeiten, damit Zeiten oder Teilnehmergrenzen angepasst werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Putzslot existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
-          <tr><td>1</td><td>Bearbeite den Slot (PUT /api/v1/cleaning/admin/slots/{id}) mit neuer startTime, endTime, minParticipants, maxParticipants</td><td>Slot-Daten werden aktualisiert</td><td><input type="checkbox" data-cb="step_US_237_1" onchange="onCheck()"></td></tr>
+          <tr><td>1</td><td>Bearbeite den Slot (PUT /api/v1/cleaning/slots/{id}) mit neuer startTime, endTime, minParticipants, maxParticipants</td><td>Slot-Daten werden aktualisiert</td><td><input type="checkbox" data-cb="step_US_237_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Pruefe die aktualisierten Werte</td><td>Neue Werte sind gesetzt, `updatedAt` ist aktualisiert</td><td><input type="checkbox" data-cb="step_US_237_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_237_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur startTime, endTime, minParticipants, maxParticipants sind aenderbar</label>
-        <label><input type="checkbox" data-cb="crit_US_237_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Datum und configId sind nicht aenderbar</label>
-        <label><input type="checkbox" data-cb="crit_US_237_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins des Bereichs koennen Slots bearbeiten</label>
+        <label><input type="checkbox" data-cb="crit_US_237_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur startTime, endTime, minParticipants, maxParticipants sind aenderbar</label>
+        <label><input type="checkbox" data-cb="crit_US_237_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Datum und configId sind nicht aenderbar</label>
+        <label><input type="checkbox" data-cb="crit_US_237_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Nur Putz-Admins des Bereichs koennen Slots bearbeiten</label>
       </div>
     </div>
     <div class="story" id="story-US_238" data-story="US-238" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-238</span> <span class="story-title">Putzaktion-Konfiguration bearbeiten</span></div>
       </div>
-      <div class="story-als">Als Putz-Administrator moechte ich eine Putzaktion-Konfiguration bearbeiten, damit Titel, Zeiten oder Stundengutschrift angepasst werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine CleaningConfig existiert.</div>
+      <div class="story-als">Als Putz-Administrator moechte ich eine Putzaktion-Konfiguration bearbeiten, damit Titel, Zeiten oder Stundengutschrift angepasst werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Eine CleaningConfig existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
-          <tr><td>1</td><td>Bearbeite die Konfiguration (PUT /api/v1/cleaning/admin/configs/{id}) mit neuem Titel und Zeiten</td><td>Konfiguration wird aktualisiert</td><td><input type="checkbox" data-cb="step_US_238_1" onchange="onCheck()"></td></tr>
+          <tr><td>1</td><td>Bearbeite die Konfiguration (PUT /api/v1/cleaning/configs/{id}) mit neuem Titel und Zeiten</td><td>Konfiguration wird aktualisiert</td><td><input type="checkbox" data-cb="step_US_238_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Aendere `active` auf `false`</td><td>Konfiguration wird deaktiviert, keine neuen Slots werden generiert</td><td><input type="checkbox" data-cb="step_US_238_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Pruefe `hoursCredit`</td><td>Stundengutschrift kann angepasst werden</td><td><input type="checkbox" data-cb="step_US_238_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_238_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Aenderbar: title, description, startTime, endTime, minParticipants, maxParticipants, hoursCredit, active</label>
-        <label><input type="checkbox" data-cb="crit_US_238_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> NICHT aenderbar: sectionId, dayOfWeek, specificDate (hierzu neue Config erstellen)</label>
-        <label><input type="checkbox" data-cb="crit_US_238_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Deaktivierte Configs (`active=false`) generieren keine neuen Slots</label>
+        <label><input type="checkbox" data-cb="crit_US_238_0" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Aenderbar: title, description, startTime, endTime, minParticipants, maxParticipants, hoursCredit, active</label>
+        <label><input type="checkbox" data-cb="crit_US_238_1" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> NICHT aenderbar: sectionId, dayOfWeek, specificDate (hierzu neue Config erstellen)</label>
+        <label><input type="checkbox" data-cb="crit_US_238_2" data-crit="1" data-module="Putz_Orga___Cleaning" onchange="onCheck()"> Deaktivierte Configs (`active=false`) generieren keine neuen Slots</label>
       </div>
     </div>
   </div>
@@ -4406,8 +4753,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-250</span> <span class="story-title">Fotobox-Einstellungen konfigurieren (Raumleiter)</span></div>
       </div>
-      <div class="story-als">Als Raumleiter (LEADER) moechte ich die Fotobox-Einstellungen fuer meinen Raum konfigurieren, damit Mitglieder Fotos teilen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines Raums. Fotobox-Modul ist aktiviert (`monteweb.modules.fotobox.enabled=true`).</div>
+      <div class="story-als">Als Raumleiter (LEADER) moechte ich die Fotobox-Einstellungen fuer meinen Raum konfigurieren, damit Mitglieder Fotos teilen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist LEADER eines Raums. Fotobox-Modul ist aktiviert (`monteweb.modules.fotobox.enabled=true`).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4417,18 +4764,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Setze `maxImagesPerThread` auf 50 und `maxFileSizeMb` auf 10</td><td>Limits werden gespeichert</td><td><input type="checkbox" data-cb="step_US_250_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_250_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Standard-Einstellungen: `enabled=false`, `defaultPermission=VIEW_ONLY`, `maxFileSizeMb=10`</label>
-        <label><input type="checkbox" data-cb="crit_US_250_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur LEADER oder SUPERADMIN koennen Einstellungen aendern</label>
-        <label><input type="checkbox" data-cb="crit_US_250_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> `maxImagesPerThread` &lt;= 0 oder null bedeutet kein Limit</label>
-        <label><input type="checkbox" data-cb="crit_US_250_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Einstellungen gelten raumweit</label>
+        <label><input type="checkbox" data-cb="crit_US_250_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Standard-Einstellungen: `enabled=false`, `defaultPermission=VIEW_ONLY`, `maxFileSizeMb=10`</label>
+        <label><input type="checkbox" data-cb="crit_US_250_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur LEADER oder SUPERADMIN koennen Einstellungen aendern</label>
+        <label><input type="checkbox" data-cb="crit_US_250_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> `maxImagesPerThread` &lt;= 0 oder null bedeutet kein Limit</label>
+        <label><input type="checkbox" data-cb="crit_US_250_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Einstellungen gelten raumweit</label>
       </div>
     </div>
     <div class="story" id="story-US_251" data-story="US-251" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-251</span> <span class="story-title">Fotobox-Thread erstellen</span></div>
       </div>
-      <div class="story-als">Als Raumleiter (LEADER) oder Benutzer mit CREATE_THREADS-Berechtigung moechte ich einen neuen Foto-Thread erstellen, damit Fotos thematisch gruppiert werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Fotobox ist fuer den Raum aktiviert. Benutzer hat mindestens CREATE_THREADS-Berechtigung.</div>
+      <div class="story-als">Als Raumleiter (LEADER) oder Benutzer mit CREATE_THREADS-Berechtigung moechte ich einen neuen Foto-Thread erstellen, damit Fotos thematisch gruppiert werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Fotobox ist fuer den Raum aktiviert. Benutzer hat mindestens CREATE_THREADS-Berechtigung.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4438,18 +4785,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefe die Thread-Liste (GET /api/v1/rooms/{roomId}/fotobox/threads)</td><td>Neuer Thread erscheint in der Liste</td><td><input type="checkbox" data-cb="step_US_251_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_251_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> CREATE_THREADS-Berechtigung wird geprueft (ordinal-basiert: CREATE_THREADS &gt; POST_IMAGES &gt; VIEW_ONLY)</label>
-        <label><input type="checkbox" data-cb="crit_US_251_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> LEADER und SUPERADMIN haben immer CREATE_THREADS-Berechtigung</label>
-        <label><input type="checkbox" data-cb="crit_US_251_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Thread hat Felder: title, description, audience, createdBy, coverImageId (optional)</label>
-        <label><input type="checkbox" data-cb="crit_US_251_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> `FotoboxThreadCreatedEvent` wird publiziert</label>
+        <label><input type="checkbox" data-cb="crit_US_251_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> CREATE_THREADS-Berechtigung wird geprueft (ordinal-basiert: CREATE_THREADS &gt; POST_IMAGES &gt; VIEW_ONLY)</label>
+        <label><input type="checkbox" data-cb="crit_US_251_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> LEADER und SUPERADMIN haben immer CREATE_THREADS-Berechtigung</label>
+        <label><input type="checkbox" data-cb="crit_US_251_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Thread hat Felder: title, description, audience, createdBy, coverImageId (optional)</label>
+        <label><input type="checkbox" data-cb="crit_US_251_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> `FotoboxThreadCreatedEvent` wird publiziert</label>
       </div>
     </div>
     <div class="story" id="story-US_252" data-story="US-252" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-252</span> <span class="story-title">Thread-Audience fuer verschiedene Rollen</span></div>
       </div>
-      <div class="story-als">Als Elternteil (P) moechte ich Threads mit Audience PARENTS_ONLY erstellen, damit nur Eltern die Fotos sehen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Elternteil mit CREATE_THREADS-Berechtigung.</div>
+      <div class="story-als">Als Elternteil (P) moechte ich Threads mit Audience PARENTS_ONLY erstellen, damit nur Eltern die Fotos sehen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Elternteil mit CREATE_THREADS-Berechtigung.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4460,18 +4807,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Logge dich als Elternteil ein und pruefe die Thread-Liste</td><td>Nur Threads mit Audience ALL und PARENTS_ONLY sind sichtbar</td><td><input type="checkbox" data-cb="step_US_252_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_252_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Eltern erstellen automatisch `PARENTS_ONLY`-Threads (resolveAudience)</label>
-        <label><input type="checkbox" data-cb="crit_US_252_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Lehrer/Leader/Admins koennen die Audience explizit waehlen (ALL, PARENTS_ONLY, STUDENTS_ONLY)</label>
-        <label><input type="checkbox" data-cb="crit_US_252_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Thread-Liste wird serverseitig nach Audience gefiltert basierend auf der Benutzerrolle</label>
-        <label><input type="checkbox" data-cb="crit_US_252_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> `getAllowedAudiences()` bestimmt die sichtbaren Audiences pro Benutzer</label>
+        <label><input type="checkbox" data-cb="crit_US_252_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Eltern erstellen automatisch `PARENTS_ONLY`-Threads (resolveAudience)</label>
+        <label><input type="checkbox" data-cb="crit_US_252_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Lehrer/Leader/Admins koennen die Audience explizit waehlen (ALL, PARENTS_ONLY, STUDENTS_ONLY)</label>
+        <label><input type="checkbox" data-cb="crit_US_252_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Thread-Liste wird serverseitig nach Audience gefiltert basierend auf der Benutzerrolle</label>
+        <label><input type="checkbox" data-cb="crit_US_252_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> `getAllowedAudiences()` bestimmt die sichtbaren Audiences pro Benutzer</label>
       </div>
     </div>
     <div class="story" id="story-US_253" data-story="US-253" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-253</span> <span class="story-title">Fotos hochladen (max 20 pro Upload)</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied mit POST_IMAGES-Berechtigung moechte ich Fotos in einen Thread hochladen, damit ich Bilder mit der Gruppe teilen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Thread existiert. Benutzer hat mindestens POST_IMAGES-Berechtigung und eine aktive PHOTO_CONSENT.</div>
+      <div class="story-als">Als Raum-Mitglied mit POST_IMAGES-Berechtigung moechte ich Fotos in einen Thread hochladen, damit ich Bilder mit der Gruppe teilen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Thread existiert. Benutzer hat mindestens POST_IMAGES-Berechtigung und eine aktive PHOTO_CONSENT.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4482,19 +4829,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Versuche ohne PHOTO_CONSENT hochzuladen</td><td>Fehler 403: &quot;PHOTO_CONSENT required to upload images to Fotobox&quot;</td><td><input type="checkbox" data-cb="step_US_253_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_253_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Maximum 20 Dateien pro Upload (`MAX_FILES_PER_UPLOAD = 20`)</label>
-        <label><input type="checkbox" data-cb="crit_US_253_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Erlaubte Content-Types: image/jpeg, image/png, image/webp, image/gif</label>
-        <label><input type="checkbox" data-cb="crit_US_253_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Thumbnails werden automatisch generiert (400px, JPEG, 80% Qualitaet)</label>
-        <label><input type="checkbox" data-cb="crit_US_253_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> PHOTO_CONSENT ist Pflicht fuer Uploads</label>
-        <label><input type="checkbox" data-cb="crit_US_253_4" data-crit="1" data-module="Fotobox" onchange="onCheck()"> POST_IMAGES-Berechtigung ist Mindestanforderung</label>
+        <label><input type="checkbox" data-cb="crit_US_253_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Maximum 20 Dateien pro Upload (`MAX_FILES_PER_UPLOAD = 20`)</label>
+        <label><input type="checkbox" data-cb="crit_US_253_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Erlaubte Content-Types: image/jpeg, image/png, image/webp, image/gif</label>
+        <label><input type="checkbox" data-cb="crit_US_253_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Thumbnails werden automatisch generiert (400px, JPEG, 80% Qualitaet)</label>
+        <label><input type="checkbox" data-cb="crit_US_253_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> PHOTO_CONSENT ist Pflicht fuer Uploads</label>
+        <label><input type="checkbox" data-cb="crit_US_253_4" data-crit="1" data-module="Fotobox" onchange="onCheck()"> POST_IMAGES-Berechtigung ist Mindestanforderung</label>
       </div>
     </div>
     <div class="story" id="story-US_254" data-story="US-254" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-254</span> <span class="story-title">Content-Type-Validierung ueber Magic Bytes</span></div>
       </div>
-      <div class="story-als">Als System moechte ich den Dateityp ueber Magic Bytes (nicht den deklarierten Content-Type) pruefen, damit keine als Bilder getarnten Schadateien hochgeladen werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Upload-Endpunkt ist erreichbar.</div>
+      <div class="story-als">Als System moechte ich den Dateityp ueber Magic Bytes (nicht den deklarierten Content-Type) pruefen, damit keine als Bilder getarnten Schadateien hochgeladen werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Upload-Endpunkt ist erreichbar.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4506,20 +4853,20 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Lade eine Datei &lt; 4 Bytes hoch</td><td>Fehler: &quot;File too small to be a valid image&quot;</td><td><input type="checkbox" data-cb="step_US_254_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_254_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> JPEG: Bytes 0-2 = `FF D8 FF`</label>
-        <label><input type="checkbox" data-cb="crit_US_254_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> PNG: Bytes 0-3 = `89 50 4E 47`</label>
-        <label><input type="checkbox" data-cb="crit_US_254_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> GIF: Bytes 0-2 = `47 49 46`</label>
-        <label><input type="checkbox" data-cb="crit_US_254_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> WebP: Bytes 0-3 = `52 49 46 46` UND Bytes 8-11 = `57 45 42 50`</label>
-        <label><input type="checkbox" data-cb="crit_US_254_4" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Dateien &lt; 4 Bytes werden abgelehnt</label>
-        <label><input type="checkbox" data-cb="crit_US_254_5" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Der deklarierte Content-Type-Header wird ignoriert (nur Magic Bytes zaehlen)</label>
+        <label><input type="checkbox" data-cb="crit_US_254_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> JPEG: Bytes 0-2 = `FF D8 FF`</label>
+        <label><input type="checkbox" data-cb="crit_US_254_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> PNG: Bytes 0-3 = `89 50 4E 47`</label>
+        <label><input type="checkbox" data-cb="crit_US_254_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> GIF: Bytes 0-2 = `47 49 46`</label>
+        <label><input type="checkbox" data-cb="crit_US_254_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> WebP: Bytes 0-3 = `52 49 46 46` UND Bytes 8-11 = `57 45 42 50`</label>
+        <label><input type="checkbox" data-cb="crit_US_254_4" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Dateien &lt; 4 Bytes werden abgelehnt</label>
+        <label><input type="checkbox" data-cb="crit_US_254_5" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Der deklarierte Content-Type-Header wird ignoriert (nur Magic Bytes zaehlen)</label>
       </div>
     </div>
     <div class="story" id="story-US_255" data-story="US-255" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-255</span> <span class="story-title">Lightbox-Ansicht</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied mit VIEW_ONLY-Berechtigung moechte ich Fotos in einer Lightbox-Ansicht betrachten, damit ich Bilder im Grossformat sehen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Thread mit hochgeladenen Bildern existiert.</div>
+      <div class="story-als">Als Raum-Mitglied mit VIEW_ONLY-Berechtigung moechte ich Fotos in einer Lightbox-Ansicht betrachten, damit ich Bilder im Grossformat sehen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Thread mit hochgeladenen Bildern existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4529,18 +4876,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefe die Thumbnail-URL</td><td>Thumbnail ueber GET /api/v1/fotobox/images/{id}/thumbnail?token={jwt}</td><td><input type="checkbox" data-cb="step_US_255_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_255_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Bilder werden ueber JWT-Token-Authentifizierung per Query-Parameter geladen (`?token=`)</label>
-        <label><input type="checkbox" data-cb="crit_US_255_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Sortierung nach `sortOrder` aufsteigend, dann `createdAt` aufsteigend</label>
-        <label><input type="checkbox" data-cb="crit_US_255_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> VIEW_ONLY-Berechtigung genuegt zum Betrachten</label>
-        <label><input type="checkbox" data-cb="crit_US_255_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Lightbox unterstuetzt Vor-/Zurueck-Navigation</label>
+        <label><input type="checkbox" data-cb="crit_US_255_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Bilder werden ueber JWT-Token-Authentifizierung per Query-Parameter geladen (`?token=`)</label>
+        <label><input type="checkbox" data-cb="crit_US_255_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Sortierung nach `sortOrder` aufsteigend, dann `createdAt` aufsteigend</label>
+        <label><input type="checkbox" data-cb="crit_US_255_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> VIEW_ONLY-Berechtigung genuegt zum Betrachten</label>
+        <label><input type="checkbox" data-cb="crit_US_255_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Lightbox unterstuetzt Vor-/Zurueck-Navigation</label>
       </div>
     </div>
     <div class="story" id="story-US_256" data-story="US-256" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-256</span> <span class="story-title">Berechtigungshierarchie der Fotobox</span></div>
       </div>
-      <div class="story-als">Als System moechte ich die Fotobox-Berechtigungen hierarchisch pruefen, damit die richtige Zugriffsebene durchgesetzt wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Fotobox ist fuer einen Raum aktiviert. Verschiedene Benutzerrollen existieren.</div>
+      <div class="story-als">Als System moechte ich die Fotobox-Berechtigungen hierarchisch pruefen, damit die richtige Zugriffsebene durchgesetzt wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Fotobox ist fuer einen Raum aktiviert. Verschiedene Benutzerrollen existieren.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4553,41 +4900,41 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Versuche auf einen Raum mit deaktivierter Fotobox zuzugreifen</td><td>Fehler: &quot;Fotobox not enabled for this room&quot;</td><td><input type="checkbox" data-cb="step_US_256_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_256_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Hierarchie: CREATE_THREADS (ordinal 2) &gt; POST_IMAGES (ordinal 1) &gt; VIEW_ONLY (ordinal 0)</label>
-        <label><input type="checkbox" data-cb="crit_US_256_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> SUPERADMIN: immer CREATE_THREADS, auch ohne Raum-Mitgliedschaft</label>
-        <label><input type="checkbox" data-cb="crit_US_256_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> LEADER: immer CREATE_THREADS</label>
-        <label><input type="checkbox" data-cb="crit_US_256_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Andere Mitglieder: `defaultPermission` aus den Raum-Einstellungen</label>
-        <label><input type="checkbox" data-cb="crit_US_256_4" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nicht-Mitglieder: Zugriff verweigert (ausser SUPERADMIN)</label>
-        <label><input type="checkbox" data-cb="crit_US_256_5" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Deaktivierte Fotobox: Zugriff fuer alle verweigert</label>
+        <label><input type="checkbox" data-cb="crit_US_256_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Hierarchie: CREATE_THREADS (ordinal 2) &gt; POST_IMAGES (ordinal 1) &gt; VIEW_ONLY (ordinal 0)</label>
+        <label><input type="checkbox" data-cb="crit_US_256_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> SUPERADMIN: immer CREATE_THREADS, auch ohne Raum-Mitgliedschaft</label>
+        <label><input type="checkbox" data-cb="crit_US_256_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> LEADER: immer CREATE_THREADS</label>
+        <label><input type="checkbox" data-cb="crit_US_256_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Andere Mitglieder: `defaultPermission` aus den Raum-Einstellungen</label>
+        <label><input type="checkbox" data-cb="crit_US_256_4" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nicht-Mitglieder: Zugriff verweigert (ausser SUPERADMIN)</label>
+        <label><input type="checkbox" data-cb="crit_US_256_5" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Deaktivierte Fotobox: Zugriff fuer alle verweigert</label>
       </div>
     </div>
     <div class="story" id="story-US_257" data-story="US-257" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-257</span> <span class="story-title">Foto loeschen</span></div>
       </div>
-      <div class="story-als">Als Foto-Uploader oder Raumleiter moechte ich ein Foto loeschen, damit fehlerhafte oder ungewuenschte Bilder entfernt werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Bild existiert in einem Thread.</div>
+      <div class="story-als">Als Foto-Uploader oder Raumleiter moechte ich ein Foto loeschen, damit fehlerhafte oder ungewuenschte Bilder entfernt werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Bild existiert in einem Thread.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Logge dich als Uploader des Bildes ein</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_257_1" onchange="onCheck()"></td></tr>
-          <tr><td>2</td><td>Loesche das Bild (DELETE /api/v1/rooms/{roomId}/fotobox/images/{imageId})</td><td>Bild und Thumbnail werden aus MinIO und DB geloescht</td><td><input type="checkbox" data-cb="step_US_257_2" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Loesche das Bild (DELETE /api/v1/fotobox/images/{imageId})</td><td>Bild und Thumbnail werden aus MinIO und DB geloescht</td><td><input type="checkbox" data-cb="step_US_257_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Versuche als anderer Benutzer (nicht Uploader, nicht Leader) zu loeschen</td><td>Fehler: Nur Uploader oder Leader/Admin koennen loeschen</td><td><input type="checkbox" data-cb="step_US_257_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Logge dich als LEADER ein und loesche ein beliebiges Bild</td><td>Loeschung erfolgreich (Leader kann alle Bilder loeschen)</td><td><input type="checkbox" data-cb="step_US_257_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_257_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Bild-Uploader kann eigene Bilder loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_257_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> LEADER und SUPERADMIN koennen alle Bilder loeschen (isImageOwnerOrLeader)</label>
-        <label><input type="checkbox" data-cb="crit_US_257_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Original-Datei UND Thumbnail werden aus MinIO geloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_257_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> DB-Eintrag wird entfernt</label>
+        <label><input type="checkbox" data-cb="crit_US_257_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Bild-Uploader kann eigene Bilder loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_257_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> LEADER und SUPERADMIN koennen alle Bilder loeschen (isImageOwnerOrLeader)</label>
+        <label><input type="checkbox" data-cb="crit_US_257_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Original-Datei UND Thumbnail werden aus MinIO geloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_257_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> DB-Eintrag wird entfernt</label>
       </div>
     </div>
     <div class="story" id="story-US_258" data-story="US-258" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-258</span> <span class="story-title">Thread loeschen mit allen Bildern</span></div>
       </div>
-      <div class="story-als">Als Thread-Ersteller oder Raumleiter moechte ich einen Thread inklusive aller Bilder loeschen, damit ein ganzes Fotoalbum entfernt werden kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Thread mit mehreren Bildern existiert.</div>
+      <div class="story-als">Als Thread-Ersteller oder Raumleiter moechte ich einen Thread inklusive aller Bilder loeschen, damit ein ganzes Fotoalbum entfernt werden kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Thread mit mehreren Bildern existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4597,18 +4944,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Versuche als fremder Benutzer zu loeschen</td><td>Fehler: &quot;Only thread creator or room leader can delete this thread&quot;</td><td><input type="checkbox" data-cb="step_US_258_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_258_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur Thread-Ersteller oder Leader/Admin koennen den Thread loeschen (isThreadOwnerOrLeader)</label>
-        <label><input type="checkbox" data-cb="crit_US_258_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Alle Bilder des Threads werden zuerst aus MinIO geloescht (Originale + Thumbnails)</label>
-        <label><input type="checkbox" data-cb="crit_US_258_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Dann werden alle Image-DB-Eintraege geloescht (`deleteAllByThreadId`)</label>
-        <label><input type="checkbox" data-cb="crit_US_258_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Zuletzt wird der Thread-Eintrag selbst geloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_258_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur Thread-Ersteller oder Leader/Admin koennen den Thread loeschen (isThreadOwnerOrLeader)</label>
+        <label><input type="checkbox" data-cb="crit_US_258_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Alle Bilder des Threads werden zuerst aus MinIO geloescht (Originale + Thumbnails)</label>
+        <label><input type="checkbox" data-cb="crit_US_258_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Dann werden alle Image-DB-Eintraege geloescht (`deleteAllByThreadId`)</label>
+        <label><input type="checkbox" data-cb="crit_US_258_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Zuletzt wird der Thread-Eintrag selbst geloescht</label>
       </div>
     </div>
     <div class="story" id="story-US_259" data-story="US-259" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-259</span> <span class="story-title">Thread bearbeiten</span></div>
       </div>
-      <div class="story-als">Als Thread-Ersteller oder Raumleiter moechte ich den Titel und die Beschreibung eines Threads aendern, damit Korrekturen moeglich sind.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Thread existiert.</div>
+      <div class="story-als">Als Thread-Ersteller oder Raumleiter moechte ich den Titel und die Beschreibung eines Threads aendern, damit Korrekturen moeglich sind.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Thread existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4618,28 +4965,28 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Versuche als fremder Benutzer zu bearbeiten</td><td>Fehler: &quot;Only thread creator or room leader can edit this thread&quot;</td><td><input type="checkbox" data-cb="step_US_259_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_259_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur Thread-Ersteller oder Leader/Admin koennen bearbeiten</label>
-        <label><input type="checkbox" data-cb="crit_US_259_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur `title` und `description` sind aenderbar (nicht `audience`, `roomId`)</label>
-        <label><input type="checkbox" data-cb="crit_US_259_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> `updatedAt` wird aktualisiert</label>
-        <label><input type="checkbox" data-cb="crit_US_259_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Room-Zugehoerigkeit wird validiert</label>
+        <label><input type="checkbox" data-cb="crit_US_259_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur Thread-Ersteller oder Leader/Admin koennen bearbeiten</label>
+        <label><input type="checkbox" data-cb="crit_US_259_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur `title` und `description` sind aenderbar (nicht `audience`, `roomId`)</label>
+        <label><input type="checkbox" data-cb="crit_US_259_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> `updatedAt` wird aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_259_3" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Room-Zugehoerigkeit wird validiert</label>
       </div>
     </div>
     <div class="story" id="story-US_260" data-story="US-260" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-260</span> <span class="story-title">Bild-Caption aktualisieren</span></div>
       </div>
-      <div class="story-als">Als Bild-Uploader oder Raumleiter moechte ich die Bildbeschreibung (Caption) aendern, damit ich Kommentare zu Fotos hinzufuegen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Bild existiert in einem Thread.</div>
+      <div class="story-als">Als Bild-Uploader oder Raumleiter moechte ich die Bildbeschreibung (Caption) aendern, damit ich Kommentare zu Fotos hinzufuegen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Bild existiert in einem Thread.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
-          <tr><td>1</td><td>Bearbeite das Bild (PUT /api/v1/rooms/{roomId}/fotobox/images/{imageId}) mit Caption (max 500 Zeichen)</td><td>Caption wird aktualisiert</td><td><input type="checkbox" data-cb="step_US_260_1" onchange="onCheck()"></td></tr>
+          <tr><td>1</td><td>Bearbeite das Bild (PUT /api/v1/fotobox/images/{imageId}) mit Caption (max 500 Zeichen)</td><td>Caption wird aktualisiert</td><td><input type="checkbox" data-cb="step_US_260_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Pruefe die Bildliste des Threads</td><td>Neue Caption wird angezeigt</td><td><input type="checkbox" data-cb="step_US_260_2" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_260_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Caption max 500 Zeichen</label>
-        <label><input type="checkbox" data-cb="crit_US_260_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur Uploader oder Leader/Admin koennen die Caption aendern</label>
-        <label><input type="checkbox" data-cb="crit_US_260_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Bild hat zusaetzliche Metadaten: width, height, sortOrder</label>
+        <label><input type="checkbox" data-cb="crit_US_260_0" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Caption max 500 Zeichen</label>
+        <label><input type="checkbox" data-cb="crit_US_260_1" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Nur Uploader oder Leader/Admin koennen die Caption aendern</label>
+        <label><input type="checkbox" data-cb="crit_US_260_2" data-crit="1" data-module="Fotobox" onchange="onCheck()"> Bild hat zusaetzliche Metadaten: width, height, sortOrder</label>
       </div>
     </div>
   </div>
@@ -4648,7 +4995,7 @@ td:last-child { width: 40px; text-align: center; }
   <div class="module-header" onclick="toggleModule('Fundgrube___Lost___Found')">
     <h2><span class="chevron">&#9654;</span> Fundgrube / Lost &amp; Found <span class="badge">13 Stories</span></h2>
     <div>
-      <span class="progress-info" id="prog-Fundgrube___Lost___Found">0/49</span>
+      <span class="progress-info" id="prog-Fundgrube___Lost___Found">0/50</span>
       <div class="progress-bar" style="width:120px"><div class="progress-fill" id="bar-Fundgrube___Lost___Found" style="width:0%"></div></div>
     </div>
   </div>
@@ -4657,8 +5004,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-270</span> <span class="story-title">Fundgegenstand einstellen</span></div>
       </div>
-      <div class="story-als">Als beliebiger Benutzer moechte ich einen Fundgegenstand einstellen, damit der Eigentuemer ihn wiederfinden kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt. Fundgrube-Modul ist aktiviert (`monteweb.modules.fundgrube.enabled=true`).</div>
+      <div class="story-als">Als beliebiger Benutzer moechte ich einen Fundgegenstand einstellen, damit der Eigentuemer ihn wiederfinden kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt. Fundgrube-Modul ist aktiviert (`monteweb.modules.fundgrube.enabled=true`).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4669,18 +5016,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Klicke auf &quot;Erstellen&quot; (POST /api/v1/fundgrube/items)</td><td>Item wird erstellt mit `createdBy`, `createdAt`, ohne `claimedBy`</td><td><input type="checkbox" data-cb="step_US_270_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_270_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Alle eingeloggten Benutzer koennen Gegenstaende einstellen</label>
-        <label><input type="checkbox" data-cb="crit_US_270_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Titel ist Pflichtfeld (max 300 Zeichen), Beschreibung optional (max 2000 Zeichen)</label>
-        <label><input type="checkbox" data-cb="crit_US_270_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `sectionId` ist optional (null = schulweit sichtbar)</label>
-        <label><input type="checkbox" data-cb="crit_US_270_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `claimedBy`, `claimedAt`, `expiresAt` sind initial null</label>
+        <label><input type="checkbox" data-cb="crit_US_270_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Alle eingeloggten Benutzer koennen Gegenstaende einstellen</label>
+        <label><input type="checkbox" data-cb="crit_US_270_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Titel ist Pflichtfeld (max 300 Zeichen), Beschreibung optional (max 2000 Zeichen)</label>
+        <label><input type="checkbox" data-cb="crit_US_270_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `sectionId` ist optional (null = schulweit sichtbar)</label>
+        <label><input type="checkbox" data-cb="crit_US_270_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `claimedBy`, `claimedAt`, `expiresAt` sind initial null</label>
       </div>
     </div>
     <div class="story" id="story-US_271" data-story="US-271" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-271</span> <span class="story-title">Fotos zum Fundgegenstand hochladen</span></div>
       </div>
-      <div class="story-als">Als Ersteller eines Fundgegenstands moechte ich Fotos hochladen, damit der Eigentuemer den Gegenstand leichter identifizieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgrube-Item existiert, erstellt vom Benutzer.</div>
+      <div class="story-als">Als Ersteller eines Fundgegenstands moechte ich Fotos hochladen, damit der Eigentuemer den Gegenstand leichter identifizieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgrube-Item existiert, erstellt vom Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4690,18 +5037,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Rufe das Thumbnail ab (GET /api/v1/fundgrube/images/{imageId}/thumbnail?token={jwt})</td><td>Thumbnail wird zurueckgegeben</td><td><input type="checkbox" data-cb="step_US_271_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_271_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bilder werden in MinIO gespeichert</label>
-        <label><input type="checkbox" data-cb="crit_US_271_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Thumbnails werden automatisch generiert</label>
-        <label><input type="checkbox" data-cb="crit_US_271_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bilder sind ueber JWT-Token-Parameter (`?token=`) abrufbar</label>
-        <label><input type="checkbox" data-cb="crit_US_271_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Content-Type wird korrekt erkannt und gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_271_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bilder werden in MinIO gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_271_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Thumbnails werden automatisch generiert</label>
+        <label><input type="checkbox" data-cb="crit_US_271_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bilder sind ueber JWT-Token-Parameter (`?token=`) abrufbar</label>
+        <label><input type="checkbox" data-cb="crit_US_271_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Content-Type wird korrekt erkannt und gespeichert</label>
       </div>
     </div>
     <div class="story" id="story-US_272" data-story="US-272" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-272</span> <span class="story-title">Fundgegenstaende auflisten mit Bereichsfilter</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die Fundgrube nach Schulbereich filtern, damit ich schneller finde, was ich suche.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Fundgegenstaende mit verschiedenen sectionIds existieren.</div>
+      <div class="story-als">Als Benutzer moechte ich die Fundgrube nach Schulbereich filtern, damit ich schneller finde, was ich suche.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Fundgegenstaende mit verschiedenen sectionIds existieren.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4710,17 +5057,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Pruefe einen Gegenstand ohne sectionId</td><td>Dieser erscheint bei ALLEN Bereichsfiltern (schulweit)</td><td><input type="checkbox" data-cb="step_US_272_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_272_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Gegenstaende ohne `sectionId` sind schulweit sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_272_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bereichsfilter ist optional</label>
-        <label><input type="checkbox" data-cb="crit_US_272_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bereits beanspruchte (claimed) Gegenstaende koennen separat gefiltert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_272_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Gegenstaende ohne `sectionId` sind schulweit sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_272_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bereichsfilter ist optional</label>
+        <label><input type="checkbox" data-cb="crit_US_272_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bereits beanspruchte (claimed) Gegenstaende koennen separat gefiltert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_273" data-story="US-273" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-273</span> <span class="story-title">Fundgegenstand beanspruchen (Claim)</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich einen Fundgegenstand beanspruchen, damit ich ihn abholen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein unbeanspruchter Fundgegenstand existiert.</div>
+      <div class="story-als">Als Benutzer moechte ich einen Fundgegenstand beanspruchen, damit ich ihn abholen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein unbeanspruchter Fundgegenstand existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4728,21 +5075,23 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Gib optionalen Kommentar ein (max 1000 Zeichen) und sende (POST /api/v1/fundgrube/items/{itemId}/claim)</td><td>`claimedBy` wird auf den Benutzer gesetzt, `claimedAt` auf den aktuellen Zeitpunkt</td><td><input type="checkbox" data-cb="step_US_273_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Pruefe `expiresAt`</td><td>`expiresAt = claimedAt + 24 Stunden`</td><td><input type="checkbox" data-cb="step_US_273_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Versuche, einen bereits beanspruchten Gegenstand erneut zu beanspruchen</td><td>Fehler: Gegenstand ist bereits beansprucht</td><td><input type="checkbox" data-cb="step_US_273_4" onchange="onCheck()"></td></tr>
+          <tr><td>5</td><td>Versuche, den eigenen Fundgegenstand zu beanspruchen</td><td>Fehler (BadRequest): &quot;Cannot claim your own item&quot;</td><td><input type="checkbox" data-cb="step_US_273_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_273_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `claimedBy` wird auf den beanspruchenden Benutzer gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_273_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `claimedAt` wird auf `Instant.now()` gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_273_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `expiresAt` wird auf `claimedAt + 24 Stunden` gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_273_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Kommentar ist optional (max 1000 Zeichen)</label>
-        <label><input type="checkbox" data-cb="crit_US_273_4" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Doppelbeanspruchung wird verhindert</label>
+        <label><input type="checkbox" data-cb="crit_US_273_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `claimedBy` wird auf den beanspruchenden Benutzer gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_273_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `claimedAt` wird auf `Instant.now()` gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_273_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `expiresAt` wird auf `claimedAt + 24 Stunden` gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_273_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Kommentar ist optional (max 1000 Zeichen)</label>
+        <label><input type="checkbox" data-cb="crit_US_273_4" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Doppelbeanspruchung wird verhindert</label>
+        <label><input type="checkbox" data-cb="crit_US_273_5" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Der Ersteller kann seinen eigenen Gegenstand NICHT beanspruchen</label>
       </div>
     </div>
     <div class="story" id="story-US_274" data-story="US-274" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-274</span> <span class="story-title">Claim-Ablauf nach 24 Stunden</span></div>
       </div>
-      <div class="story-als">Als System moechte ich beanspruchte Gegenstaende nach 24 Stunden automatisch loeschen, damit nicht abgeholte Gegenstaende nicht dauerhaft blockiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Gegenstand wurde vor mehr als 24 Stunden beansprucht. Der `@Scheduled`-Job laeuft taeglich um 3:00 Uhr.</div>
+      <div class="story-als">Als System moechte ich beanspruchte Gegenstaende nach 24 Stunden automatisch loeschen, damit nicht abgeholte Gegenstaende nicht dauerhaft blockiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Gegenstand wurde vor mehr als 24 Stunden beansprucht. Der `@Scheduled`-Job laeuft taeglich um 3:00 Uhr.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4752,38 +5101,38 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefe nicht-abgelaufene Gegenstaende</td><td>Noch nicht abgelaufene Gegenstaende bleiben erhalten</td><td><input type="checkbox" data-cb="step_US_274_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_274_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Cleanup-Job laeuft taeglich um 3:00 Uhr (`@Scheduled(cron = &quot;0 0 3 * * *&quot;)`)</label>
-        <label><input type="checkbox" data-cb="crit_US_274_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Nur Gegenstaende mit `expiresAt &lt; Instant.now()` werden geloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_274_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Fuer jeden abgelaufenen Gegenstand: alle Bilder (Originale + Thumbnails) aus MinIO loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_274_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Dann DB-Eintraege loeschen (Item + Images)</label>
-        <label><input type="checkbox" data-cb="crit_US_274_4" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Log-Eintrag: &quot;Fundgrube cleanup: deleted X expired items&quot;</label>
+        <label><input type="checkbox" data-cb="crit_US_274_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Cleanup-Job laeuft taeglich um 3:00 Uhr (`@Scheduled(cron = &quot;0 0 3 * * *&quot;)`)</label>
+        <label><input type="checkbox" data-cb="crit_US_274_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Nur Gegenstaende mit `expiresAt &lt; Instant.now()` werden geloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_274_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Fuer jeden abgelaufenen Gegenstand: alle Bilder (Originale + Thumbnails) aus MinIO loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_274_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Dann DB-Eintraege loeschen (Item + Images)</label>
+        <label><input type="checkbox" data-cb="crit_US_274_4" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Log-Eintrag: &quot;Fundgrube cleanup: deleted X expired items&quot;</label>
       </div>
     </div>
     <div class="story" id="story-US_275" data-story="US-275" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-275</span> <span class="story-title">Fundgegenstand bearbeiten</span></div>
       </div>
-      <div class="story-als">Als Ersteller eines Fundgegenstands moechte ich den Titel und die Beschreibung aendern, damit ich Fehler korrigieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgrube-Item existiert, erstellt vom Benutzer.</div>
+      <div class="story-als">Als Ersteller eines Fundgegenstands moechte ich den Titel und die Beschreibung aendern, damit ich Fehler korrigieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgrube-Item existiert, erstellt vom Benutzer.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Bearbeite den Gegenstand (PUT /api/v1/fundgrube/items/{itemId}) mit neuem Titel</td><td>Titel wird aktualisiert, `updatedAt` wird gesetzt</td><td><input type="checkbox" data-cb="step_US_275_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Aendere die Beschreibung</td><td>Beschreibung wird aktualisiert</td><td><input type="checkbox" data-cb="step_US_275_2" onchange="onCheck()"></td></tr>
-          <tr><td>3</td><td>Versuche als anderer Benutzer zu bearbeiten</td><td>Fehler: Nur Ersteller oder Admins koennen bearbeiten</td><td><input type="checkbox" data-cb="step_US_275_3" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Versuche als anderer Benutzer zu bearbeiten</td><td>Fehler: Nur Ersteller, SUPERADMIN oder zustaendiger SECTION_ADMIN koennen bearbeiten</td><td><input type="checkbox" data-cb="step_US_275_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_275_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Nur der Ersteller oder Admins koennen bearbeiten</label>
-        <label><input type="checkbox" data-cb="crit_US_275_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `updatedAt` wird bei jeder Aenderung aktualisiert</label>
-        <label><input type="checkbox" data-cb="crit_US_275_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Titel und Beschreibung sind aenderbar, sectionId kann geaendert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_275_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bearbeiten/Loeschen erlaubt fuer Ersteller, SUPERADMIN sowie den SECTION_ADMIN des Item-Bereichs (specialRoles `SECTION_ADMIN:&lt;sectionId&gt;`)</label>
+        <label><input type="checkbox" data-cb="crit_US_275_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `updatedAt` wird bei jeder Aenderung aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_275_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Titel und Beschreibung sind aenderbar, sectionId kann geaendert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_276" data-story="US-276" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-276</span> <span class="story-title">Fundgegenstand loeschen</span></div>
       </div>
-      <div class="story-als">Als Ersteller eines Fundgegenstands moechte ich den Gegenstand loeschen, damit er aus der Liste entfernt wird (z.B. wenn der Eigentuemer gefunden wurde).</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgrube-Item mit Bildern existiert.</div>
+      <div class="story-als">Als Ersteller eines Fundgegenstands moechte ich den Gegenstand loeschen, damit er aus der Liste entfernt wird (z.B. wenn der Eigentuemer gefunden wurde).</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgrube-Item mit Bildern existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4793,17 +5142,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Versuche als fremder Benutzer zu loeschen</td><td>Fehler: Nur Ersteller oder Admins koennen loeschen</td><td><input type="checkbox" data-cb="step_US_276_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_276_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Nur der Ersteller oder Admins koennen loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_276_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Alle Bilder werden vor dem Item aus MinIO geloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_276_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Kaskadenloesung: Images zuerst, dann Item</label>
+        <label><input type="checkbox" data-cb="crit_US_276_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Nur der Ersteller oder Admins koennen loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_276_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Alle Bilder werden vor dem Item aus MinIO geloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_276_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Kaskadenloesung: Images zuerst, dann Item</label>
       </div>
     </div>
     <div class="story" id="story-US_277" data-story="US-277" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-277</span> <span class="story-title">Bild vom Fundgegenstand loeschen</span></div>
       </div>
-      <div class="story-als">Als Ersteller eines Fundgegenstands moechte ich einzelne Fotos entfernen, damit falsche oder doppelte Bilder geloescht werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgrube-Item mit mehreren Bildern existiert.</div>
+      <div class="story-als">Als Ersteller eines Fundgegenstands moechte ich einzelne Fotos entfernen, damit falsche oder doppelte Bilder geloescht werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgrube-Item mit mehreren Bildern existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4812,18 +5161,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Pruefe den Fundgegenstand</td><td>Item existiert weiterhin</td><td><input type="checkbox" data-cb="step_US_277_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_277_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Nur der Ersteller des Items oder Admins koennen Bilder loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_277_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Original und Thumbnail werden aus MinIO geloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_277_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> DB-Eintrag des Bildes wird entfernt</label>
-        <label><input type="checkbox" data-cb="crit_US_277_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Das Item selbst bleibt erhalten</label>
+        <label><input type="checkbox" data-cb="crit_US_277_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Nur der Ersteller des Items oder Admins koennen Bilder loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_277_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Original und Thumbnail werden aus MinIO geloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_277_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> DB-Eintrag des Bildes wird entfernt</label>
+        <label><input type="checkbox" data-cb="crit_US_277_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Das Item selbst bleibt erhalten</label>
       </div>
     </div>
     <div class="story" id="story-US_278" data-story="US-278" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-278</span> <span class="story-title">Fundgegenstand-Detailansicht</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die Details eines Fundgegenstands mit allen Bildern sehen, damit ich pruefen kann, ob es mein verlorener Gegenstand ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgegenstand mit Bildern existiert.</div>
+      <div class="story-als">Als Benutzer moechte ich die Details eines Fundgegenstands mit allen Bildern sehen, damit ich pruefen kann, ob es mein verlorener Gegenstand ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ein Fundgegenstand mit Bildern existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4833,18 +5182,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Pruefe die `isClaimed()`-Methode</td><td>`true` wenn `claimedBy != null`, sonst `false`</td><td><input type="checkbox" data-cb="step_US_278_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_278_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Alle Item-Details werden angezeigt (inklusive Claim-Status)</label>
-        <label><input type="checkbox" data-cb="crit_US_278_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bilder werden als Thumbnails mit Lightbox-Funktion angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_278_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bild-URLs enthalten JWT-Token als Query-Parameter</label>
-        <label><input type="checkbox" data-cb="crit_US_278_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `isClaimed()` prueft ob `claimedBy != null`</label>
+        <label><input type="checkbox" data-cb="crit_US_278_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Alle Item-Details werden angezeigt (inklusive Claim-Status)</label>
+        <label><input type="checkbox" data-cb="crit_US_278_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bilder werden als Thumbnails mit Lightbox-Funktion angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_278_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bild-URLs enthalten JWT-Token als Query-Parameter</label>
+        <label><input type="checkbox" data-cb="crit_US_278_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `isClaimed()` prueft ob `claimedBy != null`</label>
       </div>
     </div>
     <div class="story" id="story-US_279" data-story="US-279" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-279</span> <span class="story-title">Fundgrube bei deaktiviertem Modul</span></div>
       </div>
-      <div class="story-als">Als System moechte ich sicherstellen, dass die Fundgrube nur verfuegbar ist, wenn das Modul aktiviert ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> `monteweb.modules.fundgrube.enabled = false`.</div>
+      <div class="story-als">Als System moechte ich sicherstellen, dass die Fundgrube nur verfuegbar ist, wenn das Modul aktiviert ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> `monteweb.modules.fundgrube.enabled = false`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4853,17 +5202,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Aktiviere das Modul und starte die Anwendung neu</td><td>Fundgrube ist verfuegbar</td><td><input type="checkbox" data-cb="step_US_279_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_279_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `@ConditionalOnProperty(prefix = &quot;monteweb.modules&quot;, name = &quot;fundgrube.enabled&quot;, havingValue = &quot;true&quot;)` auf allen Beans</label>
-        <label><input type="checkbox" data-cb="crit_US_279_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bei deaktiviertem Modul: kein Controller, kein Service, kein Cleanup-Job registriert</label>
-        <label><input type="checkbox" data-cb="crit_US_279_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Frontend zeigt den Menuepunkt nur bei aktiviertem Modul</label>
+        <label><input type="checkbox" data-cb="crit_US_279_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `@ConditionalOnProperty(prefix = &quot;monteweb.modules&quot;, name = &quot;fundgrube.enabled&quot;, havingValue = &quot;true&quot;)` auf allen Beans</label>
+        <label><input type="checkbox" data-cb="crit_US_279_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Bei deaktiviertem Modul: kein Controller, kein Service, kein Cleanup-Job registriert</label>
+        <label><input type="checkbox" data-cb="crit_US_279_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Frontend zeigt den Menuepunkt nur bei aktiviertem Modul</label>
       </div>
     </div>
     <div class="story" id="story-US_280" data-story="US-280" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-280</span> <span class="story-title">Fundgrube-Item mit abgelaufenem Claim wieder verfuegbar</span></div>
       </div>
-      <div class="story-als">Als System moechte ich beanspruchte Gegenstaende nach Ablauf der 24-Stunden-Frist loeschen, damit die Fundgrube nicht mit ungenutzten Claims blockiert wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Items existieren: eines mit abgelaufenem Claim, eines mit aktivem Claim, eines unbeansprucht.</div>
+      <div class="story-als">Als System moechte ich beanspruchte Gegenstaende nach Ablauf der 24-Stunden-Frist loeschen, damit die Fundgrube nicht mit ungenutzten Claims blockiert wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Items existieren: eines mit abgelaufenem Claim, eines mit aktivem Claim, eines unbeansprucht.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4872,18 +5221,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Pruefe das unbeanspruchte Item</td><td>Bleibt erhalten (kein expiresAt gesetzt)</td><td><input type="checkbox" data-cb="step_US_280_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_280_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `itemRepo.findExpired(now)` findet nur Items mit `expiresAt &lt; now`</label>
-        <label><input type="checkbox" data-cb="crit_US_280_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Items ohne `expiresAt` (unbeansprucht) werden NICHT geloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_280_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Items mit `expiresAt` in der Zukunft werden NICHT geloescht</label>
-        <label><input type="checkbox" data-cb="crit_US_280_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Geloeschte Items: erst MinIO-Dateien loeschen, dann `itemRepo.deleteExpired(now)`</label>
+        <label><input type="checkbox" data-cb="crit_US_280_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> `itemRepo.findExpired(now)` findet nur Items mit `expiresAt &lt; now`</label>
+        <label><input type="checkbox" data-cb="crit_US_280_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Items ohne `expiresAt` (unbeansprucht) werden NICHT geloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_280_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Items mit `expiresAt` in der Zukunft werden NICHT geloescht</label>
+        <label><input type="checkbox" data-cb="crit_US_280_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Geloeschte Items: erst MinIO-Dateien loeschen, dann `itemRepo.deleteExpired(now)`</label>
       </div>
     </div>
     <div class="story" id="story-US_281" data-story="US-281" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-281</span> <span class="story-title">Fundgrube-Suche ueber mehrere Bereiche</span></div>
       </div>
-      <div class="story-als">Als SUPERADMIN (SA) moechte ich alle Fundgegenstaende aller Bereiche sehen, damit ich einen vollstaendigen Ueberblick habe.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Fundgegenstaende in verschiedenen Schulbereichen existieren.</div>
+      <div class="story-als">Als SUPERADMIN (SA) moechte ich alle Fundgegenstaende aller Bereiche sehen, damit ich einen vollstaendigen Ueberblick habe.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Fundgegenstaende in verschiedenen Schulbereichen existieren.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4892,17 +5241,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Pruefe die Sortierung</td><td>Neueste Gegenstaende zuerst</td><td><input type="checkbox" data-cb="step_US_281_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_281_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Ohne Filter: alle Gegenstaende sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_281_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Mit sectionId-Filter: nur Gegenstaende des Bereichs + schulweite Items</label>
-        <label><input type="checkbox" data-cb="crit_US_281_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> SUPERADMIN hat Zugriff auf alle Bereiche</label>
+        <label><input type="checkbox" data-cb="crit_US_281_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Ohne Filter: alle Gegenstaende sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_281_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Mit sectionId-Filter: nur Gegenstaende des Bereichs + schulweite Items</label>
+        <label><input type="checkbox" data-cb="crit_US_281_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> SUPERADMIN hat Zugriff auf alle Bereiche</label>
       </div>
     </div>
     <div class="story" id="story-US_282" data-story="US-282" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-282</span> <span class="story-title">Fundgrube Berechtigungspruefung fuer Loeschen/Bearbeiten</span></div>
       </div>
-      <div class="story-als">Als System moechte ich sicherstellen, dass nur berechtigte Benutzer Items bearbeiten oder loeschen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Fundgegenstaende verschiedener Ersteller existieren.</div>
+      <div class="story-als">Als System moechte ich sicherstellen, dass nur berechtigte Benutzer Items bearbeiten oder loeschen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Fundgegenstaende verschiedener Ersteller existieren.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4914,10 +5263,10 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>SUPERADMIN loescht fremdes Item</td><td>Erfolgreich</td><td><input type="checkbox" data-cb="step_US_282_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_282_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Ersteller hat volle Rechte auf sein eigenes Item (CRUD)</label>
-        <label><input type="checkbox" data-cb="crit_US_282_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Fremde Benutzer gleicher oder niedrigerer Rolle koennen nicht bearbeiten/loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_282_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> SUPERADMIN kann alle Items bearbeiten/loeschen</label>
-        <label><input type="checkbox" data-cb="crit_US_282_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Beanspruchen (Claim) kann jeder eingeloggte Benutzer bei unbeanspruchten Items</label>
+        <label><input type="checkbox" data-cb="crit_US_282_0" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Ersteller hat volle Rechte auf sein eigenes Item (CRUD)</label>
+        <label><input type="checkbox" data-cb="crit_US_282_1" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Fremde Benutzer gleicher oder niedrigerer Rolle koennen nicht bearbeiten/loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_282_2" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> SUPERADMIN kann alle Items bearbeiten/loeschen</label>
+        <label><input type="checkbox" data-cb="crit_US_282_3" data-crit="1" data-module="Fundgrube___Lost___Found" onchange="onCheck()"> Beanspruchen (Claim) kann jeder eingeloggte Benutzer bei unbeanspruchten Items</label>
       </div>
     </div>
   </div>
@@ -4935,8 +5284,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-300</span> <span class="story-title">Wiki-Seite erstellen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich eine Wiki-Seite in meinem Raum erstellen, damit ich Wissen fuer alle Raummitglieder dokumentieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Modul aktiviert (`monteweb.modules.wiki.enabled=true`). Benutzer ist Mitglied eines Raumes.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich eine Wiki-Seite in meinem Raum erstellen, damit ich Wissen fuer alle Raummitglieder dokumentieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Modul aktiviert (`monteweb.modules.wiki.enabled=true`). Benutzer ist Mitglied eines Raumes.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4951,19 +5300,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>9</td><td>Seite wird im Wiki-Baum angezeigt</td><td>Neuer Eintrag &quot;Klassenregeln&quot; im Baum sichtbar</td><td><input type="checkbox" data-cb="step_US_300_9" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_300_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> Wiki-Seite wird mit Titel und Markdown-Inhalt erstellt</label>
-        <label><input type="checkbox" data-cb="crit_US_300_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Slug wird automatisch aus dem Titel generiert</label>
-        <label><input type="checkbox" data-cb="crit_US_300_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Seite erscheint im Seitenbaum des Raumes</label>
-        <label><input type="checkbox" data-cb="crit_US_300_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Erstellungsdatum und Autor werden gespeichert</label>
-        <label><input type="checkbox" data-cb="crit_US_300_4" data-crit="1" data-module="Wiki" onchange="onCheck()"> API-Aufruf: `POST /api/v1/rooms/{roomId}/wiki/pages` liefert 200</label>
+        <label><input type="checkbox" data-cb="crit_US_300_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> Wiki-Seite wird mit Titel und Markdown-Inhalt erstellt</label>
+        <label><input type="checkbox" data-cb="crit_US_300_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Slug wird automatisch aus dem Titel generiert</label>
+        <label><input type="checkbox" data-cb="crit_US_300_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Seite erscheint im Seitenbaum des Raumes</label>
+        <label><input type="checkbox" data-cb="crit_US_300_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Erstellungsdatum und Autor werden gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_300_4" data-crit="1" data-module="Wiki" onchange="onCheck()"> API-Aufruf: `POST /api/v1/rooms/{roomId}/wiki/pages` liefert 200</label>
       </div>
     </div>
     <div class="story" id="story-US_301" data-story="US-301" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-301</span> <span class="story-title">Wiki-Seite per Slug aufrufen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich eine Wiki-Seite ueber ihren Slug aufrufen, damit ich stabile, lesbare URLs fuer Wiki-Seiten habe.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Wiki-Seite im Raum vorhanden.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich eine Wiki-Seite ueber ihren Slug aufrufen, damit ich stabile, lesbare URLs fuer Wiki-Seiten habe.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Wiki-Seite im Raum vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4974,18 +5323,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Autor und Aenderungsdatum werden angezeigt</td><td>Metadaten sichtbar</td><td><input type="checkbox" data-cb="step_US_301_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_301_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> Seite wird ueber `GET /api/v1/rooms/{roomId}/wiki/pages/{slug}` geladen</label>
-        <label><input type="checkbox" data-cb="crit_US_301_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Slug ist eindeutig pro Raum</label>
-        <label><input type="checkbox" data-cb="crit_US_301_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Markdown wird korrekt zu HTML gerendert</label>
-        <label><input type="checkbox" data-cb="crit_US_301_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Seitentitel, Inhalt und Metadaten werden angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_301_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> Seite wird ueber `GET /api/v1/rooms/{roomId}/wiki/pages/{slug}` geladen</label>
+        <label><input type="checkbox" data-cb="crit_US_301_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Slug ist eindeutig pro Raum</label>
+        <label><input type="checkbox" data-cb="crit_US_301_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Markdown wird korrekt zu HTML gerendert</label>
+        <label><input type="checkbox" data-cb="crit_US_301_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Seitentitel, Inhalt und Metadaten werden angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_302" data-story="US-302" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-302</span> <span class="story-title">Wiki-Seite bearbeiten</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich eine bestehende Wiki-Seite bearbeiten, damit ich Inhalte aktualisieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Seite &quot;Klassenregeln&quot; existiert im Raum.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich eine bestehende Wiki-Seite bearbeiten, damit ich Inhalte aktualisieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Seite &quot;Klassenregeln&quot; existiert im Raum.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -4997,18 +5346,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Geaenderten Inhalt pruefen</td><td>Regel 3 ist sichtbar, Aenderungsdatum aktualisiert</td><td><input type="checkbox" data-cb="step_US_302_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_302_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `PUT /api/v1/rooms/{roomId}/wiki/pages/{pageId}` aktualisiert die Seite</label>
-        <label><input type="checkbox" data-cb="crit_US_302_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Eine neue Version wird bei jeder Bearbeitung angelegt</label>
-        <label><input type="checkbox" data-cb="crit_US_302_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Aenderungsdatum und bearbeitender Benutzer werden aktualisiert</label>
-        <label><input type="checkbox" data-cb="crit_US_302_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Slug kann optional geaendert werden</label>
+        <label><input type="checkbox" data-cb="crit_US_302_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `PUT /api/v1/rooms/{roomId}/wiki/pages/{pageId}` aktualisiert die Seite</label>
+        <label><input type="checkbox" data-cb="crit_US_302_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Eine neue Version wird bei jeder Bearbeitung angelegt</label>
+        <label><input type="checkbox" data-cb="crit_US_302_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Aenderungsdatum und bearbeitender Benutzer werden aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_302_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Slug kann optional geaendert werden</label>
       </div>
     </div>
     <div class="story" id="story-US_303" data-story="US-303" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-303</span> <span class="story-title">Wiki-Seite loeschen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich eine Wiki-Seite loeschen, damit veraltete Inhalte entfernt werden koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Seite existiert im Raum.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich eine Wiki-Seite loeschen, damit veraltete Inhalte entfernt werden koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Seite existiert im Raum.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5019,18 +5368,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Wiki-Baum pruefen</td><td>Geloeschte Seite ist nicht mehr im Baum sichtbar</td><td><input type="checkbox" data-cb="step_US_303_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_303_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `DELETE /api/v1/rooms/{roomId}/wiki/pages/{pageId}` loescht die Seite</label>
-        <label><input type="checkbox" data-cb="crit_US_303_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Kindseiten werden korrekt behandelt (verwaist oder mitgeloescht)</label>
-        <label><input type="checkbox" data-cb="crit_US_303_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Bestaetigung-Dialog wird vor Loeschung angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_303_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Seite verschwindet aus dem Wiki-Baum</label>
+        <label><input type="checkbox" data-cb="crit_US_303_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `DELETE /api/v1/rooms/{roomId}/wiki/pages/{pageId}` loescht die Seite</label>
+        <label><input type="checkbox" data-cb="crit_US_303_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Kindseiten werden korrekt behandelt (verwaist oder mitgeloescht)</label>
+        <label><input type="checkbox" data-cb="crit_US_303_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Bestaetigung-Dialog wird vor Loeschung angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_303_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Seite verschwindet aus dem Wiki-Baum</label>
       </div>
     </div>
     <div class="story" id="story-US_304" data-story="US-304" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-304</span> <span class="story-title">Wiki-Versionshistorie anzeigen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich die Versionshistorie einer Wiki-Seite einsehen, damit ich Aenderungen nachvollziehen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Seite wurde mindestens zweimal bearbeitet (mind. 2 Versionen).</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich die Versionshistorie einer Wiki-Seite einsehen, damit ich Aenderungen nachvollziehen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Seite wurde mindestens zweimal bearbeitet (mind. 2 Versionen).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5041,18 +5390,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Versionsnummer, Autor und Datum pruefen</td><td>Metadaten jeder Version sind sichtbar</td><td><input type="checkbox" data-cb="step_US_304_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_304_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `GET /api/v1/rooms/{roomId}/wiki/pages/{pageId}/versions` liefert Versionsliste</label>
-        <label><input type="checkbox" data-cb="crit_US_304_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> `GET /api/v1/rooms/{roomId}/wiki/versions/{versionId}` liefert einzelne Version</label>
-        <label><input type="checkbox" data-cb="crit_US_304_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Jede Version enthaelt: Inhalt, Autor, Zeitstempel</label>
-        <label><input type="checkbox" data-cb="crit_US_304_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Versionen sind chronologisch sortiert (neueste zuerst)</label>
+        <label><input type="checkbox" data-cb="crit_US_304_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `GET /api/v1/rooms/{roomId}/wiki/pages/{pageId}/versions` liefert Versionsliste</label>
+        <label><input type="checkbox" data-cb="crit_US_304_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> `GET /api/v1/rooms/{roomId}/wiki/versions/{versionId}` liefert einzelne Version</label>
+        <label><input type="checkbox" data-cb="crit_US_304_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Jede Version enthaelt: Inhalt, Autor, Zeitstempel</label>
+        <label><input type="checkbox" data-cb="crit_US_304_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Versionen sind chronologisch sortiert (neueste zuerst)</label>
       </div>
     </div>
     <div class="story" id="story-US_305" data-story="US-305" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-305</span> <span class="story-title">Wiki-Seitenhierarchie (Parent-Child)</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich Wiki-Seiten hierarchisch organisieren (Eltern-Kind-Beziehung), damit zusammengehoerende Inhalte strukturiert dargestellt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Wiki-Seite existiert im Raum.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich Wiki-Seiten hierarchisch organisieren (Eltern-Kind-Beziehung), damit zusammengehoerende Inhalte strukturiert dargestellt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Wiki-Seite existiert im Raum.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5064,18 +5413,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Kindseite oeffnen</td><td>Breadcrumb oder Parent-Link zeigt Elternseite an</td><td><input type="checkbox" data-cb="step_US_305_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_305_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `parent_id` (self-referencing FK) verknuepft Kind- mit Elternseite</label>
-        <label><input type="checkbox" data-cb="crit_US_305_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Wiki-Baum (`GET /api/v1/rooms/{roomId}/wiki`) zeigt hierarchische Struktur</label>
-        <label><input type="checkbox" data-cb="crit_US_305_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Kindseiten werden unter der Elternseite eingerueckt angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_305_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Tiefe Verschachtelung ist moeglich (mind. 3 Ebenen)</label>
+        <label><input type="checkbox" data-cb="crit_US_305_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `parent_id` (self-referencing FK) verknuepft Kind- mit Elternseite</label>
+        <label><input type="checkbox" data-cb="crit_US_305_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Wiki-Baum (`GET /api/v1/rooms/{roomId}/wiki`) zeigt hierarchische Struktur</label>
+        <label><input type="checkbox" data-cb="crit_US_305_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Kindseiten werden unter der Elternseite eingerueckt angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_305_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Tiefe Verschachtelung ist moeglich (mind. 3 Ebenen)</label>
       </div>
     </div>
     <div class="story" id="story-US_306" data-story="US-306" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-306</span> <span class="story-title">Wiki-Suche innerhalb eines Raumes</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich Wiki-Seiten innerhalb meines Raumes durchsuchen, damit ich schnell relevante Inhalte finde.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Wiki-Seiten mit unterschiedlichem Inhalt im Raum vorhanden.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich Wiki-Seiten innerhalb meines Raumes durchsuchen, damit ich schnell relevante Inhalte finde.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Wiki-Seiten mit unterschiedlichem Inhalt im Raum vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5086,10 +5435,10 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Suchergebnis anklicken</td><td>Entsprechende Wiki-Seite wird geoeffnet</td><td><input type="checkbox" data-cb="step_US_306_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_306_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `GET /api/v1/rooms/{roomId}/wiki/search?q={suchbegriff}` liefert Treffer</label>
-        <label><input type="checkbox" data-cb="crit_US_306_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Suche durchsucht Titel und Inhalt der Wiki-Seiten</label>
-        <label><input type="checkbox" data-cb="crit_US_306_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Ergebnisse werden als Liste mit Seitentitel angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_306_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Nur Seiten des aktuellen Raumes werden durchsucht</label>
+        <label><input type="checkbox" data-cb="crit_US_306_0" data-crit="1" data-module="Wiki" onchange="onCheck()"> `GET /api/v1/rooms/{roomId}/wiki/search?q={suchbegriff}` liefert Treffer</label>
+        <label><input type="checkbox" data-cb="crit_US_306_1" data-crit="1" data-module="Wiki" onchange="onCheck()"> Suche durchsucht Titel und Inhalt der Wiki-Seiten</label>
+        <label><input type="checkbox" data-cb="crit_US_306_2" data-crit="1" data-module="Wiki" onchange="onCheck()"> Ergebnisse werden als Liste mit Seitentitel angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_306_3" data-crit="1" data-module="Wiki" onchange="onCheck()"> Nur Seiten des aktuellen Raumes werden durchsucht</label>
       </div>
     </div>
   </div>
@@ -5107,8 +5456,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-307</span> <span class="story-title">Kanban-Board im Raum anzeigen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich das Kanban-Board meines Raumes sehen, damit ich einen Ueberblick ueber alle Aufgaben habe.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Tasks-Modul aktiviert (`monteweb.modules.tasks.enabled=true`). Benutzer ist Mitglied eines Raumes.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich das Kanban-Board meines Raumes sehen, damit ich einen Ueberblick ueber alle Aufgaben habe.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Tasks-Modul aktiviert (`monteweb.modules.tasks.enabled=true`). Benutzer ist Mitglied eines Raumes.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5118,18 +5467,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Board-Struktur pruefen</td><td>Standard-Spalten sind sichtbar (z.B. &quot;Offen&quot;, &quot;In Arbeit&quot;, &quot;Erledigt&quot;)</td><td><input type="checkbox" data-cb="step_US_307_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_307_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> `GET /api/v1/rooms/{roomId}/tasks` liefert das Board mit Spalten und Tasks</label>
-        <label><input type="checkbox" data-cb="crit_US_307_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Board ist eindeutig pro Raum (unique constraint)</label>
-        <label><input type="checkbox" data-cb="crit_US_307_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalten werden in korrekter Reihenfolge (`position`) angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_307_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Leere Spalten werden mit Platzhaltertext angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_307_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> `GET /api/v1/rooms/{roomId}/tasks` liefert das Board mit Spalten und Tasks</label>
+        <label><input type="checkbox" data-cb="crit_US_307_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Board ist eindeutig pro Raum (unique constraint)</label>
+        <label><input type="checkbox" data-cb="crit_US_307_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalten werden in korrekter Reihenfolge (`position`) angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_307_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Leere Spalten werden mit Platzhaltertext angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_308" data-story="US-308" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-308</span> <span class="story-title">Spalte im Kanban-Board erstellen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich neue Spalten im Kanban-Board erstellen, damit ich den Workflow an unsere Beduerfnisse anpassen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Kanban-Board fuer den Raum existiert.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich neue Spalten im Kanban-Board erstellen, damit ich den Workflow an unsere Beduerfnisse anpassen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Kanban-Board fuer den Raum existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5141,18 +5490,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Position der neuen Spalte pruefen</td><td>Spalte ist an der richtigen Position (rechts von bestehenden Spalten)</td><td><input type="checkbox" data-cb="step_US_308_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_308_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> `POST /api/v1/rooms/{roomId}/tasks/columns` erstellt eine neue Spalte</label>
-        <label><input type="checkbox" data-cb="crit_US_308_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalte erhaelt eine Position (`position`-Feld fuer Sortierung)</label>
-        <label><input type="checkbox" data-cb="crit_US_308_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalte wird sofort im Board angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_308_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spaltenname ist Pflichtfeld</label>
+        <label><input type="checkbox" data-cb="crit_US_308_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> `POST /api/v1/rooms/{roomId}/tasks/columns` erstellt eine neue Spalte</label>
+        <label><input type="checkbox" data-cb="crit_US_308_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalte erhaelt eine Position (`position`-Feld fuer Sortierung)</label>
+        <label><input type="checkbox" data-cb="crit_US_308_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalte wird sofort im Board angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_308_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spaltenname ist Pflichtfeld</label>
       </div>
     </div>
     <div class="story" id="story-US_309" data-story="US-309" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-309</span> <span class="story-title">Spalte im Kanban-Board umbenennen und loeschen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich Spalten umbenennen oder loeschen, damit ich das Board aktuell halten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Kanban-Board mit mindestens 2 Spalten vorhanden.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich Spalten umbenennen oder loeschen, damit ich das Board aktuell halten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Kanban-Board mit mindestens 2 Spalten vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5165,18 +5514,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Loeschung bestaetigen</td><td>Spalte wird entfernt (`DELETE /api/v1/rooms/{roomId}/tasks/columns/{columnId}`)</td><td><input type="checkbox" data-cb="step_US_309_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_309_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalten koennen umbenannt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_309_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Leere Spalten koennen geloescht werden</label>
-        <label><input type="checkbox" data-cb="crit_US_309_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalten mit Tasks: Warnung oder Verschiebung der Tasks vor Loeschung</label>
-        <label><input type="checkbox" data-cb="crit_US_309_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Bestaetigung-Dialog bei Loeschung</label>
+        <label><input type="checkbox" data-cb="crit_US_309_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalten koennen umbenannt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_309_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Leere Spalten koennen geloescht werden</label>
+        <label><input type="checkbox" data-cb="crit_US_309_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Spalten mit Tasks: Warnung oder Verschiebung der Tasks vor Loeschung</label>
+        <label><input type="checkbox" data-cb="crit_US_309_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Bestaetigung-Dialog bei Loeschung</label>
       </div>
     </div>
     <div class="story" id="story-US_310" data-story="US-310" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-310</span> <span class="story-title">Task erstellen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich eine neue Aufgabe (Task) im Kanban-Board erstellen, damit Arbeit verfolgt werden kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Kanban-Board mit Spalten vorhanden.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich eine neue Aufgabe (Task) im Kanban-Board erstellen, damit Arbeit verfolgt werden kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Kanban-Board mit Spalten vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5188,18 +5537,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>&quot;Erstellen&quot; klicken</td><td>Task erscheint in der Spalte &quot;Offen&quot;</td><td><input type="checkbox" data-cb="step_US_310_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_310_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> `POST /api/v1/rooms/{roomId}/tasks` erstellt einen neuen Task</label>
-        <label><input type="checkbox" data-cb="crit_US_310_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Task wird in der angegebenen Spalte angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_310_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Titel ist Pflichtfeld, Beschreibung optional</label>
-        <label><input type="checkbox" data-cb="crit_US_310_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Ersteller und Erstellungsdatum werden gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_310_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> `POST /api/v1/rooms/{roomId}/tasks` erstellt einen neuen Task</label>
+        <label><input type="checkbox" data-cb="crit_US_310_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Task wird in der angegebenen Spalte angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_310_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Titel ist Pflichtfeld, Beschreibung optional</label>
+        <label><input type="checkbox" data-cb="crit_US_310_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Ersteller und Erstellungsdatum werden gespeichert</label>
       </div>
     </div>
     <div class="story" id="story-US_311" data-story="US-311" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-311</span> <span class="story-title">Task verschieben (Drag &amp; Drop)</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich Tasks per Drag &amp; Drop zwischen Spalten verschieben, damit ich den Fortschritt visuell aktualisieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Task in der Spalte &quot;Offen&quot; vorhanden.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich Tasks per Drag &amp; Drop zwischen Spalten verschieben, damit ich den Fortschritt visuell aktualisieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Task in der Spalte &quot;Offen&quot; vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5210,19 +5559,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Seite neu laden</td><td>Task ist weiterhin in &quot;In Arbeit&quot; (Persistenz pruefen)</td><td><input type="checkbox" data-cb="step_US_311_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_311_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> `PUT /api/v1/rooms/{roomId}/tasks/{taskId}/move` verschiebt den Task</label>
-        <label><input type="checkbox" data-cb="crit_US_311_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Request enthaelt `columnId` und `position`</label>
-        <label><input type="checkbox" data-cb="crit_US_311_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Drag &amp; Drop funktioniert zwischen allen Spalten</label>
-        <label><input type="checkbox" data-cb="crit_US_311_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Position innerhalb einer Spalte wird respektiert</label>
-        <label><input type="checkbox" data-cb="crit_US_311_4" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Aenderung wird sofort persistiert</label>
+        <label><input type="checkbox" data-cb="crit_US_311_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> `PUT /api/v1/rooms/{roomId}/tasks/{taskId}/move` verschiebt den Task</label>
+        <label><input type="checkbox" data-cb="crit_US_311_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Request enthaelt `columnId` und `position`</label>
+        <label><input type="checkbox" data-cb="crit_US_311_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Drag &amp; Drop funktioniert zwischen allen Spalten</label>
+        <label><input type="checkbox" data-cb="crit_US_311_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Position innerhalb einer Spalte wird respektiert</label>
+        <label><input type="checkbox" data-cb="crit_US_311_4" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Aenderung wird sofort persistiert</label>
       </div>
     </div>
     <div class="story" id="story-US_312" data-story="US-312" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-312</span> <span class="story-title">Task bearbeiten und loeschen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich Tasks bearbeiten oder loeschen, damit ich Aufgaben aktuell halten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Task im Board vorhanden.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich Tasks bearbeiten oder loeschen, damit ich Aufgaben aktuell halten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Task im Board vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5235,17 +5584,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Loeschung bestaetigen</td><td>Task wird entfernt (`DELETE /api/v1/rooms/{roomId}/tasks/{taskId}`)</td><td><input type="checkbox" data-cb="step_US_312_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_312_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Titel und Beschreibung koennen bearbeitet werden</label>
-        <label><input type="checkbox" data-cb="crit_US_312_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Tasks koennen geloescht werden mit Bestaetigung</label>
-        <label><input type="checkbox" data-cb="crit_US_312_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Geloeschte Tasks verschwinden aus dem Board</label>
+        <label><input type="checkbox" data-cb="crit_US_312_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Titel und Beschreibung koennen bearbeitet werden</label>
+        <label><input type="checkbox" data-cb="crit_US_312_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Tasks koennen geloescht werden mit Bestaetigung</label>
+        <label><input type="checkbox" data-cb="crit_US_312_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Geloeschte Tasks verschwinden aus dem Board</label>
       </div>
     </div>
     <div class="story" id="story-US_313" data-story="US-313" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-313</span> <span class="story-title">Checkliste / Sub-Tasks hinzufuegen</span></div>
       </div>
-      <div class="story-als">Als Raum-Mitglied moechte ich einem Task Checklisten-Eintraege hinzufuegen, damit ich Teilaufgaben verfolgen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Task im Board vorhanden.</div>
+      <div class="story-als">Als Raum-Mitglied moechte ich einem Task Checklisten-Eintraege hinzufuegen, damit ich Teilaufgaben verfolgen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Task im Board vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5259,11 +5608,11 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Fortschrittsanzeige pruefen</td><td>&quot;1/2 erledigt&quot; oder aehnlich wird angezeigt</td><td><input type="checkbox" data-cb="step_US_313_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_313_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Checklisten-Eintraege koennen hinzugefuegt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_313_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Eintraege koennen als erledigt/offen umgeschaltet werden (Toggle)</label>
-        <label><input type="checkbox" data-cb="crit_US_313_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Eintraege koennen geloescht werden (`DELETE .../checklist/{itemId}`)</label>
-        <label><input type="checkbox" data-cb="crit_US_313_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Fortschritt (erledigt/gesamt) wird angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_313_4" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Daten in `task_checklist_items`-Tabelle gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_313_0" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Checklisten-Eintraege koennen hinzugefuegt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_313_1" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Eintraege koennen als erledigt/offen umgeschaltet werden (Toggle)</label>
+        <label><input type="checkbox" data-cb="crit_US_313_2" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Eintraege koennen geloescht werden (`DELETE .../checklist/{itemId}`)</label>
+        <label><input type="checkbox" data-cb="crit_US_313_3" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Fortschritt (erledigt/gesamt) wird angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_313_4" data-crit="1" data-module="Tasks___Kanban" onchange="onCheck()"> Daten in `task_checklist_items`-Tabelle gespeichert</label>
       </div>
     </div>
   </div>
@@ -5281,8 +5630,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-314</span> <span class="story-title">Feed-Post bookmarken</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich einen Feed-Post als Lesezeichen speichern, damit ich ihn spaeter schnell wiederfinde.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Bookmarks-Modul aktiviert (`monteweb.modules.bookmarks.enabled=true`). Mindestens ein Feed-Post vorhanden.</div>
+      <div class="story-als">Als Benutzer moechte ich einen Feed-Post als Lesezeichen speichern, damit ich ihn spaeter schnell wiederfinde.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Bookmarks-Modul aktiviert (`monteweb.modules.bookmarks.enabled=true`). Mindestens ein Feed-Post vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5293,18 +5642,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Erneut auf Lesezeichen-Icon klicken</td><td>Bookmark wird entfernt (Toggle), Icon wechselt zurueck</td><td><input type="checkbox" data-cb="step_US_314_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_314_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark wird per Toggle-Mechanismus gesetzt/entfernt</label>
-        <label><input type="checkbox" data-cb="crit_US_314_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Visuelles Feedback (Icon-Wechsel) bei Bookmark-Aktion</label>
-        <label><input type="checkbox" data-cb="crit_US_314_2" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> `contentType` = &quot;POST&quot;, `contentId` = UUID des Posts</label>
-        <label><input type="checkbox" data-cb="crit_US_314_3" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark wird in `bookmarks`-Tabelle gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_314_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark wird per Toggle-Mechanismus gesetzt/entfernt</label>
+        <label><input type="checkbox" data-cb="crit_US_314_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Visuelles Feedback (Icon-Wechsel) bei Bookmark-Aktion</label>
+        <label><input type="checkbox" data-cb="crit_US_314_2" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> `contentType` = &quot;POST&quot;, `contentId` = UUID des Posts</label>
+        <label><input type="checkbox" data-cb="crit_US_314_3" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark wird in `bookmarks`-Tabelle gespeichert</label>
       </div>
     </div>
     <div class="story" id="story-US_315" data-story="US-315" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-315</span> <span class="story-title">Kalender-Event bookmarken</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich ein Kalender-Event als Lesezeichen speichern, damit ich wichtige Termine schnell wiederfinde.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Kalender-Event vorhanden.</div>
+      <div class="story-als">Als Benutzer moechte ich ein Kalender-Event als Lesezeichen speichern, damit ich wichtige Termine schnell wiederfinde.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Kalender-Event vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5314,17 +5663,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Bookmark-Status pruefen: `GET /api/v1/bookmarks/check?contentType=EVENT&amp;contentId={id}`</td><td>`bookmarked: true`</td><td><input type="checkbox" data-cb="step_US_315_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_315_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Events koennen gebookmarkt werden (`contentType: &quot;EVENT&quot;`)</label>
-        <label><input type="checkbox" data-cb="crit_US_315_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark-Status wird korrekt angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_315_2" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Toggle funktioniert auch bei Events</label>
+        <label><input type="checkbox" data-cb="crit_US_315_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Events koennen gebookmarkt werden (`contentType: &quot;EVENT&quot;`)</label>
+        <label><input type="checkbox" data-cb="crit_US_315_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark-Status wird korrekt angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_315_2" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Toggle funktioniert auch bei Events</label>
       </div>
     </div>
     <div class="story" id="story-US_316" data-story="US-316" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-316</span> <span class="story-title">Job bookmarken</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich einen Job aus der Jobboerse als Lesezeichen speichern, damit ich interessante Angebote im Blick behalte.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Jobboard-Modul aktiviert. Mindestens ein Job vorhanden.</div>
+      <div class="story-als">Als Benutzer moechte ich einen Job aus der Jobboerse als Lesezeichen speichern, damit ich interessante Angebote im Blick behalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Jobboard-Modul aktiviert. Mindestens ein Job vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5334,34 +5683,34 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Bookmark pruefen</td><td>`bookmarked: true` fuer `contentType: &quot;JOB&quot;`</td><td><input type="checkbox" data-cb="step_US_316_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_316_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Jobs koennen gebookmarkt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_316_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark-Status wird beim Laden der Jobliste mitgeladen</label>
+        <label><input type="checkbox" data-cb="crit_US_316_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Jobs koennen gebookmarkt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_316_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark-Status wird beim Laden der Jobliste mitgeladen</label>
       </div>
     </div>
     <div class="story" id="story-US_317" data-story="US-317" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-317</span> <span class="story-title">Wiki-Seite bookmarken</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich eine Wiki-Seite als Lesezeichen speichern, damit ich wichtige Dokumentationen schnell aufrufen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Modul aktiviert. Mindestens eine Wiki-Seite vorhanden.</div>
+      <div class="story-als">Als Benutzer moechte ich eine Wiki-Seite als Lesezeichen speichern, damit ich wichtige Dokumentationen schnell aufrufen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Wiki-Modul aktiviert. Mindestens eine Wiki-Seite vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Als `lehrer@monteweb.local` (T) einloggen</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_317_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Wiki-Seite in einem Raum oeffnen</td><td>Seiteninhalt wird angezeigt</td><td><input type="checkbox" data-cb="step_US_317_2" onchange="onCheck()"></td></tr>
-          <tr><td>3</td><td>Lesezeichen-Icon klicken</td><td>Bookmark wird gesetzt (`contentType: &quot;WIKI&quot;`)</td><td><input type="checkbox" data-cb="step_US_317_3" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Lesezeichen-Icon klicken</td><td>Bookmark wird gesetzt (`contentType: &quot;WIKI_PAGE&quot;`)</td><td><input type="checkbox" data-cb="step_US_317_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_317_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Wiki-Seiten koennen gebookmarkt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_317_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark-Status wird auf der Wiki-Seite angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_317_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Wiki-Seiten koennen gebookmarkt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_317_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Bookmark-Status wird auf der Wiki-Seite angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_318" data-story="US-318" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-318</span> <span class="story-title">Bookmarks-Uebersicht anzeigen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich alle meine Lesezeichen auf einer Uebersichtsseite sehen, damit ich schnell auf gespeicherte Inhalte zugreifen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat mindestens 3 Bookmarks verschiedener Typen gesetzt.</div>
+      <div class="story-als">Als Benutzer moechte ich alle meine Lesezeichen auf einer Uebersichtsseite sehen, damit ich schnell auf gespeicherte Inhalte zugreifen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat mindestens 3 Bookmarks verschiedener Typen gesetzt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5373,19 +5722,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Pagination pruefen (bei &gt;20 Bookmarks)</td><td>Seitennavigation funktioniert</td><td><input type="checkbox" data-cb="step_US_318_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_318_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> `GET /api/v1/bookmarks?type={type}&amp;page={page}&amp;size={size}` liefert paginierte Liste</label>
-        <label><input type="checkbox" data-cb="crit_US_318_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Filter nach Typ funktioniert (POST, EVENT, JOB, WIKI oder alle)</label>
-        <label><input type="checkbox" data-cb="crit_US_318_2" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Jeder Bookmark zeigt Titel und Typ an</label>
-        <label><input type="checkbox" data-cb="crit_US_318_3" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Klick auf Bookmark navigiert zum Originalinhalt</label>
-        <label><input type="checkbox" data-cb="crit_US_318_4" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> `GET /api/v1/bookmarks/ids?contentType={type}` liefert alle bookmarkten IDs fuer Batch-Pruefung</label>
+        <label><input type="checkbox" data-cb="crit_US_318_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> `GET /api/v1/bookmarks?type={type}&amp;page={page}&amp;size={size}` liefert paginierte Liste</label>
+        <label><input type="checkbox" data-cb="crit_US_318_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Filter nach Typ funktioniert (POST, EVENT, JOB, WIKI oder alle)</label>
+        <label><input type="checkbox" data-cb="crit_US_318_2" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Jeder Bookmark zeigt Titel und Typ an</label>
+        <label><input type="checkbox" data-cb="crit_US_318_3" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Klick auf Bookmark navigiert zum Originalinhalt</label>
+        <label><input type="checkbox" data-cb="crit_US_318_4" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> `GET /api/v1/bookmarks/ids?contentType={type}` liefert alle bookmarkten IDs fuer Batch-Pruefung</label>
       </div>
     </div>
     <div class="story" id="story-US_319" data-story="US-319" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-319</span> <span class="story-title">Bookmark entfernen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich ein Lesezeichen entfernen, damit meine Bookmarks-Liste aktuell bleibt.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Bookmark vorhanden.</div>
+      <div class="story-als">Als Benutzer moechte ich ein Lesezeichen entfernen, damit meine Bookmarks-Liste aktuell bleibt.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens ein Bookmark vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5396,9 +5745,9 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Alternativ: Am Originalinhalt (Post/Event/Job/Wiki) den Bookmark-Icon klicken</td><td>Bookmark wird ebenfalls entfernt (gleicher Toggle)</td><td><input type="checkbox" data-cb="step_US_319_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_319_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Toggle-Mechanismus entfernt Bookmark beim zweiten Klick</label>
-        <label><input type="checkbox" data-cb="crit_US_319_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Entfernte Bookmarks verschwinden aus der Uebersicht</label>
-        <label><input type="checkbox" data-cb="crit_US_319_2" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Keine Bestaetigung noetig (sofortige Aktion)</label>
+        <label><input type="checkbox" data-cb="crit_US_319_0" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Toggle-Mechanismus entfernt Bookmark beim zweiten Klick</label>
+        <label><input type="checkbox" data-cb="crit_US_319_1" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Entfernte Bookmarks verschwinden aus der Uebersicht</label>
+        <label><input type="checkbox" data-cb="crit_US_319_2" data-crit="1" data-module="Lesezeichen___Bookmarks" onchange="onCheck()"> Keine Bestaetigung noetig (sofortige Aktion)</label>
       </div>
     </div>
   </div>
@@ -5416,8 +5765,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-320</span> <span class="story-title">Globale Suche oeffnen (Ctrl+K)</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die globale Suche mit Ctrl+K (bzw. Cmd+K auf Mac) oeffnen, damit ich schnell nach Inhalten suchen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als Benutzer moechte ich die globale Suche mit Ctrl+K (bzw. Cmd+K auf Mac) oeffnen, damit ich schnell nach Inhalten suchen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5428,19 +5777,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Esc druecken</td><td>Such-Dialog schliesst sich</td><td><input type="checkbox" data-cb="step_US_320_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_320_0" data-crit="1" data-module="Suche" onchange="onCheck()"> Tastenkombination Ctrl+K / Cmd+K oeffnet den Such-Dialog</label>
-        <label><input type="checkbox" data-cb="crit_US_320_1" data-crit="1" data-module="Suche" onchange="onCheck()"> Dialog ist modal mit 600px Breite</label>
-        <label><input type="checkbox" data-cb="crit_US_320_2" data-crit="1" data-module="Suche" onchange="onCheck()"> Suchfeld hat Autofokus</label>
-        <label><input type="checkbox" data-cb="crit_US_320_3" data-crit="1" data-module="Suche" onchange="onCheck()"> 8 Filter-Typen: ALL, USER, ROOM, POST, EVENT, FILE, WIKI, TASK</label>
-        <label><input type="checkbox" data-cb="crit_US_320_4" data-crit="1" data-module="Suche" onchange="onCheck()"> Esc schliesst den Dialog</label>
+        <label><input type="checkbox" data-cb="crit_US_320_0" data-crit="1" data-module="Suche" onchange="onCheck()"> Tastenkombination Ctrl+K / Cmd+K oeffnet den Such-Dialog</label>
+        <label><input type="checkbox" data-cb="crit_US_320_1" data-crit="1" data-module="Suche" onchange="onCheck()"> Dialog ist modal mit 600px Breite</label>
+        <label><input type="checkbox" data-cb="crit_US_320_2" data-crit="1" data-module="Suche" onchange="onCheck()"> Suchfeld hat Autofokus</label>
+        <label><input type="checkbox" data-cb="crit_US_320_3" data-crit="1" data-module="Suche" onchange="onCheck()"> 8 Filter-Typen: ALL, USER, ROOM, POST, EVENT, FILE, WIKI, TASK</label>
+        <label><input type="checkbox" data-cb="crit_US_320_4" data-crit="1" data-module="Suche" onchange="onCheck()"> Esc schliesst den Dialog</label>
       </div>
     </div>
     <div class="story" id="story-US_321" data-story="US-321" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-321</span> <span class="story-title">Volltextsuche ausfuehren</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich einen Suchbegriff eingeben und Ergebnisse sehen, damit ich Inhalte im System finde.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Diverse Inhalte vorhanden (Posts, Events, Raeume, Benutzer, Wiki-Seiten, Tasks, Dateien).</div>
+      <div class="story-als">Als Benutzer moechte ich einen Suchbegriff eingeben und Ergebnisse sehen, damit ich Inhalte im System finde.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Diverse Inhalte vorhanden (Posts, Events, Raeume, Benutzer, Wiki-Seiten, Tasks, Dateien).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5453,20 +5802,20 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Enter druecken auf selektiertem Ergebnis</td><td>Navigation zum Ergebnis, Dialog schliesst sich</td><td><input type="checkbox" data-cb="step_US_321_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_321_0" data-crit="1" data-module="Suche" onchange="onCheck()"> `GET /api/v1/search?q={suchbegriff}&amp;type={typ}&amp;limit=20` liefert Ergebnisse</label>
-        <label><input type="checkbox" data-cb="crit_US_321_1" data-crit="1" data-module="Suche" onchange="onCheck()"> Mindestens 2 Zeichen erforderlich fuer Suche</label>
-        <label><input type="checkbox" data-cb="crit_US_321_2" data-crit="1" data-module="Suche" onchange="onCheck()"> 300ms Debounce verzoegerung</label>
-        <label><input type="checkbox" data-cb="crit_US_321_3" data-crit="1" data-module="Suche" onchange="onCheck()"> Ergebnisse gruppiert nach Typ mit Icons</label>
-        <label><input type="checkbox" data-cb="crit_US_321_4" data-crit="1" data-module="Suche" onchange="onCheck()"> Tastaturnavigation: Pfeiltasten + Enter</label>
-        <label><input type="checkbox" data-cb="crit_US_321_5" data-crit="1" data-module="Suche" onchange="onCheck()"> Limit: max 50 Ergebnisse (serverseitig begrenzt)</label>
+        <label><input type="checkbox" data-cb="crit_US_321_0" data-crit="1" data-module="Suche" onchange="onCheck()"> `GET /api/v1/search?q={suchbegriff}&amp;type={typ}&amp;limit=20` liefert Ergebnisse</label>
+        <label><input type="checkbox" data-cb="crit_US_321_1" data-crit="1" data-module="Suche" onchange="onCheck()"> Mindestens 2 Zeichen erforderlich fuer Suche</label>
+        <label><input type="checkbox" data-cb="crit_US_321_2" data-crit="1" data-module="Suche" onchange="onCheck()"> 300ms Debounce verzoegerung</label>
+        <label><input type="checkbox" data-cb="crit_US_321_3" data-crit="1" data-module="Suche" onchange="onCheck()"> Ergebnisse gruppiert nach Typ mit Icons</label>
+        <label><input type="checkbox" data-cb="crit_US_321_4" data-crit="1" data-module="Suche" onchange="onCheck()"> Tastaturnavigation: Pfeiltasten + Enter</label>
+        <label><input type="checkbox" data-cb="crit_US_321_5" data-crit="1" data-module="Suche" onchange="onCheck()"> Limit: max 50 Ergebnisse (serverseitig begrenzt)</label>
       </div>
     </div>
     <div class="story" id="story-US_322" data-story="US-322" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-322</span> <span class="story-title">Suche nach Typ filtern</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die Suche nach bestimmten Dokumenttypen filtern, damit ich gezielter suchen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Such-Dialog ist geoeffnet.</div>
+      <div class="story-als">Als Benutzer moechte ich die Suche nach bestimmten Dokumenttypen filtern, damit ich gezielter suchen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Such-Dialog ist geoeffnet.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5477,18 +5826,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>&quot;Alle&quot;-Filter waehlen</td><td>Ergebnisse aller Typen werden angezeigt</td><td><input type="checkbox" data-cb="step_US_322_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_322_0" data-crit="1" data-module="Suche" onchange="onCheck()"> Filter-Chips fuer alle 8 Typen: ALL, USER, ROOM, POST, EVENT, FILE, WIKI, TASK</label>
-        <label><input type="checkbox" data-cb="crit_US_322_1" data-crit="1" data-module="Suche" onchange="onCheck()"> Aktiver Filter wird visuell hervorgehoben</label>
-        <label><input type="checkbox" data-cb="crit_US_322_2" data-crit="1" data-module="Suche" onchange="onCheck()"> Filterwechsel loest sofortige Neusuche aus</label>
-        <label><input type="checkbox" data-cb="crit_US_322_3" data-crit="1" data-module="Suche" onchange="onCheck()"> Typ wird als Query-Parameter `type` an API uebergeben</label>
+        <label><input type="checkbox" data-cb="crit_US_322_0" data-crit="1" data-module="Suche" onchange="onCheck()"> Filter-Chips fuer alle 8 Typen: ALL, USER, ROOM, POST, EVENT, FILE, WIKI, TASK</label>
+        <label><input type="checkbox" data-cb="crit_US_322_1" data-crit="1" data-module="Suche" onchange="onCheck()"> Aktiver Filter wird visuell hervorgehoben</label>
+        <label><input type="checkbox" data-cb="crit_US_322_2" data-crit="1" data-module="Suche" onchange="onCheck()"> Filterwechsel loest sofortige Neusuche aus</label>
+        <label><input type="checkbox" data-cb="crit_US_322_3" data-crit="1" data-module="Suche" onchange="onCheck()"> Typ wird als Query-Parameter `type` an API uebergeben</label>
       </div>
     </div>
     <div class="story" id="story-US_323" data-story="US-323" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-323</span> <span class="story-title">Solr-Volltextsuche (wenn aktiviert)</span></div>
       </div>
-      <div class="story-als">Als Administrator moechte ich dass die Suche Apache Solr nutzt (wenn aktiviert), damit eine leistungsstarke Volltextsuche mit deutscher Sprachanalyse verfuegbar ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Solr-Modul aktiviert (`monteweb.modules.solr.enabled=true`), Solr-Container laeuft.</div>
+      <div class="story-als">Als Administrator moechte ich dass die Suche Apache Solr nutzt (wenn aktiviert), damit eine leistungsstarke Volltextsuche mit deutscher Sprachanalyse verfuegbar ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Solr-Modul aktiviert (`monteweb.modules.solr.enabled=true`), Solr-Container laeuft.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5499,20 +5848,20 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Nach Dateiinhalt suchen (z.B. PDF-Inhalt)</td><td>Tika-Extraktion findet Text innerhalb von Dokumenten</td><td><input type="checkbox" data-cb="step_US_323_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_323_0" data-crit="1" data-module="Suche" onchange="onCheck()"> Solr 9.8 mit deutscher Sprachanalyse (Stemming, Stopwords)</label>
-        <label><input type="checkbox" data-cb="crit_US_323_1" data-crit="1" data-module="Suche" onchange="onCheck()"> 7 Dokumenttypen werden indexiert: USER, ROOM, POST, EVENT, FILE, WIKI, TASK</label>
-        <label><input type="checkbox" data-cb="crit_US_323_2" data-crit="1" data-module="Suche" onchange="onCheck()"> Echtzeit-Indexierung via Spring Events bei Erstellung/Aenderung</label>
-        <label><input type="checkbox" data-cb="crit_US_323_3" data-crit="1" data-module="Suche" onchange="onCheck()"> Tika-Extraktion fuer Dateiinhalte (PDF, DOCX etc.)</label>
-        <label><input type="checkbox" data-cb="crit_US_323_4" data-crit="1" data-module="Suche" onchange="onCheck()"> Admin-Reindex ueber API moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_323_5" data-crit="1" data-module="Suche" onchange="onCheck()"> Fallback auf DB-Suche wenn Solr deaktiviert/nicht erreichbar</label>
+        <label><input type="checkbox" data-cb="crit_US_323_0" data-crit="1" data-module="Suche" onchange="onCheck()"> Solr 9.8 mit deutscher Sprachanalyse (Stemming, Stopwords)</label>
+        <label><input type="checkbox" data-cb="crit_US_323_1" data-crit="1" data-module="Suche" onchange="onCheck()"> 7 Dokumenttypen werden indexiert: USER, ROOM, POST, EVENT, FILE, WIKI, TASK</label>
+        <label><input type="checkbox" data-cb="crit_US_323_2" data-crit="1" data-module="Suche" onchange="onCheck()"> Echtzeit-Indexierung via Spring Events bei Erstellung/Aenderung</label>
+        <label><input type="checkbox" data-cb="crit_US_323_3" data-crit="1" data-module="Suche" onchange="onCheck()"> Tika-Extraktion fuer Dateiinhalte (PDF, DOCX etc.)</label>
+        <label><input type="checkbox" data-cb="crit_US_323_4" data-crit="1" data-module="Suche" onchange="onCheck()"> Admin-Reindex ueber API moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_323_5" data-crit="1" data-module="Suche" onchange="onCheck()"> Fallback auf DB-Suche wenn Solr deaktiviert/nicht erreichbar</label>
       </div>
     </div>
     <div class="story" id="story-US_324" data-story="US-324" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-324</span> <span class="story-title">DB-Fallback bei deaktiviertem Solr</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich auch ohne Solr suchen koennen, damit die Suche immer funktioniert.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Solr-Modul deaktiviert.</div>
+      <div class="story-als">Als Benutzer moechte ich auch ohne Solr suchen koennen, damit die Suche immer funktioniert.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Solr-Modul deaktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5522,9 +5871,9 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Filter nach Typ funktioniert</td><td>Filterung funktioniert auch mit DB-Fallback</td><td><input type="checkbox" data-cb="step_US_324_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_324_0" data-crit="1" data-module="Suche" onchange="onCheck()"> Suche funktioniert ohne Solr (DB-Fallback)</label>
-        <label><input type="checkbox" data-cb="crit_US_324_1" data-crit="1" data-module="Suche" onchange="onCheck()"> Ergebnisformat ist identisch (gleiche SearchResult-Struktur)</label>
-        <label><input type="checkbox" data-cb="crit_US_324_2" data-crit="1" data-module="Suche" onchange="onCheck()"> Keine Fehlermeldung bei deaktiviertem Solr</label>
+        <label><input type="checkbox" data-cb="crit_US_324_0" data-crit="1" data-module="Suche" onchange="onCheck()"> Suche funktioniert ohne Solr (DB-Fallback)</label>
+        <label><input type="checkbox" data-cb="crit_US_324_1" data-crit="1" data-module="Suche" onchange="onCheck()"> Ergebnisformat ist identisch (gleiche SearchResult-Struktur)</label>
+        <label><input type="checkbox" data-cb="crit_US_324_2" data-crit="1" data-module="Suche" onchange="onCheck()"> Keine Fehlermeldung bei deaktiviertem Solr</label>
       </div>
     </div>
   </div>
@@ -5542,8 +5891,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-325</span> <span class="story-title">In-App-Benachrichtigungsliste anzeigen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich meine Benachrichtigungen in einer Liste sehen, damit ich ueber relevante Aktivitaeten informiert bin.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat Benachrichtigungen erhalten (z.B. durch Posts, Kommentare, Nachrichten).</div>
+      <div class="story-als">Als Benutzer moechte ich meine Benachrichtigungen in einer Liste sehen, damit ich ueber relevante Aktivitaeten informiert bin.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat Benachrichtigungen erhalten (z.B. durch Posts, Kommentare, Nachrichten).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5554,18 +5903,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Auf eine Benachrichtigung klicken</td><td>Navigation zum verlinkten Inhalt (z.B. Post, Raum)</td><td><input type="checkbox" data-cb="step_US_325_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_325_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `GET /api/v1/notifications` liefert paginierte Benachrichtigungsliste</label>
-        <label><input type="checkbox" data-cb="crit_US_325_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Jede Benachrichtigung hat: id, type, title, message, link, read, createdAt</label>
-        <label><input type="checkbox" data-cb="crit_US_325_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Ungelesene werden visuell hervorgehoben</label>
-        <label><input type="checkbox" data-cb="crit_US_325_3" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Klick auf Link navigiert zum Kontext</label>
+        <label><input type="checkbox" data-cb="crit_US_325_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `GET /api/v1/notifications` liefert paginierte Benachrichtigungsliste</label>
+        <label><input type="checkbox" data-cb="crit_US_325_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Jede Benachrichtigung hat: id, type, title, message, link, read, createdAt</label>
+        <label><input type="checkbox" data-cb="crit_US_325_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Ungelesene werden visuell hervorgehoben</label>
+        <label><input type="checkbox" data-cb="crit_US_325_3" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Klick auf Link navigiert zum Kontext</label>
       </div>
     </div>
     <div class="story" id="story-US_326" data-story="US-326" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-326</span> <span class="story-title">Unread-Count Badge anzeigen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die Anzahl ungelesener Benachrichtigungen als Badge sehen, damit ich sofort erkenne, ob neue Nachrichten vorliegen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine ungelesene Benachrichtigung vorhanden.</div>
+      <div class="story-als">Als Benutzer moechte ich die Anzahl ungelesener Benachrichtigungen als Badge sehen, damit ich sofort erkenne, ob neue Nachrichten vorliegen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine ungelesene Benachrichtigung vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5575,18 +5924,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Neue Benachrichtigung erhalten (z.B. neuer Post)</td><td>Badge erscheint wieder mit aktueller Zahl</td><td><input type="checkbox" data-cb="step_US_326_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_326_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `GET /api/v1/notifications/unread-count` liefert Anzahl</label>
-        <label><input type="checkbox" data-cb="crit_US_326_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Badge wird nur angezeigt wenn Count &gt; 0</label>
-        <label><input type="checkbox" data-cb="crit_US_326_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Badge wird in Echtzeit aktualisiert (Polling oder WebSocket)</label>
-        <label><input type="checkbox" data-cb="crit_US_326_3" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> NotificationBell-Komponente zeigt Badge korrekt an</label>
+        <label><input type="checkbox" data-cb="crit_US_326_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `GET /api/v1/notifications/unread-count` liefert Anzahl</label>
+        <label><input type="checkbox" data-cb="crit_US_326_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Badge wird nur angezeigt wenn Count &gt; 0</label>
+        <label><input type="checkbox" data-cb="crit_US_326_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Badge wird in Echtzeit aktualisiert (Polling oder WebSocket)</label>
+        <label><input type="checkbox" data-cb="crit_US_326_3" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> NotificationBell-Komponente zeigt Badge korrekt an</label>
       </div>
     </div>
     <div class="story" id="story-US_327" data-story="US-327" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-327</span> <span class="story-title">Benachrichtigung als gelesen markieren</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich einzelne Benachrichtigungen als gelesen markieren, damit ich den Ueberblick behalte.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Ungelesene Benachrichtigungen vorhanden.</div>
+      <div class="story-als">Als Benutzer moechte ich einzelne Benachrichtigungen als gelesen markieren, damit ich den Ueberblick behalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Ungelesene Benachrichtigungen vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5597,17 +5946,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Unread-Count Badge aktualisiert sich</td><td>Badge-Zahl sinkt um 1</td><td><input type="checkbox" data-cb="step_US_327_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_327_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `PUT /api/v1/notifications/{id}/read` markiert einzelne als gelesen</label>
-        <label><input type="checkbox" data-cb="crit_US_327_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Visuelles Feedback sofort sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_327_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Unread-Count wird aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_327_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `PUT /api/v1/notifications/{id}/read` markiert einzelne als gelesen</label>
+        <label><input type="checkbox" data-cb="crit_US_327_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Visuelles Feedback sofort sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_327_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Unread-Count wird aktualisiert</label>
       </div>
     </div>
     <div class="story" id="story-US_328" data-story="US-328" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-328</span> <span class="story-title">Alle Benachrichtigungen als gelesen markieren</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich alle Benachrichtigungen auf einmal als gelesen markieren, damit ich schnell aufraeumen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere ungelesene Benachrichtigungen vorhanden.</div>
+      <div class="story-als">Als Benutzer moechte ich alle Benachrichtigungen auf einmal als gelesen markieren, damit ich schnell aufraeumen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere ungelesene Benachrichtigungen vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5618,17 +5967,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Badge pruefen</td><td>Unread-Count ist 0, Badge verschwindet</td><td><input type="checkbox" data-cb="step_US_328_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_328_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `PUT /api/v1/notifications/read-all` markiert alle als gelesen</label>
-        <label><input type="checkbox" data-cb="crit_US_328_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Alle Eintraege visuell aktualisiert</label>
-        <label><input type="checkbox" data-cb="crit_US_328_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Badge-Count auf 0</label>
+        <label><input type="checkbox" data-cb="crit_US_328_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `PUT /api/v1/notifications/read-all` markiert alle als gelesen</label>
+        <label><input type="checkbox" data-cb="crit_US_328_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Alle Eintraege visuell aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_328_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Badge-Count auf 0</label>
       </div>
     </div>
     <div class="story" id="story-US_329" data-story="US-329" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-329</span> <span class="story-title">Benachrichtigung loeschen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich einzelne Benachrichtigungen loeschen, damit meine Liste uebersichtlich bleibt.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Benachrichtigung vorhanden.</div>
+      <div class="story-als">Als Benutzer moechte ich einzelne Benachrichtigungen loeschen, damit meine Liste uebersichtlich bleibt.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mindestens eine Benachrichtigung vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5638,17 +5987,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Geloeschte Benachrichtigung ist nicht mehr in der Liste</td><td>Liste aktualisiert sich</td><td><input type="checkbox" data-cb="step_US_329_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_329_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `DELETE /api/v1/notifications/{id}` loescht die Benachrichtigung</label>
-        <label><input type="checkbox" data-cb="crit_US_329_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Sofortige Entfernung aus der Liste</label>
-        <label><input type="checkbox" data-cb="crit_US_329_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Unread-Count wird ggf. aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_329_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `DELETE /api/v1/notifications/{id}` loescht die Benachrichtigung</label>
+        <label><input type="checkbox" data-cb="crit_US_329_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Sofortige Entfernung aus der Liste</label>
+        <label><input type="checkbox" data-cb="crit_US_329_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Unread-Count wird ggf. aktualisiert</label>
       </div>
     </div>
     <div class="story" id="story-US_330" data-story="US-330" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-330</span> <span class="story-title">Benachrichtigungstypen pruefen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich verschiedene Typen von Benachrichtigungen erhalten, damit ich ueber alle relevanten Ereignisse informiert werde.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Verschiedene Aktionen im System ausgefuehrt.</div>
+      <div class="story-als">Als Benutzer moechte ich verschiedene Typen von Benachrichtigungen erhalten, damit ich ueber alle relevanten Ereignisse informiert werde.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Verschiedene Aktionen im System ausgefuehrt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5657,25 +6006,25 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Direktnachricht erhalten → MESSAGE-Benachrichtigung</td><td>Typ: `MESSAGE`</td><td><input type="checkbox" data-cb="step_US_330_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Event erstellt → EVENT_CREATED-Benachrichtigung</td><td>Typ: `EVENT_CREATED`</td><td><input type="checkbox" data-cb="step_US_330_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Event abgesagt → EVENT_CANCELLED-Benachrichtigung</td><td>Typ: `EVENT_CANCELLED`</td><td><input type="checkbox" data-cb="step_US_330_5" onchange="onCheck()"></td></tr>
-          <tr><td>6</td><td>Formular veroeffentlicht → FORM_PUBLISHED-Benachrichtigung</td><td>Typ: `FORM_PUBLISHED`</td><td><input type="checkbox" data-cb="step_US_330_6" onchange="onCheck()"></td></tr>
+          <tr><td>6</td><td>Raum-Umfrage veroeffentlicht → FORM_PUBLISHED-Benachrichtigung</td><td>Typ: `FORM_PUBLISHED` (nur bei ROOM-Scope-Umfragen; Consent-Formulare loesen `CONSENT_REQUIRED` aus, Bereichs-/Schul-Scopes erzeugen keine Benachrichtigung)</td><td><input type="checkbox" data-cb="step_US_330_6" onchange="onCheck()"></td></tr>
           <tr><td>7</td><td>Raum-Beitrittsanfrage → ROOM_JOIN_REQUEST-Benachrichtigung (an Leader)</td><td>Typ: `ROOM_JOIN_REQUEST`</td><td><input type="checkbox" data-cb="step_US_330_7" onchange="onCheck()"></td></tr>
           <tr><td>8</td><td>Beitrittsanfrage genehmigt → ROOM_JOIN_APPROVED (an Antragsteller)</td><td>Typ: `ROOM_JOIN_APPROVED`</td><td><input type="checkbox" data-cb="step_US_330_8" onchange="onCheck()"></td></tr>
           <tr><td>9</td><td>Familieneinladung → FAMILY_INVITATION</td><td>Typ: `FAMILY_INVITATION`</td><td><input type="checkbox" data-cb="step_US_330_9" onchange="onCheck()"></td></tr>
           <tr><td>10</td><td>@Erwaehnung in Post/Kommentar → MENTION</td><td>Typ: `MENTION`</td><td><input type="checkbox" data-cb="step_US_330_10" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_330_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Mindestens 22 Benachrichtigungstypen unterstuetzt (siehe NotificationType)</label>
-        <label><input type="checkbox" data-cb="crit_US_330_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Jeder Typ hat passendes Icon und Beschreibung</label>
-        <label><input type="checkbox" data-cb="crit_US_330_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Link fuehrt zum relevanten Kontext</label>
-        <label><input type="checkbox" data-cb="crit_US_330_3" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `referenceType` und `referenceId` ermoeglichen Zuordnung</label>
+        <label><input type="checkbox" data-cb="crit_US_330_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Mindestens 22 Benachrichtigungstypen unterstuetzt (siehe NotificationType)</label>
+        <label><input type="checkbox" data-cb="crit_US_330_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Jeder Typ hat passendes Icon und Beschreibung</label>
+        <label><input type="checkbox" data-cb="crit_US_330_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Link fuehrt zum relevanten Kontext</label>
+        <label><input type="checkbox" data-cb="crit_US_330_3" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `referenceType` und `referenceId` ermoeglichen Zuordnung</label>
       </div>
     </div>
     <div class="story" id="story-US_331" data-story="US-331" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-331</span> <span class="story-title">Push-Benachrichtigungen (wenn aktiviert)</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich Push-Benachrichtigungen auf meinem Geraet erhalten, damit ich auch bei geschlossenem Browser informiert werde.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Push-Modul aktiviert (`monteweb.push.enabled=true`). Browser unterstuetzt Web Push (VAPID).</div>
+      <div class="story-als">Als Benutzer moechte ich Push-Benachrichtigungen auf meinem Geraet erhalten, damit ich auch bei geschlossenem Browser informiert werde.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Push-Modul aktiviert (`monteweb.push.enabled=true`). Browser unterstuetzt Web Push (VAPID).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5687,11 +6036,11 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Push-Benachrichtigungen deaktivieren</td><td>Subscription wird entfernt (`POST /api/v1/notifications/push/unsubscribe`)</td><td><input type="checkbox" data-cb="step_US_331_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_331_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> VAPID-basierte Web Push Notifications</label>
-        <label><input type="checkbox" data-cb="crit_US_331_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Benutzer kann Push ein-/ausschalten</label>
-        <label><input type="checkbox" data-cb="crit_US_331_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Push wird nur bei aktiviertem Modul angeboten</label>
-        <label><input type="checkbox" data-cb="crit_US_331_3" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `usePushNotifications` Composable verwaltet Subscription</label>
-        <label><input type="checkbox" data-cb="crit_US_331_4" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Deregistrierung funktioniert zuverlaessig</label>
+        <label><input type="checkbox" data-cb="crit_US_331_0" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> VAPID-basierte Web Push Notifications</label>
+        <label><input type="checkbox" data-cb="crit_US_331_1" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Benutzer kann Push ein-/ausschalten</label>
+        <label><input type="checkbox" data-cb="crit_US_331_2" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Push wird nur bei aktiviertem Modul angeboten</label>
+        <label><input type="checkbox" data-cb="crit_US_331_3" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> `usePushNotifications` Composable verwaltet Subscription</label>
+        <label><input type="checkbox" data-cb="crit_US_331_4" data-crit="1" data-module="Benachrichtigungen" onchange="onCheck()"> Deregistrierung funktioniert zuverlaessig</label>
       </div>
     </div>
   </div>
@@ -5700,7 +6049,7 @@ td:last-child { width: 40px; text-align: center; }
   <div class="module-header" onclick="toggleModule('Familie')">
     <h2><span class="chevron">&#9654;</span> Familie <span class="badge">7 Stories</span></h2>
     <div>
-      <span class="progress-info" id="prog-Familie">0/28</span>
+      <span class="progress-info" id="prog-Familie">0/29</span>
       <div class="progress-bar" style="width:120px"><div class="progress-fill" id="bar-Familie" style="width:0%"></div></div>
     </div>
   </div>
@@ -5709,8 +6058,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-332</span> <span class="story-title">Familienverbund erstellen</span></div>
       </div>
-      <div class="story-als">Als Elternteil moechte ich einen Familienverbund erstellen, damit meine Familie als Einheit im System abgebildet wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat die Rolle PARENT.</div>
+      <div class="story-als">Als Elternteil moechte ich einen Familienverbund erstellen, damit meine Familie als Einheit im System abgebildet wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat die Rolle PARENT.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5722,18 +6071,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Familie erscheint in &quot;Meine Familien&quot;</td><td>Familie mit Name und Ersteller sichtbar</td><td><input type="checkbox" data-cb="step_US_332_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_332_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Familie wird erstellt mit Name</label>
-        <label><input type="checkbox" data-cb="crit_US_332_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Ersteller wird automatisch als PARENT-Mitglied hinzugefuegt</label>
-        <label><input type="checkbox" data-cb="crit_US_332_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Familienverbund ist Abrechnungseinheit fuer Elternstunden</label>
-        <label><input type="checkbox" data-cb="crit_US_332_3" data-crit="1" data-module="Familie" onchange="onCheck()"> `GET /api/v1/families/mine` zeigt eigene Familien</label>
+        <label><input type="checkbox" data-cb="crit_US_332_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Familie wird erstellt mit Name</label>
+        <label><input type="checkbox" data-cb="crit_US_332_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Ersteller wird automatisch als PARENT-Mitglied hinzugefuegt</label>
+        <label><input type="checkbox" data-cb="crit_US_332_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Familienverbund ist Abrechnungseinheit fuer Elternstunden</label>
+        <label><input type="checkbox" data-cb="crit_US_332_3" data-crit="1" data-module="Familie" onchange="onCheck()"> `GET /api/v1/families/mine` zeigt eigene Familien</label>
       </div>
     </div>
     <div class="story" id="story-US_333" data-story="US-333" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-333</span> <span class="story-title">Familienmitglied per User-Suche einladen</span></div>
       </div>
-      <div class="story-als">Als Elternteil moechte ich andere Benutzer per Suche in meine Familie einladen, damit Familienmitglieder verknuepft werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Familienverbund existiert. Zu einladender Benutzer ist registriert.</div>
+      <div class="story-als">Als Elternteil moechte ich andere Benutzer per Suche in meine Familie einladen, damit Familienmitglieder verknuepft werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Familienverbund existiert. Zu einladender Benutzer ist registriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5743,46 +6092,46 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Namen des zu einladenden Benutzers suchen</td><td>Suchergebnisse werden angezeigt</td><td><input type="checkbox" data-cb="step_US_333_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Benutzer auswaehlen</td><td>Benutzer wird selektiert</td><td><input type="checkbox" data-cb="step_US_333_5" onchange="onCheck()"></td></tr>
           <tr><td>6</td><td>Rolle waehlen: PARENT oder CHILD</td><td>Rollen-Auswahl erscheint</td><td><input type="checkbox" data-cb="step_US_333_6" onchange="onCheck()"></td></tr>
-          <tr><td>7</td><td>Einladung senden (`POST /api/v1/families/{id}/invite`)</td><td>Einladung wird gesendet</td><td><input type="checkbox" data-cb="step_US_333_7" onchange="onCheck()"></td></tr>
+          <tr><td>7</td><td>Einladung senden (`POST /api/v1/families/{id}/invitations`)</td><td>Einladung wird gesendet</td><td><input type="checkbox" data-cb="step_US_333_7" onchange="onCheck()"></td></tr>
           <tr><td>8</td><td>Eingeladener Benutzer erhaelt Benachrichtigung</td><td>FAMILY_INVITATION-Notification erscheint</td><td><input type="checkbox" data-cb="step_US_333_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_333_0" data-crit="1" data-module="Familie" onchange="onCheck()"> User-Suche findet registrierte Benutzer</label>
-        <label><input type="checkbox" data-cb="crit_US_333_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Rollenwahl: PARENT oder CHILD</label>
-        <label><input type="checkbox" data-cb="crit_US_333_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Einladung erzeugt Benachrichtigung beim Eingeladenen</label>
-        <label><input type="checkbox" data-cb="crit_US_333_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Ein Elternteil kann nur einem Familienverbund angehoeren</label>
-        <label><input type="checkbox" data-cb="crit_US_333_4" data-crit="1" data-module="Familie" onchange="onCheck()"> Kind kann mehreren Familien zugeordnet sein (getrennte Eltern)</label>
+        <label><input type="checkbox" data-cb="crit_US_333_0" data-crit="1" data-module="Familie" onchange="onCheck()"> User-Suche findet registrierte Benutzer</label>
+        <label><input type="checkbox" data-cb="crit_US_333_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Rollenwahl: PARENT oder CHILD</label>
+        <label><input type="checkbox" data-cb="crit_US_333_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Einladung erzeugt Benachrichtigung beim Eingeladenen</label>
+        <label><input type="checkbox" data-cb="crit_US_333_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Ein Elternteil kann nur einem Familienverbund angehoeren</label>
+        <label><input type="checkbox" data-cb="crit_US_333_4" data-crit="1" data-module="Familie" onchange="onCheck()"> Kind kann mehreren Familien zugeordnet sein (getrennte Eltern)</label>
       </div>
     </div>
     <div class="story" id="story-US_334" data-story="US-334" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-334</span> <span class="story-title">Einladung annehmen / ablehnen</span></div>
       </div>
-      <div class="story-als">Als eingeladener Benutzer moechte ich eine Familieneinladung annehmen oder ablehnen, damit ich selbst entscheiden kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat eine offene Familieneinladung.</div>
+      <div class="story-als">Als eingeladener Benutzer moechte ich eine Familieneinladung annehmen oder ablehnen, damit ich selbst entscheiden kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat eine offene Familieneinladung.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Als eingeladener Benutzer einloggen</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_334_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Benachrichtigungsliste oeffnen</td><td>FAMILY_INVITATION-Benachrichtigung sichtbar</td><td><input type="checkbox" data-cb="step_US_334_2" onchange="onCheck()"></td></tr>
-          <tr><td>3</td><td>Einladungen pruefen: `GET /api/v1/families/invitations/mine`</td><td>Offene Einladungen werden angezeigt</td><td><input type="checkbox" data-cb="step_US_334_3" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Einladungen pruefen: `GET /api/v1/families/my-invitations`</td><td>Offene Einladungen werden angezeigt</td><td><input type="checkbox" data-cb="step_US_334_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Einladung annehmen: `POST /api/v1/families/invitations/{id}/accept`</td><td>Benutzer wird Familienmitglied</td><td><input type="checkbox" data-cb="step_US_334_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Familie in &quot;Meine Familien&quot; pruefen</td><td>Familie ist jetzt sichtbar</td><td><input type="checkbox" data-cb="step_US_334_5" onchange="onCheck()"></td></tr>
           <tr><td>6</td><td>Alternative: Einladung ablehnen: `POST /api/v1/families/invitations/{id}/decline`</td><td>Einladung wird entfernt</td><td><input type="checkbox" data-cb="step_US_334_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_334_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Annehmen fuegt Benutzer zur Familie hinzu (mit gewaehlter Rolle)</label>
-        <label><input type="checkbox" data-cb="crit_US_334_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Ablehnen entfernt die Einladung ohne Beitritt</label>
-        <label><input type="checkbox" data-cb="crit_US_334_2" data-crit="1" data-module="Familie" onchange="onCheck()"> FAMILY_INVITATION_ACCEPTED-Benachrichtigung an Einladenden bei Annahme</label>
-        <label><input type="checkbox" data-cb="crit_US_334_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Einladung verschwindet nach Aktion</label>
+        <label><input type="checkbox" data-cb="crit_US_334_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Annehmen fuegt Benutzer zur Familie hinzu (mit gewaehlter Rolle)</label>
+        <label><input type="checkbox" data-cb="crit_US_334_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Ablehnen entfernt die Einladung ohne Beitritt</label>
+        <label><input type="checkbox" data-cb="crit_US_334_2" data-crit="1" data-module="Familie" onchange="onCheck()"> FAMILY_INVITATION_ACCEPTED-Benachrichtigung an Einladenden bei Annahme</label>
+        <label><input type="checkbox" data-cb="crit_US_334_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Einladung verschwindet nach Aktion</label>
       </div>
     </div>
     <div class="story" id="story-US_335" data-story="US-335" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-335</span> <span class="story-title">Familien-Uebersicht und Kinder zuordnen</span></div>
       </div>
-      <div class="story-als">Als Elternteil moechte ich die Mitglieder meiner Familie sehen und Kinder zuordnen, damit die Familienstruktur korrekt abgebildet ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Familienverbund mit mindestens einem Elternteil existiert.</div>
+      <div class="story-als">Als Elternteil moechte ich die Mitglieder meiner Familie sehen und Kinder zuordnen, damit die Familienstruktur korrekt abgebildet ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Familienverbund mit mindestens einem Elternteil existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5793,39 +6142,40 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Mitglied entfernen: `DELETE /api/v1/families/{id}/members/{userId}`</td><td>Mitglied wird aus Familie entfernt</td><td><input type="checkbox" data-cb="step_US_335_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_335_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Mitgliederliste zeigt alle Familienmitglieder mit Rolle</label>
-        <label><input type="checkbox" data-cb="crit_US_335_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Kinder koennen zugeordnet werden</label>
-        <label><input type="checkbox" data-cb="crit_US_335_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Mitglieder koennen entfernt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_335_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Kind kann in mehreren Familien sein</label>
+        <label><input type="checkbox" data-cb="crit_US_335_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Mitgliederliste zeigt alle Familienmitglieder mit Rolle</label>
+        <label><input type="checkbox" data-cb="crit_US_335_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Kinder koennen zugeordnet werden</label>
+        <label><input type="checkbox" data-cb="crit_US_335_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Mitglieder koennen entfernt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_335_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Kind kann in mehreren Familien sein</label>
       </div>
     </div>
     <div class="story" id="story-US_336" data-story="US-336" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-336</span> <span class="story-title">Stundenkonto einsehen</span></div>
       </div>
-      <div class="story-als">Als Elternteil moechte ich das Stundenkonto meiner Familie einsehen, damit ich den Stand der Elternstunden kenne.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Familie hat Stunden aus Jobboerse/Putz-Orga angesammelt.</div>
+      <div class="story-als">Als Elternteil moechte ich das Stundenkonto meiner Familie einsehen, damit ich den Stand der Elternstunden kenne.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Familie hat Stunden aus Jobboerse/Putz-Orga angesammelt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Als `eltern@monteweb.local` (P) einloggen</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_336_1" onchange="onCheck()"></td></tr>
-          <tr><td>2</td><td>Familien-Seite oeffnen</td><td>Stundenkonto wird angezeigt</td><td><input type="checkbox" data-cb="step_US_336_2" onchange="onCheck()"></td></tr>
-          <tr><td>3</td><td>Gesamtstunden pruefen</td><td>Summe aus Job-Stunden und Putz-Stunden sichtbar</td><td><input type="checkbox" data-cb="step_US_336_3" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Familien-Seite oeffnen</td><td>Stundenkonto-Widget (FamilyHoursWidget) wird angezeigt, sofern das Jobboard-Modul aktiv ist</td><td><input type="checkbox" data-cb="step_US_336_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Gesamtstunden pruefen</td><td>Summe aus Job-Stunden und Putz-Stunden sichtbar (Daten aus `GET /api/v1/jobs/family/{familyId}/hours`)</td><td><input type="checkbox" data-cb="step_US_336_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Putz-Stunden werden als Sonder-Unterkonto angezeigt</td><td>Separate Anzeige der Putzstunden</td><td><input type="checkbox" data-cb="step_US_336_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_336_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Stundenkonto zeigt Gesamtstunden der Familie</label>
-        <label><input type="checkbox" data-cb="crit_US_336_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Putzstunden werden separat ausgewiesen (Sonder-Unterkonto)</label>
-        <label><input type="checkbox" data-cb="crit_US_336_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Stunden stammen aus Jobboerse und Putz-Orga</label>
-        <label><input type="checkbox" data-cb="crit_US_336_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Familienverbund ist die Abrechnungseinheit</label>
+        <label><input type="checkbox" data-cb="crit_US_336_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Stundenkonto zeigt Gesamtstunden der Familie</label>
+        <label><input type="checkbox" data-cb="crit_US_336_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Putzstunden werden separat ausgewiesen (Sonder-Unterkonto)</label>
+        <label><input type="checkbox" data-cb="crit_US_336_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Die Stundendaten stammen aus dem Jobboard-Modul (`FamilyHoursInfo`), nicht aus dem Familien-Modul (`FamilyInfo` enthaelt keine Stundenfelder)</label>
+        <label><input type="checkbox" data-cb="crit_US_336_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Das Widget wird nur angezeigt, wenn das Jobboard-Modul aktiviert ist</label>
+        <label><input type="checkbox" data-cb="crit_US_336_4" data-crit="1" data-module="Familie" onchange="onCheck()"> Familienverbund ist die Abrechnungseinheit</label>
       </div>
     </div>
     <div class="story" id="story-US_337" data-story="US-337" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-337</span> <span class="story-title">Familie deaktivieren und Stunden-Befreiung</span></div>
       </div>
-      <div class="story-als">Als Administrator moechte ich eine Familie deaktivieren oder von Elternstunden befreien, damit Sonderfaelle abgedeckt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Familienverbund existiert. Admin-Zugang.</div>
+      <div class="story-als">Als Administrator moechte ich eine Familie deaktivieren oder von Elternstunden befreien, damit Sonderfaelle abgedeckt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Familienverbund existiert. Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5838,18 +6188,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Familie erscheint als deaktiviert</td><td>Visuell als inaktiv markiert</td><td><input type="checkbox" data-cb="step_US_337_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_337_0" data-crit="1" data-module="Familie" onchange="onCheck()"> `families.is_hours_exempt` befreit Familie von Elternstunden</label>
-        <label><input type="checkbox" data-cb="crit_US_337_1" data-crit="1" data-module="Familie" onchange="onCheck()"> `families.is_active` deaktiviert den Familienverbund</label>
-        <label><input type="checkbox" data-cb="crit_US_337_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Nur SUPERADMIN kann diese Aktionen durchfuehren</label>
-        <label><input type="checkbox" data-cb="crit_US_337_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Deaktivierte Familien werden im Stundenbericht nicht beruecksichtigt</label>
+        <label><input type="checkbox" data-cb="crit_US_337_0" data-crit="1" data-module="Familie" onchange="onCheck()"> `families.is_hours_exempt` befreit Familie von Elternstunden</label>
+        <label><input type="checkbox" data-cb="crit_US_337_1" data-crit="1" data-module="Familie" onchange="onCheck()"> `families.is_active` deaktiviert den Familienverbund</label>
+        <label><input type="checkbox" data-cb="crit_US_337_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Nur SUPERADMIN kann diese Aktionen durchfuehren</label>
+        <label><input type="checkbox" data-cb="crit_US_337_3" data-crit="1" data-module="Familie" onchange="onCheck()"> Deaktivierte Familien werden im Stundenbericht nicht beruecksichtigt</label>
       </div>
     </div>
     <div class="story" id="story-US_338" data-story="US-338" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-338</span> <span class="story-title">Familie verlassen</span></div>
       </div>
-      <div class="story-als">Als Familienmitglied moechte ich eine Familie verlassen koennen, damit ich nicht mehr mit diesem Verbund verknuepft bin.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied einer Familie.</div>
+      <div class="story-als">Als Familienmitglied moechte ich eine Familie verlassen koennen, damit ich nicht mehr mit diesem Verbund verknuepft bin.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist Mitglied einer Familie.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5860,9 +6210,9 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Familie erscheint nicht mehr in &quot;Meine Familien&quot;</td><td>Liste aktualisiert</td><td><input type="checkbox" data-cb="step_US_338_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_338_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Mitglied kann Familie verlassen</label>
-        <label><input type="checkbox" data-cb="crit_US_338_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Bestaetigung erforderlich</label>
-        <label><input type="checkbox" data-cb="crit_US_338_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Letzte PARENT kann Familie nicht verlassen (oder Familie wird geloescht)</label>
+        <label><input type="checkbox" data-cb="crit_US_338_0" data-crit="1" data-module="Familie" onchange="onCheck()"> Mitglied kann Familie verlassen</label>
+        <label><input type="checkbox" data-cb="crit_US_338_1" data-crit="1" data-module="Familie" onchange="onCheck()"> Bestaetigung erforderlich</label>
+        <label><input type="checkbox" data-cb="crit_US_338_2" data-crit="1" data-module="Familie" onchange="onCheck()"> Letzte PARENT kann Familie nicht verlassen (oder Familie wird geloescht)</label>
       </div>
     </div>
   </div>
@@ -5880,8 +6230,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-339</span> <span class="story-title">Benutzer auflisten und filtern</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich alle Benutzer auflisten und filtern, damit ich die Benutzerverwaltung effizient durchfuehren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Benutzer im System (~220 Seed-User).</div>
+      <div class="story-als">Als Superadmin moechte ich alle Benutzer auflisten und filtern, damit ich die Benutzerverwaltung effizient durchfuehren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Benutzer im System (~220 Seed-User).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5893,19 +6243,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Pagination: Naechste Seite</td><td>Weitere Benutzer werden geladen</td><td><input type="checkbox" data-cb="step_US_339_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_339_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> `GET /api/v1/admin/users?role={role}&amp;active={bool}&amp;search={text}&amp;page={p}&amp;size={s}` funktioniert</label>
-        <label><input type="checkbox" data-cb="crit_US_339_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Filter: Rolle (SUPERADMIN, SECTION_ADMIN, TEACHER, PARENT, STUDENT)</label>
-        <label><input type="checkbox" data-cb="crit_US_339_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Filter: Aktiv/Inaktiv</label>
-        <label><input type="checkbox" data-cb="crit_US_339_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Freitext-Suche ueber Name und E-Mail</label>
-        <label><input type="checkbox" data-cb="crit_US_339_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Pagination mit 20 Eintraegen pro Seite</label>
+        <label><input type="checkbox" data-cb="crit_US_339_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> `GET /api/v1/admin/users?role={role}&amp;active={bool}&amp;search={text}&amp;page={p}&amp;size={s}` funktioniert</label>
+        <label><input type="checkbox" data-cb="crit_US_339_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Filter: Rolle (SUPERADMIN, SECTION_ADMIN, TEACHER, PARENT, STUDENT)</label>
+        <label><input type="checkbox" data-cb="crit_US_339_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Filter: Aktiv/Inaktiv</label>
+        <label><input type="checkbox" data-cb="crit_US_339_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Freitext-Suche ueber Name und E-Mail</label>
+        <label><input type="checkbox" data-cb="crit_US_339_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Pagination mit 20 Eintraegen pro Seite</label>
       </div>
     </div>
     <div class="story" id="story-US_340" data-story="US-340" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-340</span> <span class="story-title">Benutzer erstellen und Profil bearbeiten (Admin)</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich Benutzerprofile bearbeiten, damit ich Daten korrigieren oder aktualisieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer existiert im System.</div>
+      <div class="story-als">Als Superadmin moechte ich Benutzerprofile bearbeiten, damit ich Daten korrigieren oder aktualisieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer existiert im System.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5916,17 +6266,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Audit-Log pruefen</td><td>Aenderung wurde protokolliert</td><td><input type="checkbox" data-cb="step_US_340_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_340_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Admin kann E-Mail, Vorname, Nachname, Telefon aendern</label>
-        <label><input type="checkbox" data-cb="crit_US_340_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Nur SUPERADMIN hat Zugriff (`@PreAuthorize(&quot;hasRole('SUPERADMIN')&quot;)`)</label>
-        <label><input type="checkbox" data-cb="crit_US_340_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Datenzugriff wird im Data-Access-Log protokolliert (DSGVO)</label>
+        <label><input type="checkbox" data-cb="crit_US_340_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Admin kann E-Mail, Vorname, Nachname, Telefon aendern</label>
+        <label><input type="checkbox" data-cb="crit_US_340_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Nur SUPERADMIN hat Zugriff (`@PreAuthorize(&quot;hasRole('SUPERADMIN')&quot;)`)</label>
+        <label><input type="checkbox" data-cb="crit_US_340_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Datenzugriff wird im Data-Access-Log protokolliert (DSGVO)</label>
       </div>
     </div>
     <div class="story" id="story-US_341" data-story="US-341" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-341</span> <span class="story-title">Benutzerrolle zuweisen</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich einem Benutzer eine Rolle zuweisen, damit Berechtigungen korrekt vergeben werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer existiert.</div>
+      <div class="story-als">Als Superadmin moechte ich einem Benutzer eine Rolle zuweisen, damit Berechtigungen korrekt vergeben werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5937,17 +6287,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Benutzer hat jetzt TEACHER-Berechtigungen</td><td>Rollenwechsel wirksam</td><td><input type="checkbox" data-cb="step_US_341_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_341_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Rolle kann auf SUPERADMIN, SECTION_ADMIN, TEACHER, PARENT, STUDENT gesetzt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_341_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Rollenwechsel wirkt sich sofort auf Berechtigungen aus</label>
-        <label><input type="checkbox" data-cb="crit_US_341_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Mindestens ein SUPERADMIN muss im System bleiben</label>
+        <label><input type="checkbox" data-cb="crit_US_341_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Rolle kann auf SUPERADMIN, SECTION_ADMIN, TEACHER, PARENT, STUDENT gesetzt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_341_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Rollenwechsel wirkt sich sofort auf Berechtigungen aus</label>
+        <label><input type="checkbox" data-cb="crit_US_341_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Mindestens ein SUPERADMIN muss im System bleiben</label>
       </div>
     </div>
     <div class="story" id="story-US_342" data-story="US-342" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-342</span> <span class="story-title">Benutzer sperren und freischalten</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich Benutzer sperren oder freischalten, damit ich den Zugang kontrollieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer existiert.</div>
+      <div class="story-als">Als Superadmin moechte ich Benutzer sperren oder freischalten, damit ich den Zugang kontrollieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5959,17 +6309,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Benutzer kann sich wieder einloggen</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_342_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_342_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Gesperrte Benutzer koennen sich nicht einloggen</label>
-        <label><input type="checkbox" data-cb="crit_US_342_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Status-Aenderung ist reversibel</label>
-        <label><input type="checkbox" data-cb="crit_US_342_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Admin kann sich nicht selbst sperren</label>
+        <label><input type="checkbox" data-cb="crit_US_342_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Gesperrte Benutzer koennen sich nicht einloggen</label>
+        <label><input type="checkbox" data-cb="crit_US_342_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Status-Aenderung ist reversibel</label>
+        <label><input type="checkbox" data-cb="crit_US_342_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Admin kann sich nicht selbst sperren</label>
       </div>
     </div>
     <div class="story" id="story-US_343" data-story="US-343" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-343</span> <span class="story-title">Spezialrollen zuweisen (PUTZORGA, ELTERNBEIRAT, SECTION_ADMIN)</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich Benutzern Spezialrollen zuweisen, damit sie besondere Funktionen nutzen koennen.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer existiert.</div>
+      <div class="story-als">Als Superadmin moechte ich Benutzern Spezialrollen zuweisen, damit sie besondere Funktionen nutzen koennen.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer existiert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -5981,17 +6331,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Assigned-Roles aktualisieren: `PUT /api/v1/admin/users/{id}/assigned-roles`</td><td>Mehrere Rollen gleichzeitig setzen</td><td><input type="checkbox" data-cb="step_US_343_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_343_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Spezialrollen: PUTZORGA, ELTERNBEIRAT, SECTION_ADMIN:{sectionId}</label>
-        <label><input type="checkbox" data-cb="crit_US_343_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Mehrere Spezialrollen pro Benutzer moeglich</label>
-        <label><input type="checkbox" data-cb="crit_US_343_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> SECTION_ADMIN erhaelt Zugriff auf den zugeordneten Bereich</label>
+        <label><input type="checkbox" data-cb="crit_US_343_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Spezialrollen: PUTZORGA, ELTERNBEIRAT, SECTION_ADMIN:{sectionId}</label>
+        <label><input type="checkbox" data-cb="crit_US_343_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Mehrere Spezialrollen pro Benutzer moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_343_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> SECTION_ADMIN erhaelt Zugriff auf den zugeordneten Bereich</label>
       </div>
     </div>
     <div class="story" id="story-US_344" data-story="US-344" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-344</span> <span class="story-title">System-Konfiguration aendern</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich die Systemkonfiguration aendern, damit ich die Plattform an unsere Schule anpassen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
+      <div class="story-als">Als Superadmin moechte ich die Systemkonfiguration aendern, damit ich die Plattform an unsere Schule anpassen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6005,85 +6355,85 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Speichern: `PUT /api/v1/admin/config`</td><td>Konfiguration wird persistiert</td><td><input type="checkbox" data-cb="step_US_344_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_344_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Konfigurationsfelder: Schulname, Bundesland, Ferien, Upload-Groesse, Sprachen</label>
-        <label><input type="checkbox" data-cb="crit_US_344_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> `GET /api/v1/admin/config` laedt aktuelle Konfiguration</label>
-        <label><input type="checkbox" data-cb="crit_US_344_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> `PUT /api/v1/admin/config` speichert Aenderungen</label>
-        <label><input type="checkbox" data-cb="crit_US_344_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Bundesland bestimmt Feiertage (16 deutsche Bundeslaender)</label>
+        <label><input type="checkbox" data-cb="crit_US_344_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Konfigurationsfelder: Schulname, Bundesland, Ferien, Upload-Groesse, Sprachen</label>
+        <label><input type="checkbox" data-cb="crit_US_344_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> `GET /api/v1/admin/config` laedt aktuelle Konfiguration</label>
+        <label><input type="checkbox" data-cb="crit_US_344_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> `PUT /api/v1/admin/config` speichert Aenderungen</label>
+        <label><input type="checkbox" data-cb="crit_US_344_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Bundesland bestimmt Feiertage (16 deutsche Bundeslaender)</label>
       </div>
     </div>
     <div class="story" id="story-US_345" data-story="US-345" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-345</span> <span class="story-title">Theme / Design anpassen</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich das Design der Plattform anpassen, damit es zum Erscheinungsbild unserer Schule passt.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
+      <div class="story-als">Als Superadmin moechte ich das Design der Plattform anpassen, damit es zum Erscheinungsbild unserer Schule passt.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Als `admin@monteweb.local` (SA) einloggen</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_345_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Admin &gt; Design (AdminTheme) oeffnen</td><td>Theme-Editor wird angezeigt</td><td><input type="checkbox" data-cb="step_US_345_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Primaerfarbe aendern</td><td>Farbwahl (Colorpicker)</td><td><input type="checkbox" data-cb="step_US_345_3" onchange="onCheck()"></td></tr>
-          <tr><td>4</td><td>Speichern: `PUT /api/v1/admin/theme`</td><td>Theme wird aktualisiert</td><td><input type="checkbox" data-cb="step_US_345_4" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Speichern: `PUT /api/v1/admin/config/theme`</td><td>Theme wird aktualisiert</td><td><input type="checkbox" data-cb="step_US_345_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Seite neu laden</td><td>Neue Farben werden angewendet (CSS Custom Properties `--mw-*`)</td><td><input type="checkbox" data-cb="step_US_345_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_345_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Theme-Farben koennen angepasst werden</label>
-        <label><input type="checkbox" data-cb="crit_US_345_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> CSS Custom Properties `--mw-*` werden aktualisiert</label>
-        <label><input type="checkbox" data-cb="crit_US_345_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Theme wird aus Backend-Tenant-Config geladen</label>
-        <label><input type="checkbox" data-cb="crit_US_345_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Aenderungen sind sofort sichtbar nach Neuladen</label>
+        <label><input type="checkbox" data-cb="crit_US_345_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Theme-Farben koennen angepasst werden</label>
+        <label><input type="checkbox" data-cb="crit_US_345_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> CSS Custom Properties `--mw-*` werden aktualisiert</label>
+        <label><input type="checkbox" data-cb="crit_US_345_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Theme wird aus Backend-Tenant-Config geladen</label>
+        <label><input type="checkbox" data-cb="crit_US_345_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Aenderungen sind sofort sichtbar nach Neuladen</label>
       </div>
     </div>
     <div class="story" id="story-US_346" data-story="US-346" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-346</span> <span class="story-title">Module aktivieren / deaktivieren</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich optionale Module ein- oder ausschalten, damit ich nur benoetigte Funktionen aktiviere.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
+      <div class="story-als">Als Superadmin moechte ich optionale Module ein- oder ausschalten, damit ich nur benoetigte Funktionen aktiviere.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Als `admin@monteweb.local` (SA) einloggen</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_346_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Admin &gt; Module (AdminModules) oeffnen</td><td>Liste aller Module mit Toggles</td><td><input type="checkbox" data-cb="step_US_346_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Modul &quot;Fotobox&quot; deaktivieren</td><td>Toggle auf &quot;aus&quot;</td><td><input type="checkbox" data-cb="step_US_346_3" onchange="onCheck()"></td></tr>
-          <tr><td>4</td><td>Speichern: `PUT /api/v1/admin/modules`</td><td>Modulstatus wird in `tenant_config.modules` JSONB gespeichert</td><td><input type="checkbox" data-cb="step_US_346_4" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Speichern: `PUT /api/v1/admin/config/modules`</td><td>Modulstatus wird in `tenant_config.modules` JSONB gespeichert</td><td><input type="checkbox" data-cb="step_US_346_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Fotobox-Menueeintrag verschwindet in der Navigation</td><td>Frontend blendet deaktivierte Module aus</td><td><input type="checkbox" data-cb="step_US_346_5" onchange="onCheck()"></td></tr>
           <tr><td>6</td><td>Modul &quot;Fotobox&quot; wieder aktivieren</td><td>Toggle auf &quot;ein&quot;, Menueeintrag erscheint wieder</td><td><input type="checkbox" data-cb="step_US_346_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_346_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Property-basierte Module: messaging, files, jobboard, cleaning, calendar, forms, fotobox, fundgrube, bookmarks, tasks, wiki, profilefields</label>
-        <label><input type="checkbox" data-cb="crit_US_346_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> DB-managed Toggles (JSONB): jitsi, wopi, clamav, maintenance, ldap, directoryAdminOnly, impersonation</label>
-        <label><input type="checkbox" data-cb="crit_US_346_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Backend: `@ConditionalOnProperty` fuer Property-Module, `adminModuleApi.isModuleEnabled()` fuer DB-Toggles</label>
-        <label><input type="checkbox" data-cb="crit_US_346_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Frontend: Menue-Eintraege nur bei aktiviertem Modul sichtbar</label>
-        <label><input type="checkbox" data-cb="crit_US_346_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Module koennen jederzeit ein-/ausgeschaltet werden</label>
+        <label><input type="checkbox" data-cb="crit_US_346_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Property-basierte Module: messaging, files, jobboard, cleaning, calendar, forms, fotobox, fundgrube, bookmarks, tasks, wiki, profilefields</label>
+        <label><input type="checkbox" data-cb="crit_US_346_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> DB-managed Toggles (JSONB): jitsi, wopi, clamav, maintenance, ldap, directoryAdminOnly, impersonation</label>
+        <label><input type="checkbox" data-cb="crit_US_346_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Backend: `@ConditionalOnProperty` fuer Property-Module, `adminModuleApi.isModuleEnabled()` fuer DB-Toggles</label>
+        <label><input type="checkbox" data-cb="crit_US_346_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Frontend: Menue-Eintraege nur bei aktiviertem Modul sichtbar</label>
+        <label><input type="checkbox" data-cb="crit_US_346_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Module koennen jederzeit ein-/ausgeschaltet werden</label>
       </div>
     </div>
     <div class="story" id="story-US_347" data-story="US-347" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-347</span> <span class="story-title">Logo hochladen</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich das Schullogo hochladen, damit es in der Navigation und auf der Login-Seite angezeigt wird.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
+      <div class="story-als">Als Superadmin moechte ich das Schullogo hochladen, damit es in der Navigation und auf der Login-Seite angezeigt wird.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Als `admin@monteweb.local` (SA) einloggen</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_347_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Admin-Panel oeffnen, Logo-Bereich suchen</td><td>Logo-Upload-Bereich sichtbar</td><td><input type="checkbox" data-cb="step_US_347_2" onchange="onCheck()"></td></tr>
-          <tr><td>3</td><td>Logo-Datei auswaehlen (PNG/JPG)</td><td>Datei wird hochgeladen: `POST /api/v1/admin/logo`</td><td><input type="checkbox" data-cb="step_US_347_3" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Logo-Datei auswaehlen (PNG/JPG)</td><td>Datei wird hochgeladen: `POST /api/v1/admin/config/logo`</td><td><input type="checkbox" data-cb="step_US_347_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Vorschau des Logos pruefen</td><td>Hochgeladenes Logo wird angezeigt</td><td><input type="checkbox" data-cb="step_US_347_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Seite neu laden</td><td>Logo erscheint in Navigation und Login</td><td><input type="checkbox" data-cb="step_US_347_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_347_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Logo kann hochgeladen werden (PNG, JPG)</label>
-        <label><input type="checkbox" data-cb="crit_US_347_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Logo wird in Navigation und Login-Seite angezeigt</label>
-        <label><input type="checkbox" data-cb="crit_US_347_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Altes Logo wird beim Hochladen ersetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_347_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Logo kann hochgeladen werden (PNG, JPG)</label>
+        <label><input type="checkbox" data-cb="crit_US_347_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Logo wird in Navigation und Login-Seite angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_347_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Altes Logo wird beim Hochladen ersetzt</label>
       </div>
     </div>
     <div class="story" id="story-US_348" data-story="US-348" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-348</span> <span class="story-title">Audit-Log einsehen</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich das Audit-Log einsehen, damit ich sicherheitsrelevante Aktionen nachvollziehen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang. Verschiedene Aktionen wurden durchgefuehrt.</div>
+      <div class="story-als">Als Superadmin moechte ich das Audit-Log einsehen, damit ich sicherheitsrelevante Aktionen nachvollziehen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang. Verschiedene Aktionen wurden durchgefuehrt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6094,18 +6444,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>`GET /api/v1/admin/audit-log`</td><td>Paginierte Audit-Log-Eintraege</td><td><input type="checkbox" data-cb="step_US_348_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_348_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Audit-Log protokolliert sicherheitsrelevante Aktionen</label>
-        <label><input type="checkbox" data-cb="crit_US_348_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Eintraege enthalten: Aktion, Benutzer, Zeitstempel, IP-Adresse, Details</label>
-        <label><input type="checkbox" data-cb="crit_US_348_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Paginierung und Filterung funktionieren</label>
-        <label><input type="checkbox" data-cb="crit_US_348_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Nur SUPERADMIN hat Zugriff</label>
+        <label><input type="checkbox" data-cb="crit_US_348_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Audit-Log protokolliert sicherheitsrelevante Aktionen</label>
+        <label><input type="checkbox" data-cb="crit_US_348_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Eintraege enthalten: Aktion, Benutzer, Zeitstempel, IP-Adresse, Details</label>
+        <label><input type="checkbox" data-cb="crit_US_348_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Paginierung und Filterung funktionieren</label>
+        <label><input type="checkbox" data-cb="crit_US_348_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Nur SUPERADMIN hat Zugriff</label>
       </div>
     </div>
     <div class="story" id="story-US_349" data-story="US-349" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-349</span> <span class="story-title">Error-Reports verwalten und GitHub-Issue erstellen</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich Fehlerberichte einsehen und optional als GitHub-Issue erstellen, damit Fehler systematisch verfolgt werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Error-Reports vorhanden. Optional: `tenant_config.github_repo` und `tenant_config.github_pat` konfiguriert.</div>
+      <div class="story-als">Als Superadmin moechte ich Fehlerberichte einsehen und optional als GitHub-Issue erstellen, damit Fehler systematisch verfolgt werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Error-Reports vorhanden. Optional: `tenant_config.github_repo` und `tenant_config.github_pat` konfiguriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6113,24 +6463,24 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>2</td><td>Admin &gt; Error-Reports (AdminErrorReports) oeffnen</td><td>Liste der Fehlerberichte</td><td><input type="checkbox" data-cb="step_US_349_2" onchange="onCheck()"></td></tr>
           <tr><td>3</td><td>Fehlerbericht oeffnen</td><td>Details: Fingerprint, Occurrences, Status, Stack-Trace</td><td><input type="checkbox" data-cb="step_US_349_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>Status aendern: NEW -&gt; REPORTED</td><td>`PUT /api/v1/admin/error-reports/{id}/status`</td><td><input type="checkbox" data-cb="step_US_349_4" onchange="onCheck()"></td></tr>
-          <tr><td>5</td><td>GitHub-Issue erstellen</td><td>`POST /api/v1/admin/error-reports/{id}/github-issue`</td><td><input type="checkbox" data-cb="step_US_349_5" onchange="onCheck()"></td></tr>
+          <tr><td>5</td><td>GitHub-Issue erstellen</td><td>`POST /api/v1/admin/error-reports/{id}/github`</td><td><input type="checkbox" data-cb="step_US_349_5" onchange="onCheck()"></td></tr>
           <tr><td>6</td><td>GitHub-Issue-URL wird angezeigt</td><td>`github_issue_url` wird gespeichert</td><td><input type="checkbox" data-cb="step_US_349_6" onchange="onCheck()"></td></tr>
           <tr><td>7</td><td>Status auf RESOLVED setzen</td><td>Fehlerbericht als geloest markiert</td><td><input type="checkbox" data-cb="step_US_349_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_349_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Error-Reports mit Fingerprint-basierter Deduplizierung</label>
-        <label><input type="checkbox" data-cb="crit_US_349_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Status-Workflow: NEW -&gt; REPORTED -&gt; RESOLVED / IGNORED</label>
-        <label><input type="checkbox" data-cb="crit_US_349_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> GitHub-Issue-Erstellung mit konfiguriertem PAT</label>
-        <label><input type="checkbox" data-cb="crit_US_349_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> GitHub-Config aktualisierbar: `PUT /api/v1/admin/error-reports/github-config`</label>
-        <label><input type="checkbox" data-cb="crit_US_349_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Occurrence-Tracking (Haeufigkeit des Fehlers)</label>
+        <label><input type="checkbox" data-cb="crit_US_349_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Error-Reports mit Fingerprint-basierter Deduplizierung</label>
+        <label><input type="checkbox" data-cb="crit_US_349_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Status-Workflow: NEW -&gt; REPORTED -&gt; RESOLVED / IGNORED</label>
+        <label><input type="checkbox" data-cb="crit_US_349_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> GitHub-Issue-Erstellung mit konfiguriertem PAT</label>
+        <label><input type="checkbox" data-cb="crit_US_349_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> GitHub-Config aktualisierbar: `PUT /api/v1/admin/error-reports/github-config`</label>
+        <label><input type="checkbox" data-cb="crit_US_349_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Occurrence-Tracking (Haeufigkeit des Fehlers)</label>
       </div>
     </div>
     <div class="story" id="story-US_350" data-story="US-350" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-350</span> <span class="story-title">Analytics Dashboard</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich ein Analytics Dashboard sehen, damit ich die Nutzung der Plattform verstehe.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang. Plattform wird aktiv genutzt.</div>
+      <div class="story-als">Als Superadmin moechte ich ein Analytics Dashboard sehen, damit ich die Nutzung der Plattform verstehe.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang. Plattform wird aktiv genutzt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6142,18 +6492,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>`GET /api/v1/admin/analytics`</td><td>Analytics-Daten werden zurueckgegeben</td><td><input type="checkbox" data-cb="step_US_350_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_350_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> User-Stats: Gesamt, aktiv, nach Rolle</label>
-        <label><input type="checkbox" data-cb="crit_US_350_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Content-Stats: Posts, Events, Messages, Files</label>
-        <label><input type="checkbox" data-cb="crit_US_350_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Engagement-Stats: Kommentare, Reaktionen, Login-Haeufigkeit</label>
-        <label><input type="checkbox" data-cb="crit_US_350_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Daten werden serverseitig berechnet (AnalyticsService)</label>
+        <label><input type="checkbox" data-cb="crit_US_350_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> User-Stats: Gesamt, aktiv, nach Rolle</label>
+        <label><input type="checkbox" data-cb="crit_US_350_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Content-Stats: Posts, Events, Messages, Files</label>
+        <label><input type="checkbox" data-cb="crit_US_350_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Engagement-Stats: Kommentare, Reaktionen, Login-Haeufigkeit</label>
+        <label><input type="checkbox" data-cb="crit_US_350_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Daten werden serverseitig berechnet (AnalyticsService)</label>
       </div>
     </div>
     <div class="story" id="story-US_351" data-story="US-351" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-351</span> <span class="story-title">2FA-Einstellungen verwalten (Admin)</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich die Zwei-Faktor-Authentifizierung systemweit konfigurieren, damit die Sicherheit entsprechend den Anforderungen eingestellt ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
+      <div class="story-als">Als Superadmin moechte ich die Zwei-Faktor-Authentifizierung systemweit konfigurieren, damit die Sicherheit entsprechend den Anforderungen eingestellt ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6167,21 +6517,21 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>2FA-Modus auf &quot;DISABLED&quot; setzen</td><td>2FA fuer alle deaktiviert</td><td><input type="checkbox" data-cb="step_US_351_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_351_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Drei Modi: DISABLED, OPTIONAL, MANDATORY (`tenant_config.two_factor_mode`)</label>
-        <label><input type="checkbox" data-cb="crit_US_351_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> MANDATORY mit Grace Period (7 Tage Standard): `two_factor_grace_deadline`</label>
-        <label><input type="checkbox" data-cb="crit_US_351_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> 2FA-Setup: `POST /api/v1/auth/2fa/setup` → TOTP Secret + QR-Code</label>
-        <label><input type="checkbox" data-cb="crit_US_351_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> 2FA-Bestaetigung: `POST /api/v1/auth/2fa/confirm` mit TOTP-Code</label>
-        <label><input type="checkbox" data-cb="crit_US_351_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> 2FA-Deaktivierung: `POST /api/v1/auth/2fa/disable` mit Passwort</label>
-        <label><input type="checkbox" data-cb="crit_US_351_5" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Recovery Codes bei 2FA-Setup generiert</label>
-        <label><input type="checkbox" data-cb="crit_US_351_6" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> `POST /api/v1/auth/2fa/verify` bei Login wenn 2FA aktiv</label>
+        <label><input type="checkbox" data-cb="crit_US_351_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Drei Modi: DISABLED, OPTIONAL, MANDATORY (`tenant_config.two_factor_mode`)</label>
+        <label><input type="checkbox" data-cb="crit_US_351_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> MANDATORY mit Grace Period (7 Tage Standard): `two_factor_grace_deadline`</label>
+        <label><input type="checkbox" data-cb="crit_US_351_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> 2FA-Setup: `POST /api/v1/auth/2fa/setup` → TOTP Secret + QR-Code</label>
+        <label><input type="checkbox" data-cb="crit_US_351_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> 2FA-Bestaetigung: `POST /api/v1/auth/2fa/confirm` mit TOTP-Code</label>
+        <label><input type="checkbox" data-cb="crit_US_351_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> 2FA-Deaktivierung: `POST /api/v1/auth/2fa/disable` mit Passwort</label>
+        <label><input type="checkbox" data-cb="crit_US_351_5" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Recovery Codes bei 2FA-Setup generiert</label>
+        <label><input type="checkbox" data-cb="crit_US_351_6" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> `POST /api/v1/auth/2fa/verify` bei Login wenn 2FA aktiv</label>
       </div>
     </div>
     <div class="story" id="story-US_352" data-story="US-352" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-352</span> <span class="story-title">Impersonation (Als anderer Benutzer agieren)</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich als ein anderer Benutzer agieren (Impersonation), damit ich Probleme aus Sicht des Benutzers nachvollziehen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Impersonation-Modul aktiviert (DB-Toggle `impersonation`). Admin-Zugang.</div>
+      <div class="story-als">Als Superadmin moechte ich als ein anderer Benutzer agieren (Impersonation), damit ich Probleme aus Sicht des Benutzers nachvollziehen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Impersonation-Modul aktiviert (DB-Toggle `impersonation`). Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6195,44 +6545,44 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Anwendung zeigt wieder Admin-Ansicht</td><td>SUPERADMIN-Rechte aktiv</td><td><input type="checkbox" data-cb="step_US_352_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_352_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Nur SUPERADMIN kann impersonieren</label>
-        <label><input type="checkbox" data-cb="crit_US_352_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Impersonation-Modul muss aktiviert sein (DB-Toggle)</label>
-        <label><input type="checkbox" data-cb="crit_US_352_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Kann keinen anderen SUPERADMIN impersonieren</label>
-        <label><input type="checkbox" data-cb="crit_US_352_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> JWT enthaelt `impersonatedBy`-Claim mit Admin-UUID</label>
-        <label><input type="checkbox" data-cb="crit_US_352_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Impersonation kann jederzeit beendet werden</label>
-        <label><input type="checkbox" data-cb="crit_US_352_5" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Audit-Log protokolliert Start und Ende der Impersonation</label>
+        <label><input type="checkbox" data-cb="crit_US_352_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Nur SUPERADMIN kann impersonieren</label>
+        <label><input type="checkbox" data-cb="crit_US_352_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Impersonation-Modul muss aktiviert sein (DB-Toggle)</label>
+        <label><input type="checkbox" data-cb="crit_US_352_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Kann keinen anderen SUPERADMIN impersonieren</label>
+        <label><input type="checkbox" data-cb="crit_US_352_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> JWT enthaelt `impersonatedBy`-Claim mit Admin-UUID</label>
+        <label><input type="checkbox" data-cb="crit_US_352_4" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Impersonation kann jederzeit beendet werden</label>
+        <label><input type="checkbox" data-cb="crit_US_352_5" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Audit-Log protokolliert Start und Ende der Impersonation</label>
       </div>
     </div>
     <div class="story" id="story-US_353" data-story="US-353" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-353</span> <span class="story-title">CSV-Import von Benutzern</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich Benutzer per CSV-Datei importieren, damit ich viele Benutzer gleichzeitig anlegen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
+      <div class="story-als">Als Superadmin moechte ich Benutzer per CSV-Datei importieren, damit ich viele Benutzer gleichzeitig anlegen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Als `admin@monteweb.local` (SA) einloggen</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_353_1" onchange="onCheck()"></td></tr>
           <tr><td>2</td><td>Admin &gt; CSV-Import (AdminCsvImport) oeffnen</td><td>Import-Formular wird angezeigt</td><td><input type="checkbox" data-cb="step_US_353_2" onchange="onCheck()"></td></tr>
-          <tr><td>3</td><td>Beispiel-CSV herunterladen: `GET /api/v1/admin/csv/example`</td><td>CSV-Vorlage wird heruntergeladen</td><td><input type="checkbox" data-cb="step_US_353_3" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Beispiel-CSV herunterladen: `GET /api/v1/admin/csv-import/example`</td><td>CSV-Vorlage wird heruntergeladen</td><td><input type="checkbox" data-cb="step_US_353_3" onchange="onCheck()"></td></tr>
           <tr><td>4</td><td>CSV-Datei mit Benutzerdaten befuellen</td><td>Vorname, Nachname, E-Mail, Rolle</td><td><input type="checkbox" data-cb="step_US_353_4" onchange="onCheck()"></td></tr>
-          <tr><td>5</td><td>CSV hochladen: `POST /api/v1/admin/csv/import`</td><td>Import wird ausgefuehrt</td><td><input type="checkbox" data-cb="step_US_353_5" onchange="onCheck()"></td></tr>
+          <tr><td>5</td><td>CSV hochladen: `POST /api/v1/admin/csv-import`</td><td>Import wird ausgefuehrt</td><td><input type="checkbox" data-cb="step_US_353_5" onchange="onCheck()"></td></tr>
           <tr><td>6</td><td>Ergebnis pruefen: Anzahl importierter Benutzer</td><td>Erfolgsmeldung mit Statistik</td><td><input type="checkbox" data-cb="step_US_353_6" onchange="onCheck()"></td></tr>
           <tr><td>7</td><td>Importierte Benutzer in der Benutzerliste pruefen</td><td>Neue Benutzer sind sichtbar</td><td><input type="checkbox" data-cb="step_US_353_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_353_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> CSV-Import mit Pflichtfeldern: E-Mail, Vorname, Nachname, Rolle</label>
-        <label><input type="checkbox" data-cb="crit_US_353_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Beispiel-CSV zum Download verfuegbar</label>
-        <label><input type="checkbox" data-cb="crit_US_353_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Fehlerbehandlung bei ungueltigem Format oder doppelten E-Mails</label>
-        <label><input type="checkbox" data-cb="crit_US_353_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Erfolgsmeldung mit Anzahl importierter Benutzer</label>
+        <label><input type="checkbox" data-cb="crit_US_353_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> CSV-Import mit Pflichtfeldern: E-Mail, Vorname, Nachname, Rolle</label>
+        <label><input type="checkbox" data-cb="crit_US_353_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Beispiel-CSV zum Download verfuegbar</label>
+        <label><input type="checkbox" data-cb="crit_US_353_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Fehlerbehandlung bei ungueltigem Format oder doppelten E-Mails</label>
+        <label><input type="checkbox" data-cb="crit_US_353_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Erfolgsmeldung mit Anzahl importierter Benutzer</label>
       </div>
     </div>
     <div class="story" id="story-US_354" data-story="US-354" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-354</span> <span class="story-title">LDAP-Verbindung testen</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich die LDAP-Verbindung testen, damit ich die Konfiguration vor Aktivierung ueberpruefen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> LDAP-Konfiguration in Tenant-Config vorhanden.</div>
+      <div class="story-als">Als Superadmin moechte ich die LDAP-Verbindung testen, damit ich die Konfiguration vor Aktivierung ueberpruefen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> LDAP-Konfiguration in Tenant-Config vorhanden.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6244,10 +6594,10 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Fehlermeldung bei ungueltigem Server</td><td>Aussagekraeftige Fehlerbeschreibung</td><td><input type="checkbox" data-cb="step_US_354_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_354_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> LDAP-Konfiguration: url, base_dn, bind_dn, bind_password, user_search_filter</label>
-        <label><input type="checkbox" data-cb="crit_US_354_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Attribut-Mapping: attr_email, attr_firstname, attr_lastname</label>
-        <label><input type="checkbox" data-cb="crit_US_354_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Verbindungstest ohne LDAP-Modul zu aktivieren</label>
-        <label><input type="checkbox" data-cb="crit_US_354_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> LDAP-Toggle in `tenant_config.modules` JSONB</label>
+        <label><input type="checkbox" data-cb="crit_US_354_0" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> LDAP-Konfiguration: url, base_dn, bind_dn, bind_password, user_search_filter</label>
+        <label><input type="checkbox" data-cb="crit_US_354_1" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Attribut-Mapping: attr_email, attr_firstname, attr_lastname</label>
+        <label><input type="checkbox" data-cb="crit_US_354_2" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> Verbindungstest ohne LDAP-Modul zu aktivieren</label>
+        <label><input type="checkbox" data-cb="crit_US_354_3" data-crit="1" data-module="Admin_Panel" onchange="onCheck()"> LDAP-Toggle in `tenant_config.modules` JSONB</label>
       </div>
     </div>
   </div>
@@ -6265,8 +6615,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-355</span> <span class="story-title">Eigene Bereiche anzeigen</span></div>
       </div>
-      <div class="story-als">Als Bereichsleiter moechte ich meine zugeordneten Schulbereiche sehen, damit ich weiss, welche Bereiche ich verwalte.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat Rolle SECTION_ADMIN mit Spezialrolle `SECTION_ADMIN:{sectionId}`.</div>
+      <div class="story-als">Als Bereichsleiter moechte ich meine zugeordneten Schulbereiche sehen, damit ich weiss, welche Bereiche ich verwalte.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer hat Rolle SECTION_ADMIN mit Spezialrolle `SECTION_ADMIN:{sectionId}`.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6276,17 +6626,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Nur aktive Bereiche werden angezeigt</td><td>Inaktive Bereiche sind ausgeblendet</td><td><input type="checkbox" data-cb="step_US_355_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_355_0" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Bereiche werden aus `SECTION_ADMIN:{sectionId}` Spezialrollen ermittelt</label>
-        <label><input type="checkbox" data-cb="crit_US_355_1" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> SUPERADMIN sieht alle aktiven Bereiche</label>
-        <label><input type="checkbox" data-cb="crit_US_355_2" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Nur aktive Bereiche (`active=true`) werden angezeigt</label>
+        <label><input type="checkbox" data-cb="crit_US_355_0" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Bereiche werden aus `SECTION_ADMIN:{sectionId}` Spezialrollen ermittelt</label>
+        <label><input type="checkbox" data-cb="crit_US_355_1" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> SUPERADMIN sieht alle aktiven Bereiche</label>
+        <label><input type="checkbox" data-cb="crit_US_355_2" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Nur aktive Bereiche (`active=true`) werden angezeigt</label>
       </div>
     </div>
     <div class="story" id="story-US_356" data-story="US-356" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-356</span> <span class="story-title">Raeume eines Bereichs verwalten</span></div>
       </div>
-      <div class="story-als">Als Bereichsleiter moechte ich die Raeume meines Bereichs sehen und neue erstellen, damit ich die Raumstruktur meines Bereichs verwalten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Bereichsleiter ist fuer mindestens einen Bereich zustaendig.</div>
+      <div class="story-als">Als Bereichsleiter moechte ich die Raeume meines Bereichs sehen und neue erstellen, damit ich die Raumstruktur meines Bereichs verwalten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Bereichsleiter ist fuer mindestens einen Bereich zustaendig.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6298,18 +6648,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Neuer Raum erscheint in der Raumliste</td><td>Raum mit korrektem Bereich und Typ</td><td><input type="checkbox" data-cb="step_US_356_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_356_0" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Bereichsleiter sieht nur Raeume seines Bereichs</label>
-        <label><input type="checkbox" data-cb="crit_US_356_1" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Neue Raeume koennen mit Name, Beschreibung und Typ erstellt werden</label>
-        <label><input type="checkbox" data-cb="crit_US_356_2" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Raum-Typ Standard: KLASSE</label>
-        <label><input type="checkbox" data-cb="crit_US_356_3" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> SectionId muss zum verwalteten Bereich gehoeren</label>
+        <label><input type="checkbox" data-cb="crit_US_356_0" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Bereichsleiter sieht nur Raeume seines Bereichs</label>
+        <label><input type="checkbox" data-cb="crit_US_356_1" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Neue Raeume koennen mit Name, Beschreibung und Typ erstellt werden</label>
+        <label><input type="checkbox" data-cb="crit_US_356_2" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Raum-Typ Standard: KLASSE</label>
+        <label><input type="checkbox" data-cb="crit_US_356_3" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> SectionId muss zum verwalteten Bereich gehoeren</label>
       </div>
     </div>
     <div class="story" id="story-US_357" data-story="US-357" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-357</span> <span class="story-title">Mitglieder eines Bereichs verwalten</span></div>
       </div>
-      <div class="story-als">Als Bereichsleiter moechte ich die Mitglieder meines Bereichs sehen und Spezialrollen vergeben, damit ich die Organisation meines Bereichs steuern kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Bereich hat Raeume mit Mitgliedern.</div>
+      <div class="story-als">Als Bereichsleiter moechte ich die Mitglieder meines Bereichs sehen und Spezialrollen vergeben, damit ich die Organisation meines Bereichs steuern kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Bereich hat Raeume mit Mitgliedern.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6322,18 +6672,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Spezialrolle entfernen: `DELETE /api/v1/section-admin/users/{userId}/special-roles/{role}`</td><td>Rolle wird entfernt</td><td><input type="checkbox" data-cb="step_US_357_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_357_0" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Mitgliederliste enthaelt alle Benutzer aus Raeumen des Bereichs</label>
-        <label><input type="checkbox" data-cb="crit_US_357_1" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Nur PUTZORGA und ELTERNBEIRAT Spezialrollen duerfen vergeben werden</label>
-        <label><input type="checkbox" data-cb="crit_US_357_2" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Ziel-Benutzer muss in einem Raum des verwalteten Bereichs sein</label>
-        <label><input type="checkbox" data-cb="crit_US_357_3" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Unberechtigte Rollenvergabe wird abgelehnt</label>
+        <label><input type="checkbox" data-cb="crit_US_357_0" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Mitgliederliste enthaelt alle Benutzer aus Raeumen des Bereichs</label>
+        <label><input type="checkbox" data-cb="crit_US_357_1" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Nur PUTZORGA und ELTERNBEIRAT Spezialrollen duerfen vergeben werden</label>
+        <label><input type="checkbox" data-cb="crit_US_357_2" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Ziel-Benutzer muss in einem Raum des verwalteten Bereichs sein</label>
+        <label><input type="checkbox" data-cb="crit_US_357_3" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Unberechtigte Rollenvergabe wird abgelehnt</label>
       </div>
     </div>
     <div class="story" id="story-US_358" data-story="US-358" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-358</span> <span class="story-title">Zugriffsbeschraenkung fuer Section-Admin</span></div>
       </div>
-      <div class="story-als">Als System moechte ich sicherstellen, dass Bereichsleiter nur auf ihre eigenen Bereiche zugreifen, damit die Datensicherheit gewaehrleistet ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Bereichsleiter mit Zugriff auf Bereich A, aber nicht auf Bereich B.</div>
+      <div class="story-als">Als System moechte ich sicherstellen, dass Bereichsleiter nur auf ihre eigenen Bereiche zugreifen, damit die Datensicherheit gewaehrleistet ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Bereichsleiter mit Zugriff auf Bereich A, aber nicht auf Bereich B.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6343,9 +6693,9 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Zugriff auf eigenen Bereich A</td><td>Zugriff erlaubt</td><td><input type="checkbox" data-cb="step_US_358_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_358_0" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Zugriffscheck via `requireAccessToSection()` und `requireUserInAdminSections()`</label>
-        <label><input type="checkbox" data-cb="crit_US_358_1" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Fremde Bereiche: 403 Forbidden</label>
-        <label><input type="checkbox" data-cb="crit_US_358_2" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> SUPERADMIN hat Zugriff auf alle Bereiche</label>
+        <label><input type="checkbox" data-cb="crit_US_358_0" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Zugriffscheck via `requireAccessToSection()` und `requireUserInAdminSections()`</label>
+        <label><input type="checkbox" data-cb="crit_US_358_1" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> Fremde Bereiche: 403 Forbidden</label>
+        <label><input type="checkbox" data-cb="crit_US_358_2" data-crit="1" data-module="Bereichsleitung___Section_Admin" onchange="onCheck()"> SUPERADMIN hat Zugriff auf alle Bereiche</label>
       </div>
     </div>
   </div>
@@ -6363,8 +6713,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-359</span> <span class="story-title">Datenschutzerklaerung anzeigen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die Datenschutzerklaerung lesen koennen, damit ich informiert bin, wie meine Daten verarbeitet werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Datenschutztext ist in `tenant_config.privacy_policy_text` konfiguriert.</div>
+      <div class="story-als">Als Benutzer moechte ich die Datenschutzerklaerung lesen koennen, damit ich informiert bin, wie meine Daten verarbeitet werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Datenschutztext ist in `tenant_config.privacy_policy_text` konfiguriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6373,17 +6723,17 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>3</td><td>Platzhalter im Text werden ersetzt (z.B. Schulname)</td><td>Dynamische Inhalte korrekt</td><td><input type="checkbox" data-cb="step_US_359_3" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_359_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Datenschutzerklaerung ist oeffentlich zugaenglich (kein Login noetig)</label>
-        <label><input type="checkbox" data-cb="crit_US_359_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Text und Version kommen aus `tenant_config`</label>
-        <label><input type="checkbox" data-cb="crit_US_359_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Platzhalter werden serverseitig ersetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_359_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Datenschutzerklaerung ist oeffentlich zugaenglich (kein Login noetig)</label>
+        <label><input type="checkbox" data-cb="crit_US_359_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Text und Version kommen aus `tenant_config`</label>
+        <label><input type="checkbox" data-cb="crit_US_359_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Platzhalter werden serverseitig ersetzt</label>
       </div>
     </div>
     <div class="story" id="story-US_360" data-story="US-360" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-360</span> <span class="story-title">Nutzungsbedingungen akzeptieren</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die Nutzungsbedingungen akzeptieren muessen, damit die rechtliche Grundlage gegeben ist.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> `tenant_config.terms_text` und `tenant_config.terms_version` sind konfiguriert.</div>
+      <div class="story-als">Als Benutzer moechte ich die Nutzungsbedingungen akzeptieren muessen, damit die rechtliche Grundlage gegeben ist.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> `tenant_config.terms_text` und `tenant_config.terms_version` sind konfiguriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6395,19 +6745,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Bei neuer Version: Dialog erscheint erneut</td><td>Versionierte Akzeptanz</td><td><input type="checkbox" data-cb="step_US_360_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_360_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Nutzungsbedingungen muessen akzeptiert werden (TermsAcceptanceFilter)</label>
-        <label><input type="checkbox" data-cb="crit_US_360_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Versionierung: Neue Version erfordert erneute Akzeptanz</label>
-        <label><input type="checkbox" data-cb="crit_US_360_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Akzeptanz wird in `terms_acceptances`-Tabelle gespeichert (unique per user+version)</label>
-        <label><input type="checkbox" data-cb="crit_US_360_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> IP-Adresse wird bei Akzeptanz protokolliert</label>
-        <label><input type="checkbox" data-cb="crit_US_360_4" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Impersonation-Sessions ueberspringen Terms-Check</label>
+        <label><input type="checkbox" data-cb="crit_US_360_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Nutzungsbedingungen muessen akzeptiert werden (TermsAcceptanceFilter)</label>
+        <label><input type="checkbox" data-cb="crit_US_360_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Versionierung: Neue Version erfordert erneute Akzeptanz</label>
+        <label><input type="checkbox" data-cb="crit_US_360_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Akzeptanz wird in `terms_acceptances`-Tabelle gespeichert (unique per user+version)</label>
+        <label><input type="checkbox" data-cb="crit_US_360_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> IP-Adresse wird bei Akzeptanz protokolliert</label>
+        <label><input type="checkbox" data-cb="crit_US_360_4" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Impersonation-Sessions ueberspringen Terms-Check</label>
       </div>
     </div>
     <div class="story" id="story-US_361" data-story="US-361" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-361</span> <span class="story-title">Consent verwalten (Foto/Chat fuer Kinder)</span></div>
       </div>
-      <div class="story-als">Als Elternteil moechte ich Einwilligungen fuer mein Kind verwalten (Foto-Consent, Chat-Consent), damit ich die Datenschutzrechte meines Kindes wahrnehme.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Elternteil hat ein Kind in der Familie. Consent-Typen: PHOTO_CONSENT, CHAT_CONSENT.</div>
+      <div class="story-als">Als Elternteil moechte ich Einwilligungen fuer mein Kind verwalten (Foto-Consent, Chat-Consent), damit ich die Datenschutzrechte meines Kindes wahrnehme.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Elternteil hat ein Kind in der Familie. Consent-Typen: PHOTO_CONSENT, CHAT_CONSENT.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6420,19 +6770,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Consent spaeter widerrufen</td><td>`granted: false` ueberschreibt vorherigen Consent</td><td><input type="checkbox" data-cb="step_US_361_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_361_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Consent-Typen: PHOTO_CONSENT, CHAT_CONSENT</label>
-        <label><input type="checkbox" data-cb="crit_US_361_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Eltern koennen Consent fuer ihre Kinder erteilen (`targetUserId`)</label>
-        <label><input type="checkbox" data-cb="crit_US_361_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> `granted_by` protokolliert, wer die Einwilligung gegeben hat</label>
-        <label><input type="checkbox" data-cb="crit_US_361_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Consent kann jederzeit widerrufen werden</label>
-        <label><input type="checkbox" data-cb="crit_US_361_4" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Consent wird in `consent_records`-Tabelle gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_361_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Consent-Typen: PHOTO_CONSENT, CHAT_CONSENT</label>
+        <label><input type="checkbox" data-cb="crit_US_361_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Eltern koennen Consent fuer ihre Kinder erteilen (`targetUserId`)</label>
+        <label><input type="checkbox" data-cb="crit_US_361_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> `granted_by` protokolliert, wer die Einwilligung gegeben hat</label>
+        <label><input type="checkbox" data-cb="crit_US_361_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Consent kann jederzeit widerrufen werden</label>
+        <label><input type="checkbox" data-cb="crit_US_361_4" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Consent wird in `consent_records`-Tabelle gespeichert</label>
       </div>
     </div>
     <div class="story" id="story-US_362" data-story="US-362" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-362</span> <span class="story-title">Datenexport (Art. 15 DSGVO)</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich alle meine personenbezogenen Daten exportieren (Auskunftsrecht Art. 15), damit ich weiss, welche Daten ueber mich gespeichert sind.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als Benutzer moechte ich alle meine personenbezogenen Daten exportieren (Auskunftsrecht Art. 15), damit ich weiss, welche Daten ueber mich gespeichert sind.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6443,19 +6793,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Export wird im `data_access_log` protokolliert</td><td>Audit-Trail fuer Art. 15</td><td><input type="checkbox" data-cb="step_US_362_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_362_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Export umfasst alle personenbezogenen Daten des Benutzers</label>
-        <label><input type="checkbox" data-cb="crit_US_362_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Daten werden als JSON zurueckgegeben</label>
-        <label><input type="checkbox" data-cb="crit_US_362_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Export wird im Data-Access-Log protokolliert (DSGVO-Compliance)</label>
-        <label><input type="checkbox" data-cb="crit_US_362_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Auch Admin kann Export fuer Benutzer ausloesen (`GET /api/v1/admin/users/{id}/data-export`)</label>
-        <label><input type="checkbox" data-cb="crit_US_362_4" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Admin-Export wird ebenfalls protokolliert (ADMIN_DATA_EXPORT)</label>
+        <label><input type="checkbox" data-cb="crit_US_362_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Export umfasst alle personenbezogenen Daten des Benutzers</label>
+        <label><input type="checkbox" data-cb="crit_US_362_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Daten werden als JSON zurueckgegeben</label>
+        <label><input type="checkbox" data-cb="crit_US_362_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Export wird im Data-Access-Log protokolliert (DSGVO-Compliance)</label>
+        <label><input type="checkbox" data-cb="crit_US_362_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Auch Admin kann Export fuer Benutzer ausloesen (`GET /api/v1/admin/users/{id}/data-export`)</label>
+        <label><input type="checkbox" data-cb="crit_US_362_4" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Admin-Export wird ebenfalls protokolliert (ADMIN_DATA_EXPORT)</label>
       </div>
     </div>
     <div class="story" id="story-US_363" data-story="US-363" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-363</span> <span class="story-title">Kontoloesung anfordern (14-Tage-Frist)</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die Loeschung meines Kontos anfordern, damit ich mein Recht auf Vergessenwerden wahrnehme (Art. 17 DSGVO).</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als Benutzer moechte ich die Loeschung meines Kontos anfordern, damit ich mein Recht auf Vergessenwerden wahrnehme (Art. 17 DSGVO).</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6468,18 +6818,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Hinweis-Banner: &quot;Ihr Konto wird am [Datum] geloescht&quot;</td><td>Warnung sichtbar nach Login</td><td><input type="checkbox" data-cb="step_US_363_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_363_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> 14-Tage Grace Period zwischen Anforderung und Loeschung</label>
-        <label><input type="checkbox" data-cb="crit_US_363_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> `deletion_requested_at` und `scheduled_deletion_at` in Users-Tabelle</label>
-        <label><input type="checkbox" data-cb="crit_US_363_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Benutzer wird ueber bevorstehende Loeschung informiert</label>
-        <label><input type="checkbox" data-cb="crit_US_363_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Konto ist waehrend Grace Period weiterhin nutzbar</label>
+        <label><input type="checkbox" data-cb="crit_US_363_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> 14-Tage Grace Period zwischen Anforderung und Loeschung</label>
+        <label><input type="checkbox" data-cb="crit_US_363_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> `deletion_requested_at` und `scheduled_deletion_at` in Users-Tabelle</label>
+        <label><input type="checkbox" data-cb="crit_US_363_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Benutzer wird ueber bevorstehende Loeschung informiert</label>
+        <label><input type="checkbox" data-cb="crit_US_363_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Konto ist waehrend Grace Period weiterhin nutzbar</label>
       </div>
     </div>
     <div class="story" id="story-US_364" data-story="US-364" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-364</span> <span class="story-title">Kontoloesung abbrechen</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich eine angeforderte Kontoloesung abbrechen, damit ich mein Konto behalten kann, wenn ich es mir anders ueberlege.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Loeschung wurde angefordert, aber 14-Tage-Frist ist noch nicht abgelaufen.</div>
+      <div class="story-als">Als Benutzer moechte ich eine angeforderte Kontoloesung abbrechen, damit ich mein Konto behalten kann, wenn ich es mir anders ueberlege.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Loeschung wurde angefordert, aber 14-Tage-Frist ist noch nicht abgelaufen.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6489,18 +6839,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>4</td><td>Kein Warnungs-Banner mehr sichtbar</td><td>Normaler Betrieb wiederhergestellt</td><td><input type="checkbox" data-cb="step_US_364_4" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_364_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Loeschung kann innerhalb der 14-Tage-Frist abgebrochen werden</label>
-        <label><input type="checkbox" data-cb="crit_US_364_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> `deletion_requested_at` und `scheduled_deletion_at` werden auf NULL gesetzt</label>
-        <label><input type="checkbox" data-cb="crit_US_364_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Auch Admin kann Loeschung abbrechen: `POST /api/v1/admin/users/{id}/cancel-deletion`</label>
-        <label><input type="checkbox" data-cb="crit_US_364_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Nach Ablauf der Frist ist Abbruch nicht mehr moeglich</label>
+        <label><input type="checkbox" data-cb="crit_US_364_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Loeschung kann innerhalb der 14-Tage-Frist abgebrochen werden</label>
+        <label><input type="checkbox" data-cb="crit_US_364_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> `deletion_requested_at` und `scheduled_deletion_at` werden auf NULL gesetzt</label>
+        <label><input type="checkbox" data-cb="crit_US_364_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Auch Admin kann Loeschung abbrechen: `POST /api/v1/admin/users/{id}/cancel-deletion`</label>
+        <label><input type="checkbox" data-cb="crit_US_364_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Nach Ablauf der Frist ist Abbruch nicht mehr moeglich</label>
       </div>
     </div>
     <div class="story" id="story-US_365" data-story="US-365" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-365</span> <span class="story-title">Eltern-Consent fuer minderjaehrige Schueler</span></div>
       </div>
-      <div class="story-als">Als System moechte ich sicherstellen, dass Einwilligungen fuer minderjaehrige Schueler durch Erziehungsberechtigte erteilt werden, damit die DSGVO-Vorgaben eingehalten werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Schueler ist als CHILD in einer Familie eingetragen. Elternteil ist PARENT in derselben Familie.</div>
+      <div class="story-als">Als System moechte ich sicherstellen, dass Einwilligungen fuer minderjaehrige Schueler durch Erziehungsberechtigte erteilt werden, damit die DSGVO-Vorgaben eingehalten werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Schueler ist als CHILD in einer Familie eingetragen. Elternteil ist PARENT in derselben Familie.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6512,18 +6862,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>`consent_records` pruefen</td><td>`granted_by` zeigt Eltern-UUID, nicht Kind-UUID</td><td><input type="checkbox" data-cb="step_US_365_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_365_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Eltern erteilen Consent fuer ihre Kinder (`targetUserId`)</label>
-        <label><input type="checkbox" data-cb="crit_US_365_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> `granted_by`-Feld dokumentiert den Einwilligenden</label>
-        <label><input type="checkbox" data-cb="crit_US_365_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Kinder koennen ihren eigenen Consent nicht aendern</label>
-        <label><input type="checkbox" data-cb="crit_US_365_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> DSGVO Art. 8: Einwilligung bei Kindern unter 16 durch Eltern</label>
+        <label><input type="checkbox" data-cb="crit_US_365_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Eltern erteilen Consent fuer ihre Kinder (`targetUserId`)</label>
+        <label><input type="checkbox" data-cb="crit_US_365_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> `granted_by`-Feld dokumentiert den Einwilligenden</label>
+        <label><input type="checkbox" data-cb="crit_US_365_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Kinder koennen ihren eigenen Consent nicht aendern</label>
+        <label><input type="checkbox" data-cb="crit_US_365_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> DSGVO Art. 8: Einwilligung bei Kindern unter 16 durch Eltern</label>
       </div>
     </div>
     <div class="story" id="story-US_366" data-story="US-366" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-366</span> <span class="story-title">Datenaufbewahrungsfristen (Retention Policy)</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich Datenaufbewahrungsfristen konfigurieren, damit personenbezogene Daten nicht laenger als noetig gespeichert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
+      <div class="story-als">Als Superadmin moechte ich Datenaufbewahrungsfristen konfigurieren, damit personenbezogene Daten nicht laenger als noetig gespeichert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6536,10 +6886,10 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Speichern</td><td>Konfiguration wird persistiert</td><td><input type="checkbox" data-cb="step_US_366_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_366_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Konfigurierbare Aufbewahrungsfristen fuer Notifications und Audit-Log</label>
-        <label><input type="checkbox" data-cb="crit_US_366_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Datenschutztext und Nutzungsbedingungen editierbar</label>
-        <label><input type="checkbox" data-cb="crit_US_366_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Versionsaenderung erfordert erneute Akzeptanz durch Benutzer</label>
-        <label><input type="checkbox" data-cb="crit_US_366_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Chat-Bilder: automatische Bereinigung nach 90 Tagen</label>
+        <label><input type="checkbox" data-cb="crit_US_366_0" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Konfigurierbare Aufbewahrungsfristen fuer Notifications und Audit-Log</label>
+        <label><input type="checkbox" data-cb="crit_US_366_1" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Datenschutztext und Nutzungsbedingungen editierbar</label>
+        <label><input type="checkbox" data-cb="crit_US_366_2" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Versionsaenderung erfordert erneute Akzeptanz durch Benutzer</label>
+        <label><input type="checkbox" data-cb="crit_US_366_3" data-crit="1" data-module="DSGVO___Datenschutz" onchange="onCheck()"> Chat-Bilder: automatische Bereinigung nach 90 Tagen</label>
       </div>
     </div>
   </div>
@@ -6557,8 +6907,8 @@ td:last-child { width: 40px; text-align: center; }
       <div class="story-header">
         <div><span class="story-id">US-367</span> <span class="story-title">PWA installieren</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich MonteWeb als Progressive Web App auf meinem Geraet installieren, damit ich schnellen Zugriff wie bei einer nativen App habe.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Browser unterstuetzt PWA-Installation (Chrome, Edge, Safari). Service Worker registriert.</div>
+      <div class="story-als">Als Benutzer moechte ich MonteWeb als Progressive Web App auf meinem Geraet installieren, damit ich schnellen Zugriff wie bei einer nativen App habe.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Browser unterstuetzt PWA-Installation (Chrome, Edge, Safari). Service Worker registriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6571,20 +6921,20 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Nach 7 Tagen: Banner erscheint erneut</td><td>`usePwaInstall` Composable mit 7-Tage-Dismiss-Delay</td><td><input type="checkbox" data-cb="step_US_367_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_367_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `vite-plugin-pwa` + Workbox Service Worker konfiguriert</label>
-        <label><input type="checkbox" data-cb="crit_US_367_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Install-Banner mit `usePwaInstall` Composable</label>
-        <label><input type="checkbox" data-cb="crit_US_367_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> 7-Tage-Dismiss-Delay bei &quot;Spaeter&quot;-Klick</label>
-        <label><input type="checkbox" data-cb="crit_US_367_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Service Worker: NetworkFirst-Caching fuer API-Calls</label>
-        <label><input type="checkbox" data-cb="crit_US_367_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> App-Icons in `public/icons/`</label>
-        <label><input type="checkbox" data-cb="crit_US_367_5" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Standalone-Modus bei Installation</label>
+        <label><input type="checkbox" data-cb="crit_US_367_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `vite-plugin-pwa` + Workbox Service Worker konfiguriert</label>
+        <label><input type="checkbox" data-cb="crit_US_367_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Install-Banner mit `usePwaInstall` Composable</label>
+        <label><input type="checkbox" data-cb="crit_US_367_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> 7-Tage-Dismiss-Delay bei &quot;Spaeter&quot;-Klick</label>
+        <label><input type="checkbox" data-cb="crit_US_367_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Service Worker: NetworkFirst-Caching fuer API-Calls</label>
+        <label><input type="checkbox" data-cb="crit_US_367_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> App-Icons in `public/icons/`</label>
+        <label><input type="checkbox" data-cb="crit_US_367_5" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Standalone-Modus bei Installation</label>
       </div>
     </div>
     <div class="story" id="story-US_368" data-story="US-368" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-368</span> <span class="story-title">Dark Mode umschalten</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich zwischen Light Mode, Dark Mode und System-Praeferenz wechseln, damit ich die Anzeige meinen Vorlieben anpasse.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
+      <div class="story-als">Als Benutzer moechte ich zwischen Light Mode, Dark Mode und System-Praeferenz wechseln, damit ich die Anzeige meinen Vorlieben anpasse.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Benutzer ist eingeloggt.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6598,20 +6948,20 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>8</td><td>Dark-Mode auch auf Login-Seite waehlbar</td><td>Wechsel ohne Login moeglich</td><td><input type="checkbox" data-cb="step_US_368_8" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_368_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Drei Modi: SYSTEM, LIGHT, DARK</label>
-        <label><input type="checkbox" data-cb="crit_US_368_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Wert in `users.dark_mode` VARCHAR(10) gespeichert (Default: SYSTEM)</label>
-        <label><input type="checkbox" data-cb="crit_US_368_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `useDarkMode` Composable verwaltet den Modus</label>
-        <label><input type="checkbox" data-cb="crit_US_368_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> CSS Custom Properties `--mw-*` schalten um</label>
-        <label><input type="checkbox" data-cb="crit_US_368_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Dark Mode auf Login-Seite waehlbar (auch ohne Login)</label>
-        <label><input type="checkbox" data-cb="crit_US_368_5" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Validierung: nur SYSTEM, LIGHT, DARK akzeptiert (400 bei ungueltigem Wert)</label>
+        <label><input type="checkbox" data-cb="crit_US_368_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Drei Modi: SYSTEM, LIGHT, DARK</label>
+        <label><input type="checkbox" data-cb="crit_US_368_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Wert in `users.dark_mode` VARCHAR(10) gespeichert (Default: SYSTEM)</label>
+        <label><input type="checkbox" data-cb="crit_US_368_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `useDarkMode` Composable verwaltet den Modus</label>
+        <label><input type="checkbox" data-cb="crit_US_368_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> CSS Custom Properties `--mw-*` schalten um</label>
+        <label><input type="checkbox" data-cb="crit_US_368_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Dark Mode auf Login-Seite waehlbar (auch ohne Login)</label>
+        <label><input type="checkbox" data-cb="crit_US_368_5" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Validierung: nur SYSTEM, LIGHT, DARK akzeptiert (400 bei ungueltigem Wert)</label>
       </div>
     </div>
     <div class="story" id="story-US_369" data-story="US-369" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-369</span> <span class="story-title">Sprache wechseln</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die Sprache der Anwendung wechseln, damit ich die Oberflaeche in meiner bevorzugten Sprache nutzen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Sprachen konfiguriert (`tenant_config.available_languages` enthaelt mehr als eine Sprache).</div>
+      <div class="story-als">Als Benutzer moechte ich die Sprache der Anwendung wechseln, damit ich die Oberflaeche in meiner bevorzugten Sprache nutzen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Mehrere Sprachen konfiguriert (`tenant_config.available_languages` enthaelt mehr als eine Sprache).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6623,44 +6973,44 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>6</td><td>Standardsprache: Deutsch (de)</td><td>Default-Sprache korrekt</td><td><input type="checkbox" data-cb="step_US_369_6" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_369_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> i18n: de.ts + en.ts fuer alle UI-Texte</label>
-        <label><input type="checkbox" data-cb="crit_US_369_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `available_languages TEXT[]` bestimmt waehlbare Sprachen</label>
-        <label><input type="checkbox" data-cb="crit_US_369_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> LanguageSwitcher in Profil und Login (nicht im Header)</label>
-        <label><input type="checkbox" data-cb="crit_US_369_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Switcher nur sichtbar wenn &gt;1 Sprache aktiviert</label>
-        <label><input type="checkbox" data-cb="crit_US_369_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Sprachpraeferenz wird gespeichert</label>
+        <label><input type="checkbox" data-cb="crit_US_369_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> i18n: de.ts + en.ts fuer alle UI-Texte</label>
+        <label><input type="checkbox" data-cb="crit_US_369_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `available_languages TEXT[]` bestimmt waehlbare Sprachen</label>
+        <label><input type="checkbox" data-cb="crit_US_369_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> LanguageSwitcher in Profil und Login (nicht im Header)</label>
+        <label><input type="checkbox" data-cb="crit_US_369_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Switcher nur sichtbar wenn &gt;1 Sprache aktiviert</label>
+        <label><input type="checkbox" data-cb="crit_US_369_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Sprachpraeferenz wird gespeichert</label>
       </div>
     </div>
     <div class="story" id="story-US_370" data-story="US-370" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-370</span> <span class="story-title">Wartungsmodus aktivieren</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich einen Wartungsmodus aktivieren, damit das System fuer nicht-Admins gesperrt wird waehrend Wartungsarbeiten stattfinden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
+      <div class="story-als">Als Superadmin moechte ich einen Wartungsmodus aktivieren, damit das System fuer nicht-Admins gesperrt wird waehrend Wartungsarbeiten stattfinden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Admin-Zugang.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
           <tr><td>1</td><td>Als `admin@monteweb.local` (SA) einloggen</td><td>Login erfolgreich</td><td><input type="checkbox" data-cb="step_US_370_1" onchange="onCheck()"></td></tr>
-          <tr><td>2</td><td>Admin &gt; Module &gt; Wartungsmodus aktivieren</td><td>Toggle in `tenant_config.modules` JSONB: `maintenance: true`</td><td><input type="checkbox" data-cb="step_US_370_2" onchange="onCheck()"></td></tr>
-          <tr><td>3</td><td>Wartungsmeldung eingeben: &quot;System wird aktualisiert. Bitte versuchen Sie es in 30 Minuten erneut.&quot;</td><td>Meldung in `tenant_config.maintenance_message`</td><td><input type="checkbox" data-cb="step_US_370_3" onchange="onCheck()"></td></tr>
-          <tr><td>4</td><td>Speichern: `PUT /api/v1/admin/maintenance`</td><td>Wartungsmodus wird aktiviert</td><td><input type="checkbox" data-cb="step_US_370_4" onchange="onCheck()"></td></tr>
+          <tr><td>2</td><td>Admin &gt; Module &gt; Wartungsmodus aktivieren</td><td>Dedizierte Wartungs-Konfiguration (`maintenanceEnabled`), nicht der `modules`-JSONB-Toggle</td><td><input type="checkbox" data-cb="step_US_370_2" onchange="onCheck()"></td></tr>
+          <tr><td>3</td><td>Wartungsmeldung eingeben: &quot;System wird aktualisiert. Bitte versuchen Sie es in 30 Minuten erneut.&quot;</td><td>Meldung wird im Feld `maintenanceMessage` mitgesendet</td><td><input type="checkbox" data-cb="step_US_370_3" onchange="onCheck()"></td></tr>
+          <tr><td>4</td><td>Speichern: `PUT /api/v1/admin/config/maintenance` mit Body `{maintenanceEnabled, maintenanceMessage}`</td><td>Wartungsmodus wird ueber `adminService.updateMaintenance` aktiviert</td><td><input type="checkbox" data-cb="step_US_370_4" onchange="onCheck()"></td></tr>
           <tr><td>5</td><td>Als `eltern@monteweb.local` (P) einloggen versuchen</td><td>503 Service Unavailable mit Wartungsmeldung</td><td><input type="checkbox" data-cb="step_US_370_5" onchange="onCheck()"></td></tr>
           <tr><td>6</td><td>Admin-Zugang funktioniert weiterhin</td><td>SUPERADMIN ist nicht gesperrt</td><td><input type="checkbox" data-cb="step_US_370_6" onchange="onCheck()"></td></tr>
           <tr><td>7</td><td>Wartungsmodus deaktivieren</td><td>System ist wieder fuer alle zugaenglich</td><td><input type="checkbox" data-cb="step_US_370_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_370_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Wartungsmodus sperrt alle Nicht-Admins (503)</label>
-        <label><input type="checkbox" data-cb="crit_US_370_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Konfigurierbare Wartungsmeldung</label>
-        <label><input type="checkbox" data-cb="crit_US_370_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> SUPERADMIN hat weiterhin Zugang</label>
-        <label><input type="checkbox" data-cb="crit_US_370_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Aktivierung/Deaktivierung ueber Admin-Panel</label>
-        <label><input type="checkbox" data-cb="crit_US_370_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `MaintenanceModeFilter` prueft bei jedem Request</label>
+        <label><input type="checkbox" data-cb="crit_US_370_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Wartungsmodus sperrt alle Nicht-Admins (503)</label>
+        <label><input type="checkbox" data-cb="crit_US_370_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Konfigurierbare Wartungsmeldung</label>
+        <label><input type="checkbox" data-cb="crit_US_370_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> SUPERADMIN hat weiterhin Zugang</label>
+        <label><input type="checkbox" data-cb="crit_US_370_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Aktivierung/Deaktivierung ueber Admin-Panel</label>
+        <label><input type="checkbox" data-cb="crit_US_370_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `MaintenanceModeFilter` prueft bei jedem Request</label>
       </div>
     </div>
     <div class="story" id="story-US_371" data-story="US-371" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-371</span> <span class="story-title">Impersonation als Cross-Cutting-Funktion</span></div>
       </div>
-      <div class="story-als">Als Superadmin moechte ich die Impersonation aus verschiedenen Kontexten starten, damit ich flexibel Probleme diagnostizieren kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Impersonation-Modul aktiviert.</div>
+      <div class="story-als">Als Superadmin moechte ich die Impersonation aus verschiedenen Kontexten starten, damit ich flexibel Probleme diagnostizieren kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Impersonation-Modul aktiviert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6673,18 +7023,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Audit-Log pruefen</td><td>Impersonation-Start und -Ende protokolliert</td><td><input type="checkbox" data-cb="step_US_371_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_371_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Impersonierter Benutzer hat exakt die Berechtigungen der Zielrolle</label>
-        <label><input type="checkbox" data-cb="crit_US_371_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Visuelles Banner waehrend der Impersonation</label>
-        <label><input type="checkbox" data-cb="crit_US_371_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Keine Impersonation eines anderen SUPERADMIN</label>
-        <label><input type="checkbox" data-cb="crit_US_371_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Alle Aktionen waehrend Impersonation werden im Audit-Log dem Admin zugeordnet</label>
+        <label><input type="checkbox" data-cb="crit_US_371_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Impersonierter Benutzer hat exakt die Berechtigungen der Zielrolle</label>
+        <label><input type="checkbox" data-cb="crit_US_371_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Visuelles Banner waehrend der Impersonation</label>
+        <label><input type="checkbox" data-cb="crit_US_371_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Keine Impersonation eines anderen SUPERADMIN</label>
+        <label><input type="checkbox" data-cb="crit_US_371_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Alle Aktionen waehrend Impersonation werden im Audit-Log dem Admin zugeordnet</label>
       </div>
     </div>
     <div class="story" id="story-US_372" data-story="US-372" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-372</span> <span class="story-title">Responsive Design und Touch-Bedienung</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich MonteWeb auf verschiedenen Geraeten nutzen (Desktop, Tablet, Smartphone), damit ich flexibel auf die Plattform zugreifen kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> MonteWeb ist erreichbar.</div>
+      <div class="story-als">Als Benutzer moechte ich MonteWeb auf verschiedenen Geraeten nutzen (Desktop, Tablet, Smartphone), damit ich flexibel auf die Plattform zugreifen kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> MonteWeb ist erreichbar.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6695,18 +7045,18 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>GlobalSearch (Ctrl+K) auf Mobile pruefen</td><td>Dialog passt sich an (`maxWidth: 95vw`)</td><td><input type="checkbox" data-cb="step_US_372_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_372_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Responsive Breakpoints fuer Desktop, Tablet, Mobile</label>
-        <label><input type="checkbox" data-cb="crit_US_372_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Touch-optimierte Interaktionselemente</label>
-        <label><input type="checkbox" data-cb="crit_US_372_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Such-Dialog: `maxWidth: 95vw` fuer Mobile</label>
-        <label><input type="checkbox" data-cb="crit_US_372_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Kanban: Horizontal scrollbar auf kleinen Bildschirmen</label>
+        <label><input type="checkbox" data-cb="crit_US_372_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Responsive Breakpoints fuer Desktop, Tablet, Mobile</label>
+        <label><input type="checkbox" data-cb="crit_US_372_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Touch-optimierte Interaktionselemente</label>
+        <label><input type="checkbox" data-cb="crit_US_372_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Such-Dialog: `maxWidth: 95vw` fuer Mobile</label>
+        <label><input type="checkbox" data-cb="crit_US_372_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Kanban: Horizontal scrollbar auf kleinen Bildschirmen</label>
       </div>
     </div>
     <div class="story" id="story-US_373" data-story="US-373" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-373</span> <span class="story-title">Tastaturnavigation in der globalen Suche</span></div>
       </div>
-      <div class="story-als">Als Benutzer moechte ich die globale Suche komplett per Tastatur bedienen, damit ich effizient arbeiten kann.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Such-Dialog ist geoeffnet (Ctrl+K).</div>
+      <div class="story-als">Als Benutzer moechte ich die globale Suche komplett per Tastatur bedienen, damit ich effizient arbeiten kann.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Such-Dialog ist geoeffnet (Ctrl+K).</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6719,19 +7069,19 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>7</td><td>Esc druecken</td><td>Dialog schliesst sich ohne Navigation</td><td><input type="checkbox" data-cb="step_US_373_7" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_373_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Pfeil-Tasten navigieren durch Ergebnisse (zirkulaer)</label>
-        <label><input type="checkbox" data-cb="crit_US_373_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Enter oeffnet selektiertes Ergebnis</label>
-        <label><input type="checkbox" data-cb="crit_US_373_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Esc schliesst den Dialog</label>
-        <label><input type="checkbox" data-cb="crit_US_373_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `scrollIntoView({ block: 'nearest' })` bei Selektion aenderung</label>
-        <label><input type="checkbox" data-cb="crit_US_373_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Selektiertes Ergebnis visuell hervorgehoben (CSS-Klasse `selected`)</label>
+        <label><input type="checkbox" data-cb="crit_US_373_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Pfeil-Tasten navigieren durch Ergebnisse (zirkulaer)</label>
+        <label><input type="checkbox" data-cb="crit_US_373_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Enter oeffnet selektiertes Ergebnis</label>
+        <label><input type="checkbox" data-cb="crit_US_373_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Esc schliesst den Dialog</label>
+        <label><input type="checkbox" data-cb="crit_US_373_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `scrollIntoView({ block: 'nearest' })` bei Selektion aenderung</label>
+        <label><input type="checkbox" data-cb="crit_US_373_4" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Selektiertes Ergebnis visuell hervorgehoben (CSS-Klasse `selected`)</label>
       </div>
     </div>
     <div class="story" id="story-US_374" data-story="US-374" data-roles="">
       <div class="story-header">
         <div><span class="story-id">US-374</span> <span class="story-title">Fehlerberichterstattung (Frontend Error Reporting)</span></div>
       </div>
-      <div class="story-als">Als System moechte ich Frontend-Fehler automatisch melden, damit Entwickler ueber Probleme informiert werden.</div>
-      <div class="story-pre"><strong>Vorbedingungen:</strong> Error-Reporting ist konfiguriert.</div>
+      <div class="story-als">Als System moechte ich Frontend-Fehler automatisch melden, damit Entwickler ueber Probleme informiert werden.</div>
+      <div class="story-pre"><strong>Vorbedingungen:</strong> Error-Reporting ist konfiguriert.</div>
       <table>
         <thead><tr><th>#</th><th>Testschritt</th><th>Erwartetes Ergebnis</th><th>OK</th></tr></thead>
         <tbody>
@@ -6742,10 +7092,10 @@ td:last-child { width: 40px; text-align: center; }
           <tr><td>5</td><td>Admin &gt; Error-Reports: neuer Eintrag sichtbar</td><td>Admin sieht den Fehlerbericht</td><td><input type="checkbox" data-cb="step_US_374_5" onchange="onCheck()"></td></tr>
         </tbody></table>
       <div class="criteria"><h4>Akzeptanzkriterien:</h4>
-        <label><input type="checkbox" data-cb="crit_US_374_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Fehlerberichte werden per `POST /api/v1/error-reports` gemeldet (oeffentlicher Endpoint)</label>
-        <label><input type="checkbox" data-cb="crit_US_374_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Fingerprint-basierte Deduplizierung (gleiche Fehler werden zusammengefasst)</label>
-        <label><input type="checkbox" data-cb="crit_US_374_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Occurrence-Tracking (Haeufigkeit)</label>
-        <label><input type="checkbox" data-cb="crit_US_374_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `useErrorReporting` Composable im Frontend</label>
+        <label><input type="checkbox" data-cb="crit_US_374_0" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Fehlerberichte werden per `POST /api/v1/error-reports` gemeldet (oeffentlicher Endpoint)</label>
+        <label><input type="checkbox" data-cb="crit_US_374_1" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Fingerprint-basierte Deduplizierung (gleiche Fehler werden zusammengefasst)</label>
+        <label><input type="checkbox" data-cb="crit_US_374_2" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> Occurrence-Tracking (Haeufigkeit)</label>
+        <label><input type="checkbox" data-cb="crit_US_374_3" data-crit="1" data-module="Cross_Cutting" onchange="onCheck()"> `useErrorReporting` Composable im Frontend</label>
       </div>
     </div>
   </div>

--- a/docs/acceptance-tests.md
+++ b/docs/acceptance-tests.md
@@ -628,7 +628,7 @@
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
 | 1 | Verwaltung > "Profilfelder" klicken | Seite "Profilfelder verwalten" mit Untertitel "Benutzerdefinierte Felder fuer Benutzerprofile erstellen und verwalten" |
-| 2 | Button "Neues Feld" klicken | Dialog oeffnet sich mit Feldern: Feldschluessel, Bezeichnung (DE), Bezeichnung (EN), Feldtyp, Pflichtfeld, Position, Aktiv |
+| 2 | Button "Neues Feld" klicken | Dialog oeffnet sich mit Feldern: Feldschluessel, Bezeichnung (DE), Bezeichnung (EN), Feldtyp, Pflichtfeld, Position (Aktiv-Toggle erscheint erst beim Bearbeiten; neue Felder sind serverseitig immer aktiv) |
 | 3 | Feldschluessel "hobby", Bezeichnung DE "Hobby", Typ "Text" eingeben | Felder werden befuellt |
 | 4 | Speichern | Toast: "Profilfeld erstellt"; Feld erscheint in der Liste |
 | 5 | Feld bearbeiten: Typ auf "Auswahl" aendern, Optionen "Lesen, Sport, Musik" eingeben | Optionen-Feld wird sichtbar |
@@ -777,8 +777,8 @@
 
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
-| 1 | Als SA einloggen | Navigation enthaelt: Dashboard, Raeume, Familie, Nachrichten, Kalender, Formulare, Entdecken, Verwaltung, Profil, Abmelden (+ optionale Module) |
-| 2 | Als T einloggen | Navigation enthaelt: Dashboard, Raeume, Nachrichten, Kalender, Entdecken, Profil, Abmelden (kein "Verwaltung") |
+| 1 | Als SA einloggen | Navigation enthaelt: Dashboard, Raeume, Familie, Nachrichten, Kalender, Formulare, Verzeichnis, Verwaltung, Profil, Abmelden (+ optionale Module) |
+| 2 | Als T einloggen | Navigation enthaelt: Dashboard, Raeume, Nachrichten, Kalender, Verzeichnis, Profil, Abmelden (kein "Verwaltung") |
 | 3 | Als P einloggen | Navigation enthaelt: Dashboard, Raeume, Familie, Nachrichten, Kalender, Profil, Abmelden |
 | 4 | Als S einloggen | Navigation enthaelt: Dashboard, Raeume, Nachrichten, Kalender, Profil, Abmelden (kein "Familie") |
 | 5 | Als SECADMIN einloggen | Navigation enthaelt zusaetzlich "Bereichsverwaltung" |
@@ -1989,17 +1989,17 @@
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
 | 1 | Kalender oeffnen | Standard-Ansicht wird angezeigt |
-| 2 | Auf "1 Monat" klicken | Monatsansicht wird angezeigt |
+| 2 | Auf "Monat" klicken | Monatsansicht wird angezeigt |
 | 3 | Auf "3 Monate" klicken | 3-Monats-Ansicht wird angezeigt |
-| 4 | Auf "Schuljahr" klicken | Jahresansicht wird angezeigt |
-| 5 | Auf "Liste" klicken | Listenansicht mit Terminen wird angezeigt |
+| 4 | Auf "Jahr" klicken | Jahresansicht wird angezeigt |
+| 5 | Auf "Agenda" klicken | Agenda-/Listenansicht mit Terminen wird angezeigt |
 | 6 | Button "Heute" klicken | Ansicht springt auf das aktuelle Datum |
 
 **Akzeptanzkriterien:**
-- [ ] Vier Ansichten verfuegbar: Liste, 1 Monat, 3 Monate, Schuljahr
+- [ ] Vier Ansichten verfuegbar: Agenda, Monat, 3 Monate, Jahr
 - [ ] "Heute"-Button navigiert zum aktuellen Datum
 - [ ] Feiertage werden rot markiert angezeigt
-- [ ] Schulferien werden orange markiert angezeigt
+- [ ] Schulferien werden grau markiert angezeigt
 
 ---
 
@@ -2405,7 +2405,7 @@
 
 **Akzeptanzkriterien:**
 - [ ] Nachrichten erscheinen in Echtzeit ohne Seitenneuladen
-- [ ] WebSocket-Verbindung ueber `/ws/messages`
+- [ ] WebSocket-Verbindung ueber STOMP-Endpoint `/ws` (Client abonniert `/user/queue/messages`)
 - [ ] Bei Verbindungsabbruch: automatische Wiederverbindung
 - [ ] Neue Nachrichten in nicht-geoeffneten Konversationen aktualisieren den Ungelesen-Zaehler
 
@@ -2496,7 +2496,7 @@
 - [ ] Mehrfachauswahl kann aktiviert/deaktiviert werden
 - [ ] Jeder Teilnehmer kann abstimmen (erneute Abstimmung aendert die Stimme)
 - [ ] Stimmenanzahl und prozentuale Verteilung werden angezeigt
-- [ ] Nur Ersteller kann die Umfrage schliessen
+- [ ] Ersteller oder Personal (SUPERADMIN/SECTION_ADMIN/TEACHER) koennen die Umfrage schliessen
 
 ---
 
@@ -2562,7 +2562,7 @@
 - [ ] Ordner koennen in der Root-Ebene und als Unterordner erstellt werden
 - [ ] Ordnername ist Pflichtfeld
 - [ ] Ordner zeigt Sichtbarkeit (Alle/Nur Eltern/Nur Schueler)
-- [ ] KLASSE-Raeume erhalten automatisch einen Standard-Ordner bei Erstellung
+- [ ] KLASSE-Raeume erhalten bei Erstellung automatisch drei Standard-Ordner: "Eltern & Lehrer" (Nur Eltern), "Schueler & Lehrer" (Nur Schueler) und "Alle"
 
 ---
 
@@ -2751,6 +2751,327 @@
 - [ ] SUPERADMIN hat Zugriff auf alle Raum-Dateien
 - [ ] Fehlermeldung ist klar und verstaendlich
 - [ ] Keine Information ueber Existenz der Dateien wird preisgegeben
+
+---
+
+## Modul: Elternbriefe
+
+### US-375: Elternbrief als Entwurf erstellen
+**Als** Raumleiter **moechte ich** einen Elternbrief als Entwurf erstellen, **damit** ich Eltern einer Klasse strukturiert informieren kann.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Login als `lehrer@monteweb.local` (LEADER eines KLASSE-Raums).
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | KLASSE-Raum oeffnen, Bereich "Elternbriefe" waehlen | Liste der Elternbriefe (oder leerer Zustand) wird angezeigt |
+| 2 | Button "Neuer Elternbrief" klicken | Formular mit Titel, Inhalt, optionalem Sendedatum, Frist (deadline) und Erinnerungstagen oeffnet sich |
+| 3 | Titel und Inhalt eingeben | Felder werden befuellt (Titel max. 300 Zeichen, Inhalt Pflicht) |
+| 4 | API: `POST /api/v1/parent-letters` mit `{roomId, title, content, sendDate?, deadline?, reminderDays?, studentIds?}` | HTTP 200, Brief mit Status `DRAFT` wird zurueckgegeben |
+| 5 | API-Versuch fuer einen Nicht-KLASSE-Raum (z.B. FACHRAUM) | HTTP 403 — nur KLASSE-Raeume erlaubt |
+
+**Akzeptanzkriterien:**
+- [ ] Nur LEADER des Raums oder SUPERADMIN koennen Briefe erstellen
+- [ ] Elternbriefe sind nur fuer KLASSE-Raeume moeglich
+- [ ] Neuer Brief erhaelt Status `DRAFT`
+- [ ] `reminderDays` ist optional; ohne Angabe wird der Standardwert 3 gesetzt
+- [ ] `studentIds = null` adressiert die ganze Klasse, eine Auswahl beschraenkt die Empfaenger
+
+---
+
+### US-376: Empfaengerliste ueber Familienverbund aufbauen
+**Als** Raumleiter **moechte ich**, dass die Empfaenger automatisch aus dem Familienverbund ermittelt werden, **damit** alle Eltern der betroffenen Kinder erreicht werden.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. KLASSE-Raum mit Schuelern, deren Familien Eltern-Mitglieder haben. Login als LEADER.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | Elternbrief ohne `studentIds` erstellen | Fuer jeden STUDENT des Raums werden Empfaenger erzeugt |
+| 2 | Brief-Details abrufen | Empfaengerliste enthaelt pro Kind je einen Eintrag pro PARENT-Mitglied der zugehoerigen Familie(n) |
+| 3 | Elternbrief mit `studentIds = [kindA, kindB]` erstellen | Nur die Eltern der ausgewaehlten Kinder werden als Empfaenger angelegt |
+| 4 | Empfaengerstatus pruefen | Jeder Empfaengereintrag startet mit Status `OPEN` |
+
+**Akzeptanzkriterien:**
+- [ ] Pro Kind werden alle PARENT-Mitglieder der zugehoerigen Familie(n) als Empfaenger erzeugt
+- [ ] Ohne `studentIds`-Auswahl werden alle STUDENT-Mitglieder des KLASSE-Raums beruecksichtigt
+- [ ] Doppelte Empfaenger (gleiche Kombination Brief + Elternteil + Kind) werden vermieden
+- [ ] Jeder Empfaengereintrag haelt Kind-, Eltern- und Familien-Bezug
+
+---
+
+### US-377: Eigene Elternbriefe auflisten
+**Als** Raumleiter **moechte ich** meine erstellten Elternbriefe paginiert sehen, **damit** ich den Ueberblick behalte.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Login als Ersteller mehrerer Briefe.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | API: `GET /api/v1/parent-letters/my?page=0&size=20` | Paginierte Liste der selbst erstellten Briefe (nach `createdAt`) |
+| 2 | Liste pruefen | Jeder Eintrag zeigt Titel, Status, Raumname, Empfaengerzahl und bestaetigte Anzahl |
+| 3 | Als anderer Lehrer einloggen, Endpoint erneut aufrufen | Nur die eigenen Briefe des anderen Lehrers werden gelistet |
+
+**Akzeptanzkriterien:**
+- [ ] Nur die vom angemeldeten Nutzer erstellten Briefe werden zurueckgegeben
+- [ ] Antwort ist paginiert (Standard `size=20`, sortiert nach `createdAt`)
+- [ ] Jeder Listeneintrag enthaelt Gesamt- und Bestaetigt-Empfaengerzahl
+
+---
+
+### US-378: Elternbrief-Posteingang fuer Eltern
+**Als** Elternteil **moechte ich** alle an mich gesendeten Elternbriefe sehen, **damit** ich keine Information verpasse.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Login als `eltern@monteweb.local`, der Empfaenger gesendeter Briefe ist.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | API: `GET /api/v1/parent-letters/inbox?page=0&size=20` | Paginierte Liste der Briefe, bei denen der Nutzer Empfaenger ist |
+| 2 | Liste pruefen | Nur Briefe mit Status `SENT` oder `CLOSED` erscheinen |
+| 3 | Geplanter Brief (zukuenftiges Sendedatum) pruefen | Brief erscheint NICHT im Posteingang, solange das Sendedatum nicht erreicht ist |
+
+**Akzeptanzkriterien:**
+- [ ] Nur Briefe, bei denen der Nutzer Empfaenger ist, werden angezeigt
+- [ ] Nur Briefe mit Status `SENT` oder `CLOSED` erscheinen
+- [ ] Briefe mit zukuenftigem `sendDate` werden bis zur Freigabe ausgeblendet
+- [ ] Liste ist nach Erstellungsdatum absteigend sortiert und paginiert
+
+---
+
+### US-379: Briefdetails mit rollenabhaengiger Sicht
+**Als** Nutzer **moechte ich** Briefdetails passend zu meiner Rolle sehen, **damit** ich nur die fuer mich relevanten Informationen erhalte.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Ein gesendeter Elternbrief existiert.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | Als Ersteller/LEADER/SUPERADMIN `GET /api/v1/parent-letters/{id}` | Vollansicht inkl. vollstaendiger Empfaengerliste mit Status |
+| 2 | Als Eltern-Empfaenger denselben Endpoint aufrufen | Brief-Detail mit aufgeloestem Inhalt wird angezeigt |
+| 3 | Empfaengerstatus nach dem Abruf durch das Elternteil pruefen | Offene (`OPEN`) Empfaengereintraege des Elternteils werden automatisch auf `READ` mit `readAt` gesetzt |
+| 4 | Als nicht beteiligter Nutzer den Endpoint aufrufen | HTTP 403 — kein Zugriff |
+
+**Akzeptanzkriterien:**
+- [ ] Ersteller, LEADER des Raums und SUPERADMIN sehen die Empfaengerliste
+- [ ] Eltern-Empfaenger sehen den Brief; der Abruf markiert ihre offenen Eintraege als gelesen
+- [ ] Nutzer ohne Bezug zum Brief erhalten HTTP 403
+
+---
+
+### US-380: Entwurf bearbeiten
+**Als** Raumleiter **moechte ich** einen Entwurf nachtraeglich bearbeiten, **damit** ich Inhalt und Empfaengerkreis vor dem Versand anpassen kann.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Ein Brief im Status `DRAFT` existiert. Login als Ersteller/LEADER.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | API: `PUT /api/v1/parent-letters/{id}` mit geaendertem Titel/Inhalt und neuen `studentIds` | HTTP 200, Brief aktualisiert |
+| 2 | Empfaengerliste pruefen | Alte Empfaenger werden entfernt und gemaess neuen `studentIds` neu aufgebaut |
+| 3 | Bearbeitung eines bereits gesendeten Briefs (Status `SENT`) versuchen | HTTP 403 — nur `DRAFT` ist editierbar |
+
+**Akzeptanzkriterien:**
+- [ ] Nur Briefe im Status `DRAFT` koennen bearbeitet werden
+- [ ] Nur LEADER des Raums oder SUPERADMIN duerfen bearbeiten
+- [ ] Beim Speichern wird die Empfaengerliste vollstaendig neu aufgebaut
+- [ ] `reminderDays` wird nur ueberschrieben, wenn ein Wert uebergeben wird
+
+---
+
+### US-381: Elternbrief versenden oder terminiert planen
+**Als** Raumleiter **moechte ich** einen Brief sofort versenden oder fuer ein Datum planen, **damit** Eltern zum richtigen Zeitpunkt informiert werden.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Ein Brief im Status `DRAFT` existiert. Login als Ersteller/LEADER.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | Brief ohne Sendedatum: `POST /api/v1/parent-letters/{id}/send` | Status wechselt auf `SENT`, Benachrichtigungen werden ausgeloest |
+| 2 | Empfaenger pruefen | Jeder Empfaenger erhaelt eine Benachrichtigung vom Typ `PARENT_LETTER` (einmal pro Elternteil) |
+| 3 | Brief mit zukuenftigem `sendDate` versenden | Status wechselt auf `SCHEDULED`, noch keine Benachrichtigung |
+| 4 | Versand eines bereits gesendeten Briefs erneut versuchen | HTTP 403 — nur `DRAFT` kann versendet werden |
+
+**Akzeptanzkriterien:**
+- [ ] Nur LEADER des Raums oder SUPERADMIN koennen versenden
+- [ ] Liegt `sendDate` in der Zukunft, wird der Status `SCHEDULED` (kein Sofortversand)
+- [ ] Andernfalls Status `SENT` mit Benachrichtigung (`PARENT_LETTER`) und `ParentLetterSentEvent`
+- [ ] Pro Elternteil wird nur eine Benachrichtigung erzeugt, auch bei mehreren Kindern
+
+---
+
+### US-382: Terminierte Briefe automatisch versenden
+**Als** System **moechte ich** geplante Elternbriefe automatisch zustellen, **damit** kein manueller Versand noetig ist.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Mindestens ein Brief mit Status `SCHEDULED` und erreichtem `sendDate`.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | Geplanter Scheduler `dispatchScheduledLetters` laeuft taeglich um 07:00 | Faellige `SCHEDULED`-Briefe werden gefunden |
+| 2 | Verarbeitung pruefen | Status wechselt auf `SENT`, Benachrichtigungen und `ParentLetterSentEvent` werden ausgeloest |
+| 3 | Brief mit noch nicht erreichtem `sendDate` | Bleibt unveraendert `SCHEDULED` |
+
+**Akzeptanzkriterien:**
+- [ ] Scheduler laeuft taeglich um 07:00 (`cron 0 0 7 * * *`)
+- [ ] Nur `SCHEDULED`-Briefe mit erreichtem `sendDate` werden zugestellt
+- [ ] Beim Versand werden Empfaenger benachrichtigt und das Sent-Event publiziert
+
+---
+
+### US-383: Erinnerungs-Benachrichtigungen vor Fristablauf
+**Als** Elternteil **moechte ich** vor Ablauf der Frist erinnert werden, **damit** ich die Kenntnisnahme nicht vergesse.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Ein `SENT`-Brief mit gesetzter `deadline` und offenen Empfaengern.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | Scheduler `sendReminders` laeuft taeglich um 07:05 | Briefe im Erinnerungsfenster werden ermittelt |
+| 2 | Erinnerungsfenster pruefen | Erinnerung wird gesendet, sobald `deadline - reminderDays <= jetzt` |
+| 3 | Empfaengerbenachrichtigung pruefen | Nur noch offene (`OPEN`) Empfaenger erhalten eine `PARENT_LETTER_REMINDER`-Benachrichtigung |
+| 4 | Erneuter Scheduler-Lauf am Folgetag | Keine erneute Erinnerung — `reminderSent`-Flag verhindert Doppelversand |
+
+**Akzeptanzkriterien:**
+- [ ] Scheduler laeuft taeglich um 07:05 (`cron 0 5 7 * * *`)
+- [ ] Erinnerung greift, sobald `deadline - reminderDays` erreicht ist
+- [ ] Nur noch offene Empfaenger erhalten die Erinnerung
+- [ ] Pro Brief wird die Erinnerung nur einmal ausgeloest (`reminderSent`-Flag)
+
+---
+
+### US-384: Kenntnisnahme bestaetigen
+**Als** Elternteil **moechte ich** die Kenntnisnahme eines Elternbriefs pro Kind bestaetigen, **damit** die Lehrkraft den Ruecklauf nachvollziehen kann.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Login als Eltern-Empfaenger eines gesendeten Briefs.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | API: `POST /api/v1/parent-letters/{id}/confirm/{studentId}` | Empfaengereintrag wechselt auf Status `CONFIRMED` |
+| 2 | Empfaengerdaten pruefen | `confirmedAt` und `confirmedBy` werden gesetzt |
+| 3 | Erneute Bestaetigung desselben Eintrags | Idempotent — bereits bestaetigter Eintrag wird unveraendert zurueckgegeben |
+| 4 | Bestaetigung fuer ein fremdes Kind/Eltern-Kombination versuchen | HTTP 404 — kein passender Empfaengereintrag |
+
+**Akzeptanzkriterien:**
+- [ ] Bestaetigung erfolgt pro Kind (`studentId`) separat
+- [ ] Status wechselt auf `CONFIRMED` mit `confirmedAt`/`confirmedBy`
+- [ ] Wiederholte Bestaetigung ist idempotent
+- [ ] Nur der zugeordnete Elternteil kann seinen Empfaengereintrag bestaetigen
+
+---
+
+### US-385: Brief explizit als gelesen markieren
+**Als** Elternteil **moechte ich** einen Brief als gelesen markieren koennen, **damit** mein Lesestatus erfasst wird, auch ohne Bestaetigung.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Login als Eltern-Empfaenger mit offenem (`OPEN`) Eintrag.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | API: `POST /api/v1/parent-letters/{id}/read` | Offene Empfaengereintraege des Nutzers wechseln auf `READ` |
+| 2 | Empfaengerdaten pruefen | `readAt` wird gesetzt |
+| 3 | Bereits bestaetigten (`CONFIRMED`) Eintrag pruefen | Status bleibt `CONFIRMED` — nur `OPEN`-Eintraege werden auf `READ` gesetzt |
+
+**Akzeptanzkriterien:**
+- [ ] Nur eigene Empfaengereintraege im Status `OPEN` werden auf `READ` gesetzt
+- [ ] `readAt`-Zeitstempel wird gespeichert
+- [ ] Das Oeffnen der Detailansicht (`GET /{id}`) markiert den Brief ebenfalls als gelesen
+
+---
+
+### US-386: Variablen/Platzhalter im Briefinhalt
+**Als** Raumleiter **moechte ich** Platzhalter im Brief verwenden, **damit** Inhalte je Kind/Familie personalisiert werden.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Ein Brief mit Platzhaltern im Inhalt existiert.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | Inhalt mit `{Familie}`, `{NameKind}`, `{Anrede}`, `{LehrerName}` erstellen | Platzhalter werden im Entwurf gespeichert |
+| 2 | API: `GET /api/v1/parent-letters/{id}/pdf?studentId={kind}` | Platzhalter werden fuer das angegebene Kind aufgeloest |
+| 3 | Aufloesung pruefen | `{Familie}` = Familienname, `{NameKind}` = Vorname des Kindes, `{LehrerName}` = Anzeigename der Lehrkraft |
+| 4 | `{Anrede}` ohne ermittelbares Elternteil | Faellt auf "Sehr geehrte Eltern" zurueck |
+
+**Akzeptanzkriterien:**
+- [ ] Unterstuetzte Platzhalter: `{Familie}`, `{NameKind}`, `{Anrede}`, `{LehrerName}`
+- [ ] Aufloesung erfolgt pro Kind (ueber `studentId`)
+- [ ] Ohne `studentId` wird der Rohinhalt mit unaufgeloesten Platzhaltern ausgegeben
+- [ ] `{Anrede}` nutzt "Sehr geehrte/r <Anzeigename>" bzw. den Fallback "Sehr geehrte Eltern"
+
+---
+
+### US-387: Brief und Ruecklaufliste als PDF
+**Als** Raumleiter **moechte ich** den Brief und die Ruecklaufliste als PDF herunterladen, **damit** ich sie drucken oder archivieren kann.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Ein Brief mit Empfaengern existiert. Login als Ersteller/LEADER/SUPERADMIN.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | API: `GET /api/v1/parent-letters/{id}/pdf` | PDF des Briefs (Dateiname `Elternbrief-<Titel>.pdf`) wird geliefert |
+| 2 | PDF mit `?studentId=` abrufen | Platzhalter sind fuer das gewaehlte Kind aufgeloest |
+| 3 | API: `GET /api/v1/parent-letters/{id}/tracking-pdf` | Ruecklaufliste mit Bestaetigungsstatus aller Empfaenger (Dateiname `Ruecklauf-<Titel>.pdf`) |
+| 4 | Als nicht berechtigter Nutzer PDF abrufen | HTTP 403 — kein Zugriff |
+
+**Akzeptanzkriterien:**
+- [ ] Brief-PDF wird mit `Content-Type: application/pdf` und sprechendem Dateinamen geliefert
+- [ ] Mit `studentId` werden die Platzhalter im Brief-PDF aufgeloest
+- [ ] Tracking-PDF listet den Bestaetigungsstatus aller Empfaenger
+- [ ] PDF-Abruf erfordert Detail-Zugriff (Ersteller/LEADER/SUPERADMIN)
+
+---
+
+### US-388: Datei-Anhaenge verwalten
+**Als** Raumleiter **moechte ich** Dateien an einen Elternbrief anhaengen, **damit** Eltern zusaetzliche Dokumente erhalten.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Ein Brief im Status `DRAFT` existiert. Login als Ersteller/LEADER.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | API: `POST /api/v1/parent-letters/{id}/attachments` mit Dateien | Anhaenge werden in MinIO gespeichert und gelistet |
+| 2 | Mehr als 5 Anhaenge bzw. Datei > 10 MB hochladen | HTTP 403 — Limit ueberschritten |
+| 3 | API: `GET /api/v1/parent-letters/{id}/attachments` | Anhangsliste; auch fuer Eltern-Empfaenger zugaenglich |
+| 4 | API: `GET /api/v1/parent-letters/{id}/attachments/{attachmentId}` | Einzelner Anhang wird heruntergeladen (mit Pruefung der Brief-Zugehoerigkeit) |
+| 5 | API: `DELETE /api/v1/parent-letters/{id}/attachments/{attachmentId}` an `DRAFT`-Brief | Anhang wird geloescht |
+| 6 | Anhang aus einem gesendeten Brief loeschen | HTTP 403 — nur aus `DRAFT` moeglich |
+
+**Akzeptanzkriterien:**
+- [ ] Maximal 5 Anhaenge pro Brief, jeweils maximal 10 MB
+- [ ] Anhaenge werden in MinIO gespeichert
+- [ ] Liste und Download stehen autorisierten Nutzern inkl. Eltern-Empfaengern offen
+- [ ] Anhaenge koennen nur aus `DRAFT`-Briefen durch LEADER/SUPERADMIN geloescht werden
+
+---
+
+### US-389: Brief schliessen und Entwurf loeschen
+**Als** Raumleiter **moechte ich** Briefe schliessen oder Entwuerfe loeschen, **damit** ich den Ruecklauf beenden bzw. Fehlerstuecke entfernen kann.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Login als Ersteller/LEADER/SUPERADMIN.
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | API: `POST /api/v1/parent-letters/{id}/close` bei `SENT`/`SCHEDULED`-Brief | Status wechselt auf `CLOSED` |
+| 2 | Nach dem Schliessen Bestaetigung versuchen | Keine weiteren Bestaetigungen werden erwartet (Brief abgeschlossen) |
+| 3 | Schliessen eines `DRAFT`- oder bereits `CLOSED`-Briefs versuchen | HTTP 403 — nur `SENT`/`SCHEDULED` koennen geschlossen werden |
+| 4 | API: `DELETE /api/v1/parent-letters/{id}` bei `DRAFT`-Brief | Brief und seine Empfaengereintraege werden geloescht |
+| 5 | Loeschen eines gesendeten Briefs versuchen | HTTP 403 — nur `DRAFT` ist loeschbar |
+
+**Akzeptanzkriterien:**
+- [ ] Nur `SENT`- oder `SCHEDULED`-Briefe koennen geschlossen werden (Status `CLOSED`)
+- [ ] Nur `DRAFT`-Briefe koennen geloescht werden (inkl. Empfaengereintraege)
+- [ ] Aktionen sind LEADER des Raums oder SUPERADMIN vorbehalten
+
+---
+
+### US-390: Konfiguration, Statistik und DSGVO-Bereinigung
+**Als** Administrator **moechte ich** Elternbrief-Einstellungen pflegen, Statistiken sehen und die DSGVO-Loeschung sicherstellen, **damit** das Modul rechtskonform und konfigurierbar bleibt.
+
+**Vorbedingungen:** Modul `parentletter` ist aktiv. Login als SUPERADMIN (bzw. SECTION_ADMIN fuer den eigenen Bereich).
+
+| # | Testschritt | Erwartetes Ergebnis |
+|---|------------|---------------------|
+| 1 | API: `GET /api/v1/parent-letter-config?sectionId=` | Bereichs-Config (Briefkopf-Pfad, Signatur-Template, Erinnerungstage) mit Fallback auf globale Config |
+| 2 | API: `PUT /api/v1/parent-letter-config` mit `{signatureTemplate, reminderDays}` | Config aktualisiert; `reminderDays` nur 1–30 erlaubt |
+| 3 | API: `POST /api/v1/parent-letter-config/letterhead` (jpeg/png/svg/pdf) | Briefkopf hochgeladen; vorhandener Briefkopf wird ersetzt |
+| 4 | API: `DELETE /api/v1/parent-letter-config/letterhead` | Briefkopf wird entfernt |
+| 5 | Als Lehrkraft/Eltern Config-Endpoints aufrufen | HTTP 403 — nur SUPERADMIN/SECTION_ADMIN |
+| 6 | API: `GET /api/v1/parent-letters/stats` | Statistik: aktive Briefe, Empfaenger gesamt, bestaetigt, gelesen, ueberfaellig |
+| 7 | Nutzer loeschen (DSGVO): `UserDeletionExecutedEvent` | Ersteller wird anonymisiert, Empfaengereintraege (als Elternteil und als Kind) werden entfernt |
+
+**Akzeptanzkriterien:**
+- [ ] Config wird pro Bereich gelesen/geschrieben, mit Fallback auf die globale Config
+- [ ] `reminderDays` ist auf 1–30 begrenzt; nur SUPERADMIN/SECTION_ADMIN duerfen die Config aendern
+- [ ] Briefkopf-Upload akzeptiert image/jpeg, image/png, image/svg+xml, application/pdf und ersetzt den vorhandenen Briefkopf
+- [ ] Statistik basiert auf den `SENT`-Briefen des Nutzers (Empfaenger, bestaetigt, gelesen, ueberfaellig)
+- [ ] Bei DSGVO-Loeschung wird der Ersteller anonymisiert und alle Empfaengereintraege des Nutzers entfernt; `exportUserData` liefert erstellte Briefe und Empfaengereintraege
 
 ---
 
@@ -3479,7 +3800,7 @@
 
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
-| 1 | Navigiere zum Familien-Stundenkonto (GET /api/v1/jobs/family-hours/{familyId}) | Stundenuebersicht wird angezeigt |
+| 1 | Navigiere zum Familien-Stundenkonto (GET /api/v1/jobs/family/{familyId}/hours) | Stundenuebersicht wird angezeigt |
 | 2 | Pruefe die angezeigten Werte | `targetHours` (Zielstunden), `completedHours` (bestaetigte Elternstunden), `cleaningHours` (Putzstunden), `totalHours`, `remainingHours`, `pendingHours` werden korrekt angezeigt |
 | 3 | Pruefe die Ampel-Farbe (trafficLight) | Gruen (>= Ziel), Gelb (teilweise erfuellt), Rot (weit unter Ziel) |
 | 4 | Pruefe das Putz-Sonder-Unterkonto | `cleaningHours` zeigt separat die Stunden aus Reinigungskategorie + QR-Putzstunden |
@@ -3583,7 +3904,7 @@
 | 1 | Rufe die Gesamtuebersicht auf (GET /api/v1/jobs/report/summary) | Zusammenfassung wird angezeigt |
 | 2 | Pruefe die Job-Zaehler | `openJobs`, `activeJobs` (IN_PROGRESS), `completedJobs` werden korrekt gezaehlt |
 | 3 | Pruefe die Ampel-Zaehler | `greenCount`, `yellowCount`, `redCount` fuer alle nicht-befreiten Familien |
-| 4 | Pruefe die Sortierung im Gesamtbericht (GET /api/v1/jobs/report/all) | Familien sind sortiert: Rot zuerst, dann Gelb, dann Gruen. Innerhalb gleicher Ampel alphabetisch |
+| 4 | Pruefe die Sortierung im Gesamtbericht (GET /api/v1/jobs/report) | Familien sind sortiert: Rot zuerst, dann Gelb, dann Gruen. Innerhalb gleicher Ampel alphabetisch |
 
 **Akzeptanzkriterien:**
 - [ ] Befreite Familien (`hoursExempt=true`) werden bei den Ampelzaehlern ausgeschlossen
@@ -3695,8 +4016,8 @@
 
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
-| 1 | Navigiere zur Putz-Orga-Verwaltung (GET /api/v1/cleaning/admin/configs) | Putz-Konfigurations-Uebersicht wird angezeigt |
-| 2 | Erstelle eine neue Konfiguration (POST /api/v1/cleaning/admin/configs) mit: Titel "Wochenputz Sonnengruppe", Wochentag 3 (Mittwoch), 14:00-16:00, min 2, max 5, 2.0 Stunden-Gutschrift, ohne specificDate | Konfiguration wird erstellt |
+| 1 | Navigiere zur Putz-Orga-Verwaltung (GET /api/v1/cleaning/configs) | Putz-Konfigurations-Uebersicht wird angezeigt |
+| 2 | Erstelle eine neue Konfiguration (POST /api/v1/cleaning/configs) mit: Titel "Wochenputz Sonnengruppe", Wochentag 3 (Mittwoch), 14:00-16:00, min 2, max 5, 2.0 Stunden-Gutschrift, ohne specificDate | Konfiguration wird erstellt |
 | 3 | Pruefe die Konfiguration | `dayOfWeek=3`, `startTime=14:00`, `endTime=16:00`, `specificDate=null` (wiederkehrend), `active=true` |
 | 4 | Pruefe `participantCircle` | Standard: "SECTION" |
 
@@ -3734,7 +4055,7 @@
 
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
-| 1 | Generiere Slots (POST /api/v1/cleaning/admin/configs/{id}/generate) fuer 2026-03-01 bis 2026-03-31 | Slots werden fuer jeden Mittwoch im Maerz generiert |
+| 1 | Generiere Slots (POST /api/v1/cleaning/configs/{id}/generate) fuer 2026-03-01 bis 2026-03-31 | Slots werden fuer jeden Mittwoch im Maerz generiert |
 | 2 | Pruefe die generierten Slots | Slots existieren fuer 04.03., 11.03., 18.03., 25.03. |
 | 3 | Pruefe die Slot-Details | Jeder Slot hat `configId`, `sectionId`, `slotDate`, `startTime`, `endTime`, `minParticipants`, `maxParticipants`, `status=OPEN` |
 | 4 | Generiere nochmals fuer denselben Zeitraum | Bereits existierende Slots werden nicht dupliziert |
@@ -3872,12 +4193,13 @@
 
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
-| 1 | Rufe den QR-Token fuer einen Slot ab (GET /api/v1/cleaning/admin/slots/{id}/qr-token) | QR-Token wird zurueckgegeben |
-| 2 | Exportiere QR-Codes als PDF (GET /api/v1/cleaning/admin/qr-codes/pdf) | PDF mit QR-Codes wird generiert |
+| 1 | Rufe den QR-Token fuer einen Slot ab (GET /api/v1/cleaning/slots/{id}/qr) | QR-Token wird zurueckgegeben |
+| 2 | Exportiere QR-Codes als PDF (GET /api/v1/cleaning/configs/{id}/qr-codes?from=&to=) | PDF mit QR-Codes fuer die Slots der Konfiguration im angegebenen Zeitraum wird generiert |
 | 3 | Pruefe den PDF-Inhalt | Jeder QR-Code enthaelt den Slot-spezifischen Token, Datum und Uhrzeit |
 
 **Akzeptanzkriterien:**
 - [ ] Jeder Slot hat einen eindeutigen `qrToken`
+- [ ] PDF-Export ist konfigurations-gebunden und akzeptiert `from`/`to`-Datumsparameter
 - [ ] PDF enthaelt druckbare QR-Codes mit Slot-Informationen (Datum, Uhrzeit)
 - [ ] Nur Putz-Admins koennen QR-Codes abrufen
 
@@ -4018,7 +4340,7 @@
 
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
-| 1 | Bearbeite den Slot (PUT /api/v1/cleaning/admin/slots/{id}) mit neuer startTime, endTime, minParticipants, maxParticipants | Slot-Daten werden aktualisiert |
+| 1 | Bearbeite den Slot (PUT /api/v1/cleaning/slots/{id}) mit neuer startTime, endTime, minParticipants, maxParticipants | Slot-Daten werden aktualisiert |
 | 2 | Pruefe die aktualisierten Werte | Neue Werte sind gesetzt, `updatedAt` ist aktualisiert |
 
 **Akzeptanzkriterien:**
@@ -4035,7 +4357,7 @@
 
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
-| 1 | Bearbeite die Konfiguration (PUT /api/v1/cleaning/admin/configs/{id}) mit neuem Titel und Zeiten | Konfiguration wird aktualisiert |
+| 1 | Bearbeite die Konfiguration (PUT /api/v1/cleaning/configs/{id}) mit neuem Titel und Zeiten | Konfiguration wird aktualisiert |
 | 2 | Aendere `active` auf `false` | Konfiguration wird deaktiviert, keine neuen Slots werden generiert |
 | 3 | Pruefe `hoursCredit` | Stundengutschrift kann angepasst werden |
 
@@ -4208,7 +4530,7 @@
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
 | 1 | Logge dich als Uploader des Bildes ein | Login erfolgreich |
-| 2 | Loesche das Bild (DELETE /api/v1/rooms/{roomId}/fotobox/images/{imageId}) | Bild und Thumbnail werden aus MinIO und DB geloescht |
+| 2 | Loesche das Bild (DELETE /api/v1/fotobox/images/{imageId}) | Bild und Thumbnail werden aus MinIO und DB geloescht |
 | 3 | Versuche als anderer Benutzer (nicht Uploader, nicht Leader) zu loeschen | Fehler: Nur Uploader oder Leader/Admin koennen loeschen |
 | 4 | Logge dich als LEADER ein und loesche ein beliebiges Bild | Loeschung erfolgreich (Leader kann alle Bilder loeschen) |
 
@@ -4267,7 +4589,7 @@
 
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
-| 1 | Bearbeite das Bild (PUT /api/v1/rooms/{roomId}/fotobox/images/{imageId}) mit Caption (max 500 Zeichen) | Caption wird aktualisiert |
+| 1 | Bearbeite das Bild (PUT /api/v1/fotobox/images/{imageId}) mit Caption (max 500 Zeichen) | Caption wird aktualisiert |
 | 2 | Pruefe die Bildliste des Threads | Neue Caption wird angezeigt |
 
 **Akzeptanzkriterien:**
@@ -4349,6 +4671,7 @@
 | 2 | Gib optionalen Kommentar ein (max 1000 Zeichen) und sende (POST /api/v1/fundgrube/items/{itemId}/claim) | `claimedBy` wird auf den Benutzer gesetzt, `claimedAt` auf den aktuellen Zeitpunkt |
 | 3 | Pruefe `expiresAt` | `expiresAt = claimedAt + 24 Stunden` |
 | 4 | Versuche, einen bereits beanspruchten Gegenstand erneut zu beanspruchen | Fehler: Gegenstand ist bereits beansprucht |
+| 5 | Versuche, den eigenen Fundgegenstand zu beanspruchen | Fehler (BadRequest): "Cannot claim your own item" |
 
 **Akzeptanzkriterien:**
 - [ ] `claimedBy` wird auf den beanspruchenden Benutzer gesetzt
@@ -4356,6 +4679,7 @@
 - [ ] `expiresAt` wird auf `claimedAt + 24 Stunden` gesetzt
 - [ ] Kommentar ist optional (max 1000 Zeichen)
 - [ ] Doppelbeanspruchung wird verhindert
+- [ ] Der Ersteller kann seinen eigenen Gegenstand NICHT beanspruchen
 
 ---
 
@@ -4389,10 +4713,10 @@
 |---|------------|---------------------|
 | 1 | Bearbeite den Gegenstand (PUT /api/v1/fundgrube/items/{itemId}) mit neuem Titel | Titel wird aktualisiert, `updatedAt` wird gesetzt |
 | 2 | Aendere die Beschreibung | Beschreibung wird aktualisiert |
-| 3 | Versuche als anderer Benutzer zu bearbeiten | Fehler: Nur Ersteller oder Admins koennen bearbeiten |
+| 3 | Versuche als anderer Benutzer zu bearbeiten | Fehler: Nur Ersteller, SUPERADMIN oder zustaendiger SECTION_ADMIN koennen bearbeiten |
 
 **Akzeptanzkriterien:**
-- [ ] Nur der Ersteller oder Admins koennen bearbeiten
+- [ ] Bearbeiten/Loeschen erlaubt fuer Ersteller, SUPERADMIN sowie den SECTION_ADMIN des Item-Bereichs (specialRoles `SECTION_ADMIN:<sectionId>`)
 - [ ] `updatedAt` wird bei jeder Aenderung aktualisiert
 - [ ] Titel und Beschreibung sind aenderbar, sectionId kann geaendert werden
 
@@ -4930,7 +5254,7 @@
 |---|------------|---------------------|
 | 1 | Als `lehrer@monteweb.local` (T) einloggen | Login erfolgreich |
 | 2 | Wiki-Seite in einem Raum oeffnen | Seiteninhalt wird angezeigt |
-| 3 | Lesezeichen-Icon klicken | Bookmark wird gesetzt (`contentType: "WIKI"`) |
+| 3 | Lesezeichen-Icon klicken | Bookmark wird gesetzt (`contentType: "WIKI_PAGE"`) |
 
 **Akzeptanzkriterien:**
 - [ ] Wiki-Seiten koennen gebookmarkt werden
@@ -5207,7 +5531,7 @@
 | 3 | Direktnachricht erhalten → MESSAGE-Benachrichtigung | Typ: `MESSAGE` |
 | 4 | Event erstellt → EVENT_CREATED-Benachrichtigung | Typ: `EVENT_CREATED` |
 | 5 | Event abgesagt → EVENT_CANCELLED-Benachrichtigung | Typ: `EVENT_CANCELLED` |
-| 6 | Formular veroeffentlicht → FORM_PUBLISHED-Benachrichtigung | Typ: `FORM_PUBLISHED` |
+| 6 | Raum-Umfrage veroeffentlicht → FORM_PUBLISHED-Benachrichtigung | Typ: `FORM_PUBLISHED` (nur bei ROOM-Scope-Umfragen; Consent-Formulare loesen `CONSENT_REQUIRED` aus, Bereichs-/Schul-Scopes erzeugen keine Benachrichtigung) |
 | 7 | Raum-Beitrittsanfrage → ROOM_JOIN_REQUEST-Benachrichtigung (an Leader) | Typ: `ROOM_JOIN_REQUEST` |
 | 8 | Beitrittsanfrage genehmigt → ROOM_JOIN_APPROVED (an Antragsteller) | Typ: `ROOM_JOIN_APPROVED` |
 | 9 | Familieneinladung → FAMILY_INVITATION | Typ: `FAMILY_INVITATION` |
@@ -5281,7 +5605,7 @@
 | 4 | Namen des zu einladenden Benutzers suchen | Suchergebnisse werden angezeigt |
 | 5 | Benutzer auswaehlen | Benutzer wird selektiert |
 | 6 | Rolle waehlen: PARENT oder CHILD | Rollen-Auswahl erscheint |
-| 7 | Einladung senden (`POST /api/v1/families/{id}/invite`) | Einladung wird gesendet |
+| 7 | Einladung senden (`POST /api/v1/families/{id}/invitations`) | Einladung wird gesendet |
 | 8 | Eingeladener Benutzer erhaelt Benachrichtigung | FAMILY_INVITATION-Notification erscheint |
 
 **Akzeptanzkriterien:**
@@ -5302,7 +5626,7 @@
 |---|------------|---------------------|
 | 1 | Als eingeladener Benutzer einloggen | Login erfolgreich |
 | 2 | Benachrichtigungsliste oeffnen | FAMILY_INVITATION-Benachrichtigung sichtbar |
-| 3 | Einladungen pruefen: `GET /api/v1/families/invitations/mine` | Offene Einladungen werden angezeigt |
+| 3 | Einladungen pruefen: `GET /api/v1/families/my-invitations` | Offene Einladungen werden angezeigt |
 | 4 | Einladung annehmen: `POST /api/v1/families/invitations/{id}/accept` | Benutzer wird Familienmitglied |
 | 5 | Familie in "Meine Familien" pruefen | Familie ist jetzt sichtbar |
 | 6 | Alternative: Einladung ablehnen: `POST /api/v1/families/invitations/{id}/decline` | Einladung wird entfernt |
@@ -5344,14 +5668,15 @@
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
 | 1 | Als `eltern@monteweb.local` (P) einloggen | Login erfolgreich |
-| 2 | Familien-Seite oeffnen | Stundenkonto wird angezeigt |
-| 3 | Gesamtstunden pruefen | Summe aus Job-Stunden und Putz-Stunden sichtbar |
+| 2 | Familien-Seite oeffnen | Stundenkonto-Widget (FamilyHoursWidget) wird angezeigt, sofern das Jobboard-Modul aktiv ist |
+| 3 | Gesamtstunden pruefen | Summe aus Job-Stunden und Putz-Stunden sichtbar (Daten aus `GET /api/v1/jobs/family/{familyId}/hours`) |
 | 4 | Putz-Stunden werden als Sonder-Unterkonto angezeigt | Separate Anzeige der Putzstunden |
 
 **Akzeptanzkriterien:**
 - [ ] Stundenkonto zeigt Gesamtstunden der Familie
 - [ ] Putzstunden werden separat ausgewiesen (Sonder-Unterkonto)
-- [ ] Stunden stammen aus Jobboerse und Putz-Orga
+- [ ] Die Stundendaten stammen aus dem Jobboard-Modul (`FamilyHoursInfo`), nicht aus dem Familien-Modul (`FamilyInfo` enthaelt keine Stundenfelder)
+- [ ] Das Widget wird nur angezeigt, wenn das Jobboard-Modul aktiviert ist
 - [ ] Familienverbund ist die Abrechnungseinheit
 
 ---
@@ -5540,7 +5865,7 @@
 | 1 | Als `admin@monteweb.local` (SA) einloggen | Login erfolgreich |
 | 2 | Admin > Design (AdminTheme) oeffnen | Theme-Editor wird angezeigt |
 | 3 | Primaerfarbe aendern | Farbwahl (Colorpicker) |
-| 4 | Speichern: `PUT /api/v1/admin/theme` | Theme wird aktualisiert |
+| 4 | Speichern: `PUT /api/v1/admin/config/theme` | Theme wird aktualisiert |
 | 5 | Seite neu laden | Neue Farben werden angewendet (CSS Custom Properties `--mw-*`) |
 
 **Akzeptanzkriterien:**
@@ -5561,7 +5886,7 @@
 | 1 | Als `admin@monteweb.local` (SA) einloggen | Login erfolgreich |
 | 2 | Admin > Module (AdminModules) oeffnen | Liste aller Module mit Toggles |
 | 3 | Modul "Fotobox" deaktivieren | Toggle auf "aus" |
-| 4 | Speichern: `PUT /api/v1/admin/modules` | Modulstatus wird in `tenant_config.modules` JSONB gespeichert |
+| 4 | Speichern: `PUT /api/v1/admin/config/modules` | Modulstatus wird in `tenant_config.modules` JSONB gespeichert |
 | 5 | Fotobox-Menueeintrag verschwindet in der Navigation | Frontend blendet deaktivierte Module aus |
 | 6 | Modul "Fotobox" wieder aktivieren | Toggle auf "ein", Menueeintrag erscheint wieder |
 
@@ -5583,7 +5908,7 @@
 |---|------------|---------------------|
 | 1 | Als `admin@monteweb.local` (SA) einloggen | Login erfolgreich |
 | 2 | Admin-Panel oeffnen, Logo-Bereich suchen | Logo-Upload-Bereich sichtbar |
-| 3 | Logo-Datei auswaehlen (PNG/JPG) | Datei wird hochgeladen: `POST /api/v1/admin/logo` |
+| 3 | Logo-Datei auswaehlen (PNG/JPG) | Datei wird hochgeladen: `POST /api/v1/admin/config/logo` |
 | 4 | Vorschau des Logos pruefen | Hochgeladenes Logo wird angezeigt |
 | 5 | Seite neu laden | Logo erscheint in Navigation und Login |
 
@@ -5626,7 +5951,7 @@
 | 2 | Admin > Error-Reports (AdminErrorReports) oeffnen | Liste der Fehlerberichte |
 | 3 | Fehlerbericht oeffnen | Details: Fingerprint, Occurrences, Status, Stack-Trace |
 | 4 | Status aendern: NEW -> REPORTED | `PUT /api/v1/admin/error-reports/{id}/status` |
-| 5 | GitHub-Issue erstellen | `POST /api/v1/admin/error-reports/{id}/github-issue` |
+| 5 | GitHub-Issue erstellen | `POST /api/v1/admin/error-reports/{id}/github` |
 | 6 | GitHub-Issue-URL wird angezeigt | `github_issue_url` wird gespeichert |
 | 7 | Status auf RESOLVED setzen | Fehlerbericht als geloest markiert |
 
@@ -5723,9 +6048,9 @@
 |---|------------|---------------------|
 | 1 | Als `admin@monteweb.local` (SA) einloggen | Login erfolgreich |
 | 2 | Admin > CSV-Import (AdminCsvImport) oeffnen | Import-Formular wird angezeigt |
-| 3 | Beispiel-CSV herunterladen: `GET /api/v1/admin/csv/example` | CSV-Vorlage wird heruntergeladen |
+| 3 | Beispiel-CSV herunterladen: `GET /api/v1/admin/csv-import/example` | CSV-Vorlage wird heruntergeladen |
 | 4 | CSV-Datei mit Benutzerdaten befuellen | Vorname, Nachname, E-Mail, Rolle |
-| 5 | CSV hochladen: `POST /api/v1/admin/csv/import` | Import wird ausgefuehrt |
+| 5 | CSV hochladen: `POST /api/v1/admin/csv-import` | Import wird ausgefuehrt |
 | 6 | Ergebnis pruefen: Anzahl importierter Benutzer | Erfolgsmeldung mit Statistik |
 | 7 | Importierte Benutzer in der Benutzerliste pruefen | Neue Benutzer sind sichtbar |
 
@@ -6105,9 +6430,9 @@
 | # | Testschritt | Erwartetes Ergebnis |
 |---|------------|---------------------|
 | 1 | Als `admin@monteweb.local` (SA) einloggen | Login erfolgreich |
-| 2 | Admin > Module > Wartungsmodus aktivieren | Toggle in `tenant_config.modules` JSONB: `maintenance: true` |
-| 3 | Wartungsmeldung eingeben: "System wird aktualisiert. Bitte versuchen Sie es in 30 Minuten erneut." | Meldung in `tenant_config.maintenance_message` |
-| 4 | Speichern: `PUT /api/v1/admin/maintenance` | Wartungsmodus wird aktiviert |
+| 2 | Admin > Module > Wartungsmodus aktivieren | Dedizierte Wartungs-Konfiguration (`maintenanceEnabled`), nicht der `modules`-JSONB-Toggle |
+| 3 | Wartungsmeldung eingeben: "System wird aktualisiert. Bitte versuchen Sie es in 30 Minuten erneut." | Meldung wird im Feld `maintenanceMessage` mitgesendet |
+| 4 | Speichern: `PUT /api/v1/admin/config/maintenance` mit Body `{maintenanceEnabled, maintenanceMessage}` | Wartungsmodus wird ueber `adminService.updateMaintenance` aktiviert |
 | 5 | Als `eltern@monteweb.local` (P) einloggen versuchen | 503 Service Unavailable mit Wartungsmeldung |
 | 6 | Admin-Zugang funktioniert weiterhin | SUPERADMIN ist nicht gesperrt |
 | 7 | Wartungsmodus deaktivieren | System ist wieder fuer alle zugaenglich |

--- a/docs/audits/UC-AUDIT-2026-06-09.md
+++ b/docs/audits/UC-AUDIT-2026-06-09.md
@@ -1,0 +1,333 @@
+# MonteWeb — Use-Case Audit (Dokumentation & Umsetzung)
+
+**Stand:** 2026-06-09  ·  **Methode:** 25 parallele Agent-Audits (Modul-Dok-Sektion `docs/acceptance-tests.md` ↔ Implementierung)
+
+## Zusammenfassung
+
+- **Geprüfte User Stories / Capabilities:** ~600
+- **Korrekt umgesetzt:** 477
+- **Abweichungen (Doku ↔ Code):** 145 — Severity: 33 hoch, 53 mittel, 59 niedrig
+- **Typ:** {'contradicts_code': 27, 'partial': 68, 'incorrect': 14, 'doc_outdated': 30, 'not_implemented': 6}
+- **Davon Code/Umsetzungs-Themen:** 115  ·  **reine Doku-Aktualisierung:** 30
+- **Implementierte, aber undokumentierte Features:** 165 (Top-Lücke: **parentletter/Elternbriefe = 28**, faktisch unbeschrieben)
+
+> Wichtig: Ein Teil der Abweichungen ist `doc_outdated` — hier ist der **Code korrekt** und die Doku veraltet (z. B. US-008: generische Login-Fehlermeldung ist eine bewusste Anti-Enumeration-Härtung). Diese dürfen **nicht** "rückwärts" an die Doku angepasst werden.
+
+## Dokumentations-Lücken (undokumentierte Umsetzung)
+
+Anzahl implementierter, in `acceptance-tests.md` nicht als US-Story beschriebener Capabilities je Modul:
+
+- **gap-parentletter**: 28
+- **feed**: 10
+- **admin**: 10
+- **cleaning**: 8
+- **fotobox**: 8
+- **dashboard**: 7
+- **kalender**: 7
+- **jobboard**: 7
+- **tasks**: 7
+- **familie**: 7
+- **gap-coverage**: 7
+- **auth**: 6
+- **raeume**: 6
+- **dsgvo**: 6
+- **fundgrube**: 5
+- **notifications**: 5
+- **messaging**: 4
+- **dateien**: 4
+- **formulare**: 4
+- **suche**: 4
+- **crosscutting**: 4
+- **profil**: 3
+- **wiki**: 3
+- **bookmarks**: 3
+- **sectionadmin**: 2
+
+### Größte Lücke: Modul `parentletter` (Elternbriefe) — kein eigener `## Modul:`-Abschnitt
+
+- Elternbrief erstellen (DRAFT) fuer eine KLASSE-Raum durch LEADER/SUPERADMIN, mit Titel, Inhalt, optionalem sendDate, deadline, reminderDays und optionaler studentIds-Auswahl (null = ganze Klasse)  
+  _evidence:_ ParentLetterController.createLetter POST /api/v1/parent-letters; ParentLetterService.createLetter (only KLASSE rooms, requireLeaderOrSuperadmin); CreateParentLe
+- Eigene erstellte Elternbriefe paginiert auflisten (Lehrer/Admin-Sicht)  
+  _evidence:_ ParentLetterController.getMyLetters GET /api/v1/parent-letters/my; ParentLetterService.getMyLetters
+- Eltern-Posteingang: alle gesendeten Elternbriefe paginiert, bei denen der aktuelle Nutzer Empfaenger ist (nur SENT/CLOSED mit erreichtem sendDate)  
+  _evidence:_ ParentLetterController.getInbox GET /api/v1/parent-letters/inbox; ParentLetterService.getLettersForParent
+- Statistik ueber eigene gesendete Briefe (aktive Anzahl, Empfaenger gesamt, bestaetigt, gelesen, ueberfaellig)  
+  _evidence:_ ParentLetterController.getStats GET /api/v1/parent-letters/stats; ParentLetterService.getStats; ParentLetterStatsInfo
+- Briefdetails abrufen mit rollenabhaengiger Sicht (Ersteller/LEADER/SUPERADMIN sehen Empfaengerliste; Eltern-Empfaenger sehen aufgeloesten Inhalt und der Brief wird automatisch als gelesen markiert)  
+  _evidence:_ ParentLetterController.getLetter GET /api/v1/parent-letters/{id} (try getLetterDetail, fallback getLetterForParent on ForbiddenException); ParentLetterService.g
+- DRAFT-Elternbrief bearbeiten inkl. Neuaufbau der Empfaengerliste (studentIds)  
+  _evidence:_ ParentLetterController.updateLetter PUT /api/v1/parent-letters/{id}; ParentLetterService.updateLetter (deleteByLetterId + buildRecipients); UpdateParentLetterRe
+- Elternbrief versenden oder terminiert planen: sendDate in Zukunft -> Status SCHEDULED, sonst SENT mit Benachrichtigung an alle Eltern-Empfaenger und ParentLetterSentEvent  
+  _evidence:_ ParentLetterController.sendLetter POST /api/v1/parent-letters/{id}/send; ParentLetterService.sendLetter (scheduled = sendDate.isAfter(now)); sendNotificationsTo
+- Gesendeten oder geplanten Brief schliessen (keine weiteren Bestaetigungen mehr moeglich, Status CLOSED)  
+  _evidence:_ ParentLetterController.closeLetter POST /api/v1/parent-letters/{id}/close; ParentLetterService.closeLetter
+- DRAFT-Elternbrief loeschen (inkl. Empfaengereintraege)  
+  _evidence:_ ParentLetterController.deleteLetter DELETE /api/v1/parent-letters/{id}; ParentLetterService.deleteLetter (requireExistingDraft)
+- Eltern bestaetigen Kenntnisnahme/Empfang pro Kind (studentId) — Status CONFIRMED mit confirmedAt/confirmedBy  
+  _evidence:_ ParentLetterController.confirmLetter POST /api/v1/parent-letters/{id}/confirm/{studentId}; ParentLetterService.confirmLetter; RecipientStatus.CONFIRMED
+- Brief explizit als gelesen markieren (Eltern; OPEN -> READ mit readAt)  
+  _evidence:_ ParentLetterController.markAsRead POST /api/v1/parent-letters/{id}/read; ParentLetterService.markAsRead
+- Elternbrief als PDF herunterladen, optional mit fuer ein bestimmtes Kind aufgeloesten Platzhaltern  
+  _evidence:_ ParentLetterController.downloadLetterPdf GET /api/v1/parent-letters/{id}/pdf?studentId=; ParentLetterPdfService.generateLetterPdf; getResolvedContent
+- Ruecklauf-/Tracking-Liste (Bestaetigungsstatus aller Empfaenger) als PDF herunterladen  
+  _evidence:_ ParentLetterController.downloadTrackingPdf GET /api/v1/parent-letters/{id}/tracking-pdf; ParentLetterPdfService.generateTrackingPdf (Dateiname 'Ruecklauf-...')
+- Datei-Anhaenge zu einem Elternbrief hochladen (max. 5 Anhaenge, max. 10 MB pro Datei, MinIO-Speicherung)  
+  _evidence:_ ParentLetterController.uploadAttachments POST /api/v1/parent-letters/{id}/attachments; ParentLetterService.uploadAttachments (MAX_ATTACHMENTS=5, MAX_FILE_SIZE=1
+- Anhangsliste eines Briefs abrufen (autorisierte Nutzer inkl. Eltern-Empfaenger)  
+  _evidence:_ ParentLetterController.getAttachments GET /api/v1/parent-letters/{id}/attachments; ParentLetterService.getAttachments (requireLetterAccess)
+- Einzelnen Anhang herunterladen (mit Berechtigungspruefung, dass Anhang zum Brief gehoert)  
+  _evidence:_ ParentLetterController.downloadAttachment GET /api/v1/parent-letters/{id}/attachments/{attachmentId}; ParentLetterService.downloadAttachment / loadAuthorizedAtt
+- Anhang loeschen (nur aus DRAFT-Briefen, LEADER/SUPERADMIN)  
+  _evidence:_ ParentLetterController.deleteAttachment DELETE /api/v1/parent-letters/{id}/attachments/{attachmentId}; ParentLetterService.deleteAttachment (only DRAFT)
+- Empfaenger-Aufbau ueber Familienverbund: pro Kind werden alle Eltern (PARENT-Mitglieder) der zugehoerigen Familien als Empfaenger erzeugt; ohne studentIds-Auswahl alle Schueler des KLASSE-Raums  
+  _evidence:_ ParentLetterService.buildRecipients (familyModuleApi.findByUserId, filter PARENT; bei leerer Auswahl roomModuleApi.getMemberUserIds + filter STUDENT); ParentLet
+- Template-/Platzhalter-Aufloesung im Briefinhalt: {Familie}, {NameKind}, {Anrede}, {LehrerName}  
+  _evidence:_ ParentLetterService.resolveVariables (replace {Familie}/{NameKind}/{Anrede}/{LehrerName}); getResolvedContent
+- Konfiguration pro Schulbereich (oder global) abrufen mit Fallback auf globale Config — Briefkopf-Pfad, Signatur-Template, Reminder-Tage  
+  _evidence:_ ParentLetterConfigController.getConfig GET /api/v1/parent-letter-config?sectionId=; ParentLetterService.getConfig (section -> global fallback); ParentLetterConf
+- Konfiguration pro Bereich/global aktualisieren: Signatur-Template und Reminder-Tage (1-30) — nur SUPERADMIN/SECTION_ADMIN  
+  _evidence:_ ParentLetterConfigController.updateConfig PUT /api/v1/parent-letter-config; requireAdminAccess (SUPERADMIN|SECTION_ADMIN); UpdateParentLetterConfigRequest(signa
+- Briefkopf-Bild hochladen (image/jpeg, png, svg+xml, application/pdf) pro Bereich/global — ersetzt vorhandenen Briefkopf  
+  _evidence:_ ParentLetterConfigController.uploadLetterhead POST /api/v1/parent-letter-config/letterhead; storageService.uploadLetterhead; updateLetterheadPath
+- Briefkopf-Bild entfernen pro Bereich/global  
+  _evidence:_ ParentLetterConfigController.deleteLetterhead DELETE /api/v1/parent-letter-config/letterhead; ParentLetterService.removeLetterhead
+- Automatisches Versenden terminierter Briefe (SCHEDULED -> SENT) per taeglichem Scheduler um 07:00  
+  _evidence:_ ParentLetterReminderService.dispatchScheduledLetters @Scheduled(cron='0 0 7 * * *'); ParentLetterService.dispatchScheduledLetter
+- Automatische Erinnerungs-Benachrichtigungen vor Ablauf der deadline (deadline - reminderDays) per taeglichem Scheduler um 07:05, einmalig pro Brief (reminderSent-Flag)  
+  _evidence:_ ParentLetterReminderService.sendReminders @Scheduled(cron='0 5 7 * * *'); ParentLetterService.sendRemindersForLetter; NotificationType.PARENT_LETTER_REMINDER
+- In-App/Push-Benachrichtigungstypen PARENT_LETTER (neuer Brief) und PARENT_LETTER_REMINDER (Erinnerung) — fehlen auch in der Benachrichtigungstypen-Tabelle 17.1 des Produkthandbuchs  
+  _evidence:_ ParentLetterService.sendNotificationsToRecipients (NotificationType.PARENT_LETTER) + sendRemindersForLetter (NotificationType.PARENT_LETTER_REMINDER); produktha
+- Anzahl offener (noch nicht bestaetigter) Elternbriefe pro Elternteil (Badge/Cross-Modul-API)  
+  _evidence:_ ParentLetterModuleApi.countPendingForParent; ParentLetterService.countPendingForParent (countByParentIdAndStatusNot CONFIRMED)
+- DSGVO: Export der Elternbrief-Daten eines Nutzers (erstellte Briefe + Empfaengereintraege) und Cleanup bei Loeschung (Anonymisierung des Erstellers, Entfernen der Empfaengereintraege als Elternteil/Schueler)  
+  _evidence:_ ParentLetterModuleApi.exportUserData; ParentLetterService.exportUserData / cleanupUserData; ParentLetterDeletionListener
+
+## Umsetzungs-Abweichungen — HIGH
+
+### [auth] US-016 — incorrect
+MANDATORY-mode self-service 2FA setup at login (step 5: 'Code eingeben (aus frisch eingerichtetem Authenticator) -> Login erfolgreich oder Weiterleitung zur Profilseite') is broken. After the grace deadline, AuthService.login returns twoFactorSetupRequired(tempToken) (AuthService.login:137-143) and LoginView shows the 'setup required' screen which only offers a code input wired to submit2fa -> verify2fa(tempToken, code). But the user has NO TOTP secret yet, so verify2fa finds getTotpSecret()==null and recoveryCodes==null and always throws 'Invalid 2FA code' (AuthService.verify2fa:316-342). There is no path to actually set up 2FA with only a temp token (POST /2fa/setup requires a full authenticated session via SecurityUtils.requireCurrentUserId(), and the JwtAuthenticationFilter/validateAndExtractClaims reject temp tokens that carry a 'type' claim). The in-code comment in the setup-required template (LoginView.vue:185-187) acknowledges this is not implemented. Net effect: a user without 2FA in MANDATORY mode past the grace period cannot log in or set up 2FA. Grace-period display / mode switching (DISABLED/OPTIONAL/MANDATORY) themselves work.
+
+`frontend/src/views/LoginView.vue:176-212 (esp. comment 185-187); backend/src/main/java/com/monteweb/auth/internal/service/AuthService.java:302-342; AuthController.java:97-102 (/2fa/setup needs full session)`
+
+### [dashboard] US-040 — contradicts_code
+AC 'Familie nicht fuer STUDENT sichtbar (da nicht selbst erstellbar)' is contradicted by code. The 'Familie' nav item is gated by auth.canHaveFamily, which is true for PARENT, STUDENT, OR SUPERADMIN (stores/auth.ts:53-55). STUDENT therefore DOES see the 'Familie' menu item in both AppSidebar (line 25-27) and BottomNav (line 19-21). Doc and code disagree on whether students see Familie.
+
+`frontend/src/stores/auth.ts:53-55; frontend/src/components/layout/AppSidebar.vue:25-27; frontend/src/components/layout/BottomNav.vue:19-21`
+
+### [raeume] US-050 — contradicts_code
+Acceptance criteria require that PARENT/STUDENT cannot create rooms (button hidden AND 'POST /api/v1/rooms als P -> HTTP 403'). The backend endpoint has NO role check: RoomController.create() only calls SecurityUtils.requireCurrentUserId() with no role gate, and SecurityConfig only enforces '.anyRequest().authenticated()' for /api/v1/rooms (no hasRole). There is no @PreAuthorize on RoomController. Any authenticated PARENT or STUDENT can call POST /api/v1/rooms and create a KLASSE/GRUPPE/PROJEKT room; the API returns 201, not 403. The RoomControllerIntegrationTest has no test asserting 403 for P/S. The frontend 'Raum erstellen' button on the Discover page is also unconditionally visible (DiscoverRoomsView.vue:182, no v-if, no auth store import) - though that button actually triggers createInterestRoom (intentionally open to all). The regular createRoom UI only lives in the admin-guarded AdminRooms.vue, but the unguarded backend endpoint still violates the AK.
+
+`backend/src/main/java/com/monteweb/room/internal/controller/RoomController.java:136-142; backend/src/main/java/com/monteweb/auth/internal/config/SecurityConfig.java:79-92; frontend/src/views/DiscoverRoomsView.vue:182`
+
+### [feed] US-071 — contradicts_code
+Doc: 'PARENT und STUDENT koennen keine Feed-Beitraege erstellen'. The backend does NOT enforce the role. FeedService.createPost() only checks room membership (roomModuleApi.isUserInRoom) for SourceType.ROOM, never the author's role. A PARENT or STUDENT who is a room member can create feed posts via POST /api/v1/feed/posts (sourceType=ROOM) or POST /api/v1/feed/rooms/{roomId}/posts. The role gate is frontend-only (PostComposer v-if="auth.isTeacher || auth.isAdmin").
+
+`backend/src/main/java/com/monteweb/feed/internal/service/FeedService.java:227-241 (createPost ROOM branch); FeedController.java:214-224 (createRoomPost)`
+
+### [feed] US-087 — contradicts_code
+Doc title 'Beitrag schulweit erstellen (nur SA)' and AK 'SourceType SCHOOL' / 'nur SA'. Backend permits TEACHER and Elternbeirat (not just SUPERADMIN) to create SCHOOL/SECTION posts: isStaff = SUPERADMIN || SECTION_ADMIN || TEACHER. Frontend DashboardView shows the SCHOOL PostComposer to every teacher (v-if="auth.isTeacher || auth.isAdmin") and creates sourceType:'SCHOOL'. So school-wide posting is NOT restricted to SA.
+
+`backend/src/main/java/com/monteweb/feed/internal/service/FeedService.java:242-251; frontend/src/views/DashboardView.vue:28-31,54-57`
+
+### [feed] US-081 — contradicts_code
+AK 'Banner koennen einen Link enthalten' is broken. GET /api/v1/feed/banners returns List<FeedPostInfo>, but FeedPostInfo has no link/expiresAt/bannerType fields. The frontend SystemBanner type and component read banner.link for click navigation, so banner.link is always undefined and the link never works. SystemBannerResponse DTO (with link/expiresAt/bannerType) exists but is never used by the controller.
+
+`backend FeedController.java:50-53 + FeedPostInfo.java:10-27 (no link field); frontend/src/components/feed/SystemBanner.vue:9-11 + types/feed.ts:63-70; unused DTO SystemBannerResponse.java`
+
+### [kalender] US-108 — not_implemented
+Recurring events are stored only as attributes (recurrence + recurrenceEnd on a single CalendarEvent row); there is NO occurrence expansion anywhere. Backend has no RRULE/expansion logic (grep for plusWeeks/occurrence/expand finds nothing in com.monteweb.calendar), and the frontend eventsByDate (CalendarView.vue:218-235) only spans startDate->endDate, never the recurrence. So a 'Woechentlicher Morgenkreis' set to WEEKLY appears exactly ONCE on its start date, not every week. AC 'Termine werden korrekt in der Kalenderansicht angezeigt' and 'Einzelne Wiederholungen koennen individuell bearbeitet/geloescht werden' are unmet.
+
+`backend/src/main/java/com/monteweb/calendar/internal/service/CalendarService.java:90-120; frontend/src/views/CalendarView.vue:218-235`
+
+### [kalender] US-114 — contradicts_code
+AC '[ ] API lehnt Jitsi-Anfragen ab, wenn Modul deaktiviert' is NOT enforced. POST/DELETE /api/v1/calendar/events/{id}/jitsi (CalendarController.java:102-114) and CalendarService.generateJitsiRoom/removeJitsiRoom (CalendarService.java:238-257) have no check on the jitsi DB toggle (admin.isModuleEnabled('jitsi')). The backend generates/removes a Jitsi room even when the toggle is off; only the frontend hides the button (EventDetailView.vue:239 jitsiEnabled()).
+
+`backend/src/main/java/com/monteweb/calendar/internal/controller/CalendarController.java:102-114`
+
+### [kalender] US-113 — contradicts_code
+AC 'Nur Terminersteller oder SUPERADMIN kann Videokonferenz hinzufuegen/entfernen' is violated on the backend. generateJitsiRoom/removeJitsiRoom only call checkReadAccess(event, userId) (CalendarService.java:242,253), so ANY user who can READ the event (any room member, any section member, or any authenticated user for SCHOOL events) can add/remove the Jitsi link. The creator/SUPERADMIN restriction exists only in the frontend canManage() (EventDetailView.vue:53-57).
+
+`backend/src/main/java/com/monteweb/calendar/internal/service/CalendarService.java:239-257`
+
+### [messaging] US-124 — partial
+Existing reactions are NOT returned when loading a conversation. MessagingService.getMessages() builds MessageInfo via toMessageInfo(...) which hardcodes the reactions list to List.of() (MessagingService.java:690, called from the page.map at lines 195-198). There is also no GET endpoint for a message's reactions - the only path that returns ReactionSummary is the toggle endpoint POST /messages/{id}/reactions. Frontend confirms this: MessagesView.vue only sets msg.reactions after the current user toggles (line 224), and messaging.api.ts has no get-reactions call. Result: on conversation open/reload, all pre-existing reactions (count and userReacted highlight) from any user are invisible until the current user toggles a reaction on that message. This breaks AC 'Zaehler zeigt Gesamtanzahl der Reaktionen pro Emoji' and 'Eigene Reaktionen sind visuell hervorgehoben'.
+
+`backend/src/main/java/com/monteweb/messaging/internal/service/MessagingService.java:690`
+
+### [messaging] US-127 — incorrect
+Parent-to-parent communication rules are bypassable via group conversations. enforceCommRules(...) is only invoked in startDirectConversation (MessagingService.java:122). startGroupConversation (lines 141-156) performs NO comm-rule check. The controller routes any request with isGroup=true (or participantIds.size()>1) to the group path (MessagingController.java:49-53). So with parentToParentMessaging DISABLED (the default), a PARENT can still create a group conversation containing other PARENTs and message them, defeating AC 'Bei deaktivierter Einstellung: Fehlermeldung fuer Eltern beim Versuch'.
+
+`backend/src/main/java/com/monteweb/messaging/internal/service/MessagingService.java:141`
+
+### [messaging] US-128 — incorrect
+Same root cause as US-127: student-to-student rule is only enforced in startDirectConversation, not in startGroupConversation. A STUDENT can create a group with other STUDENTs even when studentToStudentMessaging is disabled, bypassing the rule. enforceCommRules is never called for group creation (MessagingService.java:141-156).
+
+`backend/src/main/java/com/monteweb/messaging/internal/service/MessagingService.java:141`
+
+### [dateien] US-146 — contradicts_code
+Criterion 'Nur Ersteller, LEADER oder SUPERADMIN kann Ordner loeschen' is NOT enforced. FileService.deleteFolder only calls requireRoomMembership(userId, roomId) and then deletes; it performs NO creator/LEADER/admin check (FileService.java:274-295). ANY room member (including STUDENT/PARENT) can delete ANY folder. Worse, deletion is recursive and cascades: all files in the folder are removed from MinIO+DB and all sub-folders are deleted (FileService.java:281-292), so any member can wipe a leader's entire folder tree. This contradicts both US-146 (permission) and the 'leere Ordner' framing.
+
+`backend/src/main/java/com/monteweb/files/internal/service/FileService.java:274-295`
+
+### [formulare] US-173 — contradicts_code
+AC 'PARENT sieht keinen Formular-erstellen-Button' and 'STUDENT sieht keinen Button' are violated. FormsView renders the 'Formular erstellen' Button unconditionally with NO role check (no v-if on auth role). PARENT and STUDENT see the button and reach the create form. The backend correctly rejects creation (checkCreatePermission), so the API-side AC holds, but the documented UI behavior does not.
+
+`frontend/src/views/FormsView.vue:62-68`
+
+### [jobboard] US-205 — incorrect
+Confirm-Endpoint hat KEINE Rollenpruefung. PUT /jobs/assignments/{id}/confirm (JobboardController.java:182-187) ruft direkt jobboardService.confirmAssignment auf; die Service-Methode (JobboardService.java:476-509) prueft nur Status==COMPLETED und !confirmed, aber NICHT die Rolle des Bestaetigers. Damit kann jeder authentifizierte Nutzer (auch ein Elternteil oder Schueler) eine beliebige COMPLETED-Zuweisung bestaetigen und seiner Familie Stunden gutschreiben. Im Gegensatz dazu erzwingt der Reject-Endpoint (JobboardController.java:189-202) und pending-confirmation (204-215) korrekt TEACHER/SECTION_ADMIN/SUPERADMIN. Das Frontend blendet den Confirm-Button zwar fuer Nicht-Admins aus (JobDetailView.vue:385), aber die API ist die Sicherheitsgrenze.
+
+`backend/src/main/java/com/monteweb/jobboard/internal/controller/JobboardController.java:182`
+
+### [cleaning] US-230 — partial
+Steps 1-3 work: POST /cleaning/slots/{id}/swap sets swapOffered=true (offerSwap), and swap offers are listed. BUT step 4 'Registrierung wird auf den neuen Benutzer uebertragen' is NOT implemented — there is NO swap-takeover/transfer endpoint or service method anywhere. A second parent cannot take over the offered slot; they would have to manually unregister the offerer (impossible) and register themselves. Also AC/doc references a global GET /cleaning/slots/swaps list, but only a per-slot GET /cleaning/slots/{id}/swaps exists (findSwapOffersForSlot is slot-scoped), so swap offers are NOT discoverable across the section as the AC requires.
+
+`backend/src/main/java/com/monteweb/cleaning/internal/service/CleaningService.java:413-430`
+
+### [cleaning] US-231 — incorrect
+Role gate for pending-confirmation / confirm / reject only allows user.role() TEACHER, SECTION_ADMIN or SUPERADMIN. It does NOT accept the PUTZORGA or ELTERNBEIRAT special roles. So a dedicated Putz-Admin (PUTZORGA special role) who CAN create configs and generate slots (CleaningAdminController.requireCleaningAdmin accepts PUTZORGA/ELTERNBEIRAT) CANNOT confirm cleaning hours — contradicting 'Nur Putz-Admins koennen Stunden bestaetigen/ablehnen'. Also the doc shows POST .../confirm and POST .../reject, but the actual mappings are PUT /cleaning/registrations/{id}/confirm and PUT .../reject. Hours-gating itself is correct: sumActualMinutesByFamilyInRange counts only confirmed=true rows. No CleaningCompletedEvent is published on confirm (it is published on checkout instead).
+
+`backend/src/main/java/com/monteweb/cleaning/internal/controller/CleaningController.java:112-152`
+
+### [cleaning] US-232 — contradicts_code
+AC says 'Nur Putz-Admins koennen Minuten anpassen'. The implementation does the OPPOSITE: PUT /cleaning/registrations/{id}/update-minutes has NO admin role check in the controller, and the service updateRegistrationMinutes enforces owner-only ('if (!reg.getUserId().equals(userId)) throw "Can only update own registration"'). So an admin CANNOT correct another participant's minutes, while the participant CAN edit their own. Also requires checkedOut=true first, and the documented path /registrations/{id}/minutes is actually /registrations/{id}/update-minutes. durationConfirmed=true is set correctly.
+
+`backend/src/main/java/com/monteweb/cleaning/internal/service/CleaningService.java:541-558`
+
+### [cleaning] US-233 — partial
+cancelSlot sets cancelled=true and status=CANCELLED and registration for cancelled slots is blocked (correct). BUT two ACs are NOT met: (1) cancelReason is NEVER set — the DELETE /cleaning/slots/{id} endpoint accepts no body/reason and cancelSlot(UUID) takes no reason argument, even though the entity has a cancel_reason column; (2) registered participants are NOT notified — no event/notification is published on cancel. Doc path is also wrong (DELETE /cleaning/slots/{id}, not PUT /admin/slots/{id}/cancel).
+
+`backend/src/main/java/com/monteweb/cleaning/internal/service/CleaningService.java:624-631`
+
+### [fundgrube] US-272 — contradicts_code
+Section filter EXCLUDES school-wide (sectionId=null) items, directly contradicting AC 'Gegenstaende ohne sectionId sind schulweit sichtbar' and step 3 'Dieser erscheint bei ALLEN Bereichsfiltern (schulweit)'. Repo query findActiveBySectionId uses 'WHERE i.sectionId = :sectionId AND (i.expiresAt IS NULL OR i.expiresAt > :now)' which only matches items whose sectionId equals the filter; null-section items never appear when a section filter is applied.
+
+`backend/src/main/java/com/monteweb/fundgrube/internal/repository/FundgrubeItemRepository.java:18`
+
+### [fundgrube] US-281 — contradicts_code
+Step 2 / AC 'Mit sectionId-Filter: nur Gegenstaende des Bereichs + schulweite (sectionId=null) werden angezeigt' is not satisfied. Same root cause as US-272: findActiveBySectionId returns ONLY items with sectionId = filter and never includes school-wide null-section items. Sorting newest-first (ORDER BY createdAt DESC) and unfiltered all-items listing are correct.
+
+`backend/src/main/java/com/monteweb/fundgrube/internal/repository/FundgrubeItemRepository.java:18`
+
+### [tasks] US-309 — partial
+Column RENAME is not implemented in the frontend. Test steps 3-5 (Stift-Icon edit, change name, save via PUT .../columns/{columnId}) cannot be performed: the Column Management Dialog (lines 665-695) only offers add + delete (trash icon), there is no edit/pencil control, and tasksApi.updateColumn is never called anywhere in the component. The backend endpoint PUT /columns/{columnId} and tasksApi.updateColumn exist but are dead/unused from the UI.
+
+`frontend/src/components/rooms/RoomTasks.vue:665-695`
+
+### [bookmarks] US-316 — incorrect
+AC 'Bookmark-Status wird beim Laden der Jobliste mitgeladen' is not implemented. The BookmarkButton is only placed in JobDetailView.vue:235 (single job detail), NOT in the job LIST (JobboardView.vue has zero bookmark references). The documented step 'Jobboerse oeffnen -> Lesezeichen-Icon an einem Job klicken' cannot be done from the list. Additionally loadBookmarkedIds('JOB') is never invoked, so even the detail-view icon does not reflect persisted bookmark status on load.
+
+`frontend/src/views/JobboardView.vue (no bookmark UI); frontend/src/views/JobDetailView.vue:235; frontend/src/stores/bookmarks.ts:25`
+
+### [bookmarks] US-317 — not_implemented
+Wiki bookmarking has NO frontend UI. RoomWiki.vue (the only wiki view) contains no BookmarkButton and no bookmark logic (grep for 'bookmark' returns nothing). A user cannot set a bookmark on a wiki page from the UI, so US-317 step 'Lesezeichen-Icon klicken' is impossible. Backend supports the type, but it is unreachable through the product.
+
+`frontend/src/components/rooms/RoomWiki.vue (no bookmark integration)`
+
+### [bookmarks] US-318 — incorrect
+AC 'Jeder Bookmark zeigt Titel und Typ an' is not met: BookmarkInfo (BookmarkInfo.java:9) contains only id/userId/contentType/contentId/createdAt — NO title. BookmarksView.vue renders only a type Tag + date (lines 109-110), never a title, and never resolves one from the source module. Bookmarks are shown as anonymous type+timestamp rows.
+
+`backend/src/main/java/com/monteweb/bookmark/BookmarkInfo.java:9; frontend/src/views/BookmarksView.vue:108-111`
+
+### [suche] US-323 — contradicts_code
+Akzeptanzkriterium 'Tika-Extraktion fuer Dateiinhalte (PDF, DOCX etc.)' und Testschritt 5 ('Tika-Extraktion findet Text innerhalb von Dokumenten') sind im Code nicht aktiv. Die einzige Methode, die Dateiinhalt an Solrs /update/extract (Tika ExtractingRequestHandler) streamt, ist indexFileWithContent(...) in SolrIndexingService.java:146 - sie wird aber NIRGENDS aufgerufen (grep ergibt nur die Definition). Der Upload-Listener onFileUploaded ruft trotz Pruefung auf isExtractable() immer nur indexFile(...) auf (nur Metadaten), siehe SolrIndexingListener.java:75 und 85-86. Auch reindexFiles() (SolrIndexingService.java:303-324) indexiert nur Metadaten. Das schema.xml-Feld 'file_content' und der ExtractingRequestHandler in solrconfig.xml existieren, werden aber nie befuellt. PDF-/DOCX-Volltextsuche funktioniert daher nicht.
+
+`backend/src/main/java/com/monteweb/search/internal/service/SolrIndexingListener.java:64-87 + SolrIndexingService.java:146 (nie aufgerufen)`
+
+### [suche] US-324 — partial
+Akzeptanzkriterium 'Filter nach Typ funktioniert auch mit DB-Fallback' (Testschritt 4) ist nur teilweise erfuellt. Der DB-Fallback SearchService.searchDatabase() (Zeilen 56-85) durchsucht nur USER, ROOM, POST, EVENT. Die Typen FILE, WIKI, TASK werden im DB-Fallback gar nicht behandelt - es gibt keine searchFiles/searchWiki/searchTasks-Methoden. Filtert ein Benutzer bei deaktiviertem Solr nach 'Dateien', 'Wiki' oder 'Aufgaben' (Filter-Chips existieren laut US-320), bekommt er still ein leeres Ergebnis ohne Hinweis. Solr (SolrSearchService) unterstuetzt diese 3 Typen dagegen voll.
+
+`backend/src/main/java/com/monteweb/search/internal/service/SearchService.java:56-85`
+
+### [notifications] US-330 — not_implemented
+Step 2 claims 'Kommentar zu einem Post -> Autor erhaelt COMMENT-Benachrichtigung | Typ: COMMENT'. The NotificationType.COMMENT enum constant exists (NotificationType.java:8) but is NEVER emitted anywhere in the backend (grep for NotificationType.COMMENT yields zero usages outside the enum). The FeedCommentCreatedEvent is consumed ONLY by MentionNotificationListener.onFeedCommentCreated (MentionNotificationListener.java:50-69) which sends NotificationType.MENTION to mentioned users, not a COMMENT notification to the post author. No listener notifies a post author when their post receives a comment.
+
+`backend/src/main/java/com/monteweb/notification/internal/service/MentionNotificationListener.java:50; backend/src/main/java/com/monteweb/notification/NotificationType.java:8`
+
+### [familie] US-333 — partial
+AC 'Ein Elternteil kann nur einem Familienverbund angehoeren' is only enforced on create() (FamilyService.java:82-85). It is NOT enforced when a PARENT accepts an invitation (acceptInvitation, FamilyService.java:322-355) or joins via invite code (joinByInviteCode, FamilyService.java:113-133). Both paths only call assertCanJoinFamily() which solely blocks TEACHER/SECTION_ADMIN (FamilyService.java:375-384) and then check membership of THIS family. A parent already in family A can accept a PARENT-role invitation to family B, ending up in two families, contradicting the acceptance criterion.
+
+`backend/src/main/java/com/monteweb/family/internal/service/FamilyService.java:322,113,375`
+
+### [admin] US-341 — incorrect
+AC 'Mindestens ein SUPERADMIN muss im System bleiben' is NOT enforced. UserService.updateRole (line 352-356) blindly sets the new role with no check that at least one SUPERADMIN remains. An admin can demote the last/only SUPERADMIN (including themselves), locking everyone out of admin functions. No guard exists anywhere (grep for min-superadmin/last-admin guards returns nothing in user module).
+
+`backend/src/main/java/com/monteweb/user/internal/service/UserService.java:352`
+
+### [admin] US-342 — incorrect
+AC 'Admin kann sich nicht selbst sperren' is NOT enforced. AdminUserController.setActive (line 78-84) and UserService.setActive (line 360-364) accept any user id including the current admin's own id; there is no self-deactivation guard. (Login rejection of inactive users IS correct via AuthService.java:121, and the toggle is reversible.)
+
+`backend/src/main/java/com/monteweb/user/internal/service/UserService.java:360; backend/src/main/java/com/monteweb/user/internal/controller/AdminUserController.java:78`
+
+### [admin] US-348 — contradicts_code
+AC 'Audit-Log protokolliert sicherheitsrelevante Aktionen' is effectively not implemented. AuditService.log() (line 23-27) is the ONLY writer to the audit_log table, and it is NEVER called anywhere in the codebase (grep for auditService.log / new AuditLogEntry returns only AuditService itself). The GET /api/v1/admin/audit-log endpoint therefore always returns an empty page. Additionally: (a) AuditService.findAll(pageable) supports NO filtering, contradicting AC/test-step-4 'Filtern nach Zeitraum oder Aktion'; (b) there is no frontend view consuming the endpoint (no AdminAuditLog.vue, no getAuditLog API call; only an unused i18n key 'auditLog'). Note: DSGVO logDataAccess writes to a SEPARATE data_access_log table, not this audit_log.
+
+`backend/src/main/java/com/monteweb/admin/internal/service/AuditService.java:23; backend/src/main/java/com/monteweb/admin/internal/controller/AdminConfigController.java:131`
+
+### [crosscutting] US-371 — contradicts_code
+Acceptance criterion 'Alle Aktionen waehrend Impersonation werden im Audit-Log dem Admin zugeordnet' is NOT enforced. In JwtAuthenticationFilter.authenticateWithJwt (lines 77-86) the SecurityContext principal is set to the TARGET user's ID; the admin's id is only stored as a request attribute 'impersonatedBy' (line 85) and never consumed by the audit layer. AuditService.log (line 24-26) records whatever userId it is given, and controllers pass SecurityUtils.requireCurrentUserId(), which during impersonation returns the impersonated (target) user, not the admin. Therefore actions performed while impersonating are attributed to the target user, not the admin. The only admin attribution is a plain log.info at IMPERSONATION_START/STOP (AuthService.java:381,392), which is not a structured audit-log entry.
+
+`backend/src/main/java/com/monteweb/auth/internal/config/JwtAuthenticationFilter.java:77-86; backend/src/main/java/com/monteweb/auth/internal/service/AuthService.java:380-398; backend/src/main/java/com/monteweb/admin/internal/service/AuditService.java:24-26`
+
+## Umsetzungs-Abweichungen — MEDIUM (Kurzliste)
+
+- **[auth] US-008** (contradicts_code): Acceptance demands the inactive (not-yet-approved) user sees 'Ihr Konto wartet auf Freischaltung durch einen Administrator.' The backend intentionally throws a GENERIC 'Invalid credentials' for inacti
+- **[profil] US-025** (partial): Akzeptanzkriterium 'Vorname und Nachname sind Pflichtfelder' wird NICHT erzwungen. Backend UpdateProfileRequest hat nur @Size(max=100), kein @NotBlank/@NotNull. UserService.updateProfile setzt Werte n
+- **[profil] US-027** (contradicts_code): Akzeptanzkriterium 'Profilbild wird aus MinIO geloescht' stimmt nicht mit der Implementierung ueberein. Avatare werden NICHT in MinIO gespeichert, sondern als Base64-Data-URL direkt in users.avatar_ur
+- **[profil] US-028** (partial): Akzeptanzkriterium 'Dark Mode ist auch auf der Login-Seite waehlbar' ist NICHT erfuellt. LoginView.vue enthaelt nur den LanguageSwitcher (Zeile 306), aber keinerlei Dark-Mode-/Erscheinungsbild-Auswahl
+- **[dashboard] US-037** (contradicts_code): AC3 'Banner werden kontextabhaengig angezeigt (Putz-Banner nur fuer betroffene Eltern)' is NOT enforced. The /banners endpoint takes no user context (FeedController.getActiveBanners has no userId para
+- **[dashboard] US-041** (partial): AC 'Backend-Endpunkte deaktivierter Module geben 404 zurueck' is not satisfied by the runtime Admin-UI toggle. The Admin Modules toggle (AdminModules.vue -> admin.updateModules) writes to tenant_confi
+- **[raeume] US-056** (partial): Two AK not met. (1) 'Entfernung erfordert Bestaetigung' / step 7 'Dialog: Mitglied wirklich entfernen?' is NOT implemented: removeMemberFromRoom() (RoomDetailView.vue:387) calls roomsApi.removeMember 
+- **[raeume] US-060** (partial): The 'Neue Diskussion' button is shown only v-if="isLeader" where isLeader = (member.role==='LEADER' || auth.isAdmin) (RoomDiscussions.vue:57,99). This ignores two creator rules that the backend DOES e
+- **[feed] US-070** (partial): T/SA can create room posts (works), but the acceptance criterion implicitly requires only T/SA. Backend enforces only membership, not the TEACHER/SECTION_ADMIN/SUPERADMIN role for ROOM posts, so the r
+- **[feed] US-083** (partial): AK requires color-coded source-type labels (Raum/Schulbereich/Schulweit/Pinnwand/System) and 'Klick auf Raum-Label navigiert zum Raum'. FeedPost.vue only renders 'in <em>{{ post.sourceName }}</em>' wi
+- **[feed] US-081** (partial): Banner infrastructure exists (getActiveSystemBanners returns pinned SYSTEM posts with expiresAt filtering), but (a) no backend code path ever creates a system banner - no module calls FeedModuleApi.cr
+- **[feed] US-080** (partial): Targeted-post VISIBILITY is enforced (personal feed query: target_user_ids IS NULL OR userId = ANY(...); verifyPostReadAccess/verifyPostAccess check targetUserIds). But there is NO user-facing way for
+- **[feed] US-086** (contradicts_code): AK: 'Titel allein reicht nicht aus' - a title-only post must NOT be allowed. Backend createPost validation explicitly ALLOWS a title-only post: it only throws when content is blank AND poll is null AN
+- **[feed] US-075** (partial): AK 'Nur T und SA koennen pinnen' / room context. Backend togglePin allows admins (SUPERADMIN/SECTION_ADMIN) and room LEADERs to pin (correct, broadly). But the frontend pin button is shown only with v
+- **[kalender] US-105** (contradicts_code): AC 'Nur Ersteller oder SUPERADMIN kann einen Termin absagen' contradicts the code. cancelEvent calls checkCreatePermission(scope, scopeId, userId) (CalendarService.java:148), which grants ANY user wit
+- **[kalender] US-105** (partial): Two AC mismatches: (1) AC says the cancellation feed post should reach 'alle Benutzer im Termin-Scope', but CalendarFeedListener.onEventCancelled always creates a SCHOOL-wide post (feedModule.createSy
+- **[kalender] US-106** (contradicts_code): AC 'Nur Ersteller oder SUPERADMIN kann loeschen' contradicts the code. deleteEvent uses checkCreatePermission(scope, scopeId, userId) (CalendarService.java:168), so any user with scope create rights (
+- **[kalender] US-107** (contradicts_code): AC 'Nur Ersteller oder SUPERADMIN kann bearbeiten' contradicts the code. updateEvent uses checkCreatePermission(event.getScope(), event.getScopeId(), userId) (CalendarService.java:126), so any user wi
+- **[kalender] US-116** (partial): AC 'Toggles sind persistent (bleiben nach Seitenneuladen erhalten)' is NOT met. showCleaning, showImported and showJobs are plain refs with hardcoded defaults (CalendarView.vue:40-42) and are never wr
+- **[messaging] US-121** (partial): AC 'Mindestens 2 Empfaenger muessen ausgewaehlt werden fuer Gruppenkonversation' is enforced ONLY in the frontend (NewMessageDialog.vue:33 canStart requires selectedUsers.length >= 2). Backend startGr
+- **[messaging] US-133** (partial): AC 'Direkter URL-Zugriff wird abgefangen' is not implemented client-side. The /messages route (router/index.ts:69) has NO module guard/beforeEnter; only the sidebar/bottom-nav links are conditionally 
+- **[dateien] US-140** (contradicts_code): Acceptance criterion says max file size is configurable via tenant_config.max_upload_size_mb (default 50 MB). The code does NOT read the configurable value: FileService.uploadFile enforces a hardcoded
+- **[dateien] US-143** (partial): Criterion 'Dateien innerhalb des Ordners erben die Sichtbarkeit' (files inherit folder visibility) is NOT enforced. File audience is independent of the containing folder: uploadFile sets audience pure
+- **[formulare] US-160** (partial): AC 'Optionen sind Pflicht fuer Einfach-/Mehrfachauswahl' is not enforced. Neither backend nor frontend validates that SINGLE_CHOICE/MULTIPLE_CHOICE questions have any options. QuestionRequest has no @
+- **[formulare] US-167** (incorrect): AC 'Zusammenfassung zeigt Ruecklaufquote (Antworten / Zielgruppe)' is broken for SECTION and SCHOOL forms. calculateTargetCount only returns a value for ROOM scope (room member count); for SECTION and
+- **[formulare] US-172** (not_implemented): AC 'targetCount zeigt Gesamtzahl aller Benutzer' for school-wide forms is not implemented. calculateTargetCount returns 0 for FormScope.SCHOOL (only ROOM is computed via roomModule.getMemberUserIds). 
+- **[formulare] US-177** (partial): ACs 'Visueller Hinweis Frist abgelaufen auf dem Formular' and 'Button Antwort absenden ist deaktiviert' are not implemented in FormDetailView. For a still-PUBLISHED form whose deadline has passed and 
+- **[formulare] US-181** (partial): AC 'Einfach-/Mehrfachauswahl benoetigt mindestens 2 Optionen' is not enforced anywhere (no min-options validation in backend QuestionRequest/saveQuestions/publishForm nor in frontend buildQuestionRequ
+- **[cleaning] US-235** (partial): Room LEADER can create configs for their room (requireRoomLeaderOrCleaningAdmin checks RoomRole.LEADER) and roomId is persisted/slots carry sectionId — OK. BUT 'Nur Mitglieder des definierten Kreises 
+- **[fotobox] US-257** (doc_outdated): Doc states the delete-image endpoint is DELETE /api/v1/rooms/{roomId}/fotobox/images/{imageId} (with roomId). The actual controller mapping is DELETE /api/v1/fotobox/images/{imageId} (NO roomId path s
+- **[fotobox] US-260** (doc_outdated): Doc states the caption-update endpoint is PUT /api/v1/rooms/{roomId}/fotobox/images/{imageId} (with roomId). The actual controller mapping is PUT /api/v1/fotobox/images/{imageId} (NO roomId path segme
+- **[fotobox] US-260** (partial): Caption-update (US-260) is implemented in the backend (FotoboxService.updateImage / PUT /fotobox/images/{imageId}) but there is NO frontend wiring for it: fotobox.api.ts has no updateImage method, the
+- **[fotobox] US-259** (partial): Thread editing (title/description) is implemented in the backend (FotoboxService.updateThread / PUT /rooms/{roomId}/fotobox/threads/{threadId}, owner-or-leader enforced) but there is NO frontend suppo
+- **[fundgrube] US-272** (not_implemented): AC 'Bereits beanspruchte (claimed) Gegenstaende koennen separat gefiltert werden' is not implemented. listItems(sectionId) only accepts a sectionId param; there is no parameter to filter/show claimed 
+- **[fundgrube] US-278** (partial): AC 'Bilder werden als Thumbnails mit Lightbox-Funktion angezeigt' and step 3 'Klick auf Thumbnail zeigt Originalbild' are not implemented. The detail dialog renders thumbnail <img> elements (thumbnail
+- **[wiki] US-302** (not_implemented): Akzeptanzkriterium 'Slug kann optional geaendert werden' ist NICHT implementiert. UpdatePageRequest enthaelt nur title und content (kein slug-Feld). WikiService.updatePage (Zeilen 177-199) setzt aussc
+- **[wiki] US-305** (partial): Backend unterstuetzt beliebig tiefe Hierarchie (parent_id self-FK in V077; createPage validiert nur, dass parent im selben Raum liegt). ABER (a) der Frontend-Baum rendert nur ZWEI Ebenen: Template ite
+- **[tasks] US-309** (partial): Acceptance criterion 'Bestaetigung-Dialog bei Loeschung' (confirmation dialog before deleting a column) is not implemented. deleteColumn() calls tasksApi.deleteColumn immediately on trash-icon click w
+- **[tasks] US-312** (partial): Acceptance criterion 'Tasks koennen geloescht werden mit Bestaetigung' is only partially met: the delete action exists but there is NO confirmation dialog. deleteTask() in the edit dialog calls tasksA
+- **[bookmarks] US-314** (partial): Toggle + visual icon switch works during the current session, but the initial bookmarked state is NEVER loaded. The store method loadBookmarkedIds() (frontend/src/stores/bookmarks.ts:25) is defined bu
+- **[bookmarks] US-318** (incorrect): AC 'Klick auf Bookmark navigiert zum Originalinhalt' fails for POST and WIKI_PAGE. typeRoute() (BookmarksView.vue:37-45) maps POST -> {name:'dashboard'} and WIKI_PAGE -> {name:'dashboard'} instead of 
+- **[suche] US-323** (partial): Akzeptanzkriterium 'Echtzeit-Indexierung via Spring Events bei Erstellung/Aenderung' fuer alle 7 Typen ist nicht vollstaendig. SolrIndexingListener hat @ApplicationModuleListener nur fuer POST (create
+- **[notifications] US-325** (partial): Step 3 requires 'Titel, Nachricht, Typ-Icon und Zeitstempel je Eintrag'. The NotificationBell.vue list renders title (n.title), message (n.message) and timestamp (formatTime(n.createdAt)) but renders 
+- **[notifications] US-330** (partial): Acceptance criterion 'Jeder Typ hat passendes Icon und Beschreibung' is only half met. A per-notification German 'message' (description) is generated by the backend listeners, but there is NO per-type
+- **[familie] US-337** (contradicts_code): AC states 'Nur SUPERADMIN kann diese Aktionen durchfuehren' for hours-exempt and active toggles. The code permits SECTION_ADMIN as well, both at the controller (@PreAuthorize("hasAnyRole('SUPERADMIN',
+- **[admin] US-340** (partial): AC 'Datenzugriff wird im Data-Access-Log protokolliert (DSGVO)' is NOT met for the profile edit. AdminUserController.updateProfile (line 62-68) and UserService.adminUpdateProfile (line 301-314) never 
+- **[admin] US-344** (partial): AC/test step 6 'Maximale Upload-Groesse aendern (max_upload_size_mb)' is NOT supported. The field maxUploadSizeMb exists on TenantConfig (entity line 102-103, default 50) but is absent from UpdateConf
+- **[admin] US-350** (partial): Analytics implementation is incomplete vs ACs. AnalyticsService.getAnalytics (line 18-33) returns totalUsers, activeUsers, rooms, posts, events, messages, postsThisMonth, newThisWeek. MISSING: (a) AC 
+- **[admin] US-352** (partial): AC 'Audit-Log protokolliert Start und Ende der Impersonation' is NOT met. AuthService.startImpersonation (line 380-382) and stopImpersonation (line 392) only emit log.info(...) to the application log;
+- **[dsgvo] US-360** (incorrect): AK 'IP-Adresse wird bei Akzeptanz protokolliert': The IP address is NOT taken from the actual request (request.getRemoteAddr()/X-Forwarded-For). PrivacyController.acceptTerms reads it from the client-
+- **[dsgvo] US-364** (partial): AK 'Nach Ablauf der Frist ist Abbruch nicht mehr moeglich': cancelDeletion only guards 'if (user.getDeletionRequestedAt() == null) throw'. It does NOT check whether scheduledDeletionAt is already in t
+- **[crosscutting] US-370** (doc_outdated): Story documents the maintenance toggle endpoint as 'PUT /api/v1/admin/maintenance' (step 4) and implies it sets the modules JSONB toggle 'maintenance: true' (step 2). The actual endpoint is 'PUT /api/
+- **[gap-coverage] US-230 (Putz-Orga: Swap-Angebot)** (contradicts_code): Step 3 and acceptance criteria reference 'GET /api/v1/cleaning/slots/swaps' as a collection of all swap offers visible to other parents of the same Bereich. No such endpoint exists. CleaningController
+
+## Empfehlung / Triage
+
+1. **Echte Sicherheits-/Authz-Bugs** (fehlende Rollenprüfung bei Raum/Feed/Ordner/Confirm/Putz-Minuten, Komm-Regeln-Bypass via Gruppen, letzter-SUPERADMIN/Self-Lockout) → fixen (gleiche Klasse wie Phase-1-Security).
+2. **`doc_outdated`** → Doku aktualisieren, Code belassen.
+3. **Fehlende Features** (Recurring-Events-Expansion, Wiki-Bookmark-UI, Comment-Notification, Spalten-Rename-UI) → Backlog.
+4. **Undokumentierte Module/Features** → Doku ergänzen (v. a. parentletter eigener Abschnitt).

--- a/e2e/fixtures/test-accounts.ts
+++ b/e2e/fixtures/test-accounts.ts
@@ -7,8 +7,10 @@ export interface TestAccount {
 
 export const accounts: Record<string, TestAccount> = {
   admin: {
+    // V111 resets the seeded admin to the common test password (V032 set admin123,
+    // but the latest migration normalises it to test1234 in the migrated DB).
     email: 'admin@monteweb.local',
-    password: 'admin123',
+    password: 'test1234',
     role: 'SUPERADMIN',
     displayName: 'Admin User',
   },

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,7 +1,7 @@
 import { type Page, type BrowserContext, expect } from '@playwright/test'
 import { accounts, type TestAccount } from '../fixtures/test-accounts'
 
-const BASE = 'http://localhost'
+const BASE = process.env.BASE_URL || 'http://localhost'
 
 /**
  * Login via API and inject token into sessionStorage.

--- a/e2e/tests/bookmarks-search/bookmarks-search.test.ts
+++ b/e2e/tests/bookmarks-search/bookmarks-search.test.ts
@@ -8,7 +8,7 @@ import { selectors } from '../../helpers/selectors'
 
 type Page = import('@playwright/test').Page
 
-const BASE = 'http://localhost'
+const BASE = process.env.BASE_URL || 'http://localhost'
 
 // ---------------------------------------------------------------------------
 // Token cache — avoids hitting rate limits by reusing tokens per user

--- a/e2e/tests/notifications/notifications.test.ts
+++ b/e2e/tests/notifications/notifications.test.ts
@@ -140,7 +140,7 @@ async function findFirstNotification(
 // US-325: In-App-Benachrichtigungsliste
 // ============================================================================
 test.describe('US-325: In-App-Benachrichtigungsliste', () => {
-  test.use({ storageState: 'e2e/.auth/parent.json' })
+  test.use({ storageState: 'auth-states/parent.json' })
 
   test('GET /notifications returns paginated list', async ({ page }) => {
     await login(page, accounts.parent)
@@ -285,7 +285,7 @@ test.describe('US-325: In-App-Benachrichtigungsliste', () => {
 // US-326: Unread-Count Badge
 // ============================================================================
 test.describe('US-326: Unread-Count Badge', () => {
-  test.use({ storageState: 'e2e/.auth/parent.json' })
+  test.use({ storageState: 'auth-states/parent.json' })
 
   test('GET /notifications/unread-count returns numeric count', async ({ page }) => {
     await login(page, accounts.parent)
@@ -358,7 +358,7 @@ test.describe('US-326: Unread-Count Badge', () => {
 // US-327: Benachrichtigung als gelesen markieren
 // ============================================================================
 test.describe('US-327: Benachrichtigung als gelesen markieren', () => {
-  test.use({ storageState: 'e2e/.auth/parent.json' })
+  test.use({ storageState: 'auth-states/parent.json' })
 
   test('PUT /notifications/{id}/read marks a single notification as read', async ({ page }) => {
     await login(page, accounts.parent)
@@ -430,7 +430,7 @@ test.describe('US-327: Benachrichtigung als gelesen markieren', () => {
 // US-328: Alle als gelesen markieren
 // ============================================================================
 test.describe('US-328: Alle als gelesen markieren', () => {
-  test.use({ storageState: 'e2e/.auth/parent.json' })
+  test.use({ storageState: 'auth-states/parent.json' })
 
   test('PUT /notifications/read-all marks all notifications as read', async ({ page }) => {
     await login(page, accounts.parent)
@@ -518,7 +518,7 @@ test.describe('US-328: Alle als gelesen markieren', () => {
 // US-329: Benachrichtigung loeschen
 // ============================================================================
 test.describe('US-329: Benachrichtigung loeschen', () => {
-  test.use({ storageState: 'e2e/.auth/parent.json' })
+  test.use({ storageState: 'auth-states/parent.json' })
 
   test('DELETE /notifications/{id} removes notification from list', async ({ page }) => {
     await login(page, accounts.parent)
@@ -657,7 +657,7 @@ test.describe('US-329: Benachrichtigung loeschen', () => {
 // US-330: Benachrichtigungstypen
 // ============================================================================
 test.describe('US-330: Benachrichtigungstypen', () => {
-  test.use({ storageState: 'e2e/.auth/parent.json' })
+  test.use({ storageState: 'auth-states/parent.json' })
 
   // Triggering various notification types requires cross-module events
   // (e.g., creating a room join request, publishing a form, sending a message).
@@ -677,7 +677,7 @@ test.describe('US-330: Benachrichtigungstypen', () => {
 // US-331: Push-Benachrichtigungen
 // ============================================================================
 test.describe('US-331: Push-Benachrichtigungen', () => {
-  test.use({ storageState: 'e2e/.auth/parent.json' })
+  test.use({ storageState: 'auth-states/parent.json' })
 
   // Push notifications require:
   // 1. Browser push permission grant (not automatable in headless Playwright)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,6 +6,16 @@ log_format dsgvo '$masked_ip - $remote_user [$time_local] '
                  '"$request" $status $body_bytes_sent '
                  '"$http_referer" "$http_user_agent"';
 
+# Real client IP for per-client rate limiting (forwarded as X-Real-IP).
+# Prefer Cloudflare's CF-Connecting-IP; fall back to the direct peer for
+# non-Cloudflare deployments. Without this, every request arriving via the
+# Cloudflare Tunnel shares one $remote_addr and collapses into a single
+# rate-limit bucket (one abuser locks out everyone).
+map $http_cf_connecting_ip $real_client_ip {
+    ""      $remote_addr;
+    default $http_cf_connecting_ip;
+}
+
 server {
     listen 80;
     server_name _;
@@ -45,7 +55,7 @@ server {
     location /api/ {
         proxy_pass http://backend:8080/api/;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $real_client_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 50m;
@@ -58,7 +68,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $real_client_ip;
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,14 +26,14 @@
         "@pinia/testing": "^1.0.3",
         "@types/node": "^25.3.0",
         "@vitejs/plugin-vue": "^6.0.2",
-        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/coverage-v8": "^4.1.8",
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.8.1",
         "jsdom": "^28.1.0",
         "typescript": "~5.9.3",
-        "vite": "^7.3.1",
+        "vite": "^7.3.5",
         "vite-plugin-pwa": "^1.2.0",
-        "vitest": "^4.0.18",
+        "vitest": "^4.1.8",
         "vitest-axe": "^0.1.0",
         "vue-tsc": "^3.2.5"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@types/dompurify": "^3.0.5",
         "@types/qrcode": "^1.5.6",
         "axios": "^1.13.5",
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.3.2",
         "pinia": "^3.0.4",
         "primeicons": "^7.0.0",
         "primevue": "^4.5.4",
@@ -46,14 +46,13 @@
       "license": "MIT"
     },
     "node_modules/@apideck/better-ajv-errors": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.6.tgz",
-      "integrity": "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
+      "integrity": "sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-schema": "^0.4.0",
-        "jsonpointer": "^5.0.0",
+        "jsonpointer": "^5.0.1",
         "leven": "^3.1.0"
       },
       "engines": {
@@ -64,27 +63,20 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.0.0",
-        "@csstools/css-color-parser": "^4.0.1",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.5"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
@@ -101,14 +93,14 @@
         "lru-cache": "^11.2.6"
       }
     },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -119,13 +111,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -133,10 +125,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -144,21 +143,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -174,14 +173,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+    "node_modules/@babel/core/node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -190,28 +190,101 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.6.tgz",
+      "integrity": "sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0-rc.6",
+        "@babel/types": "^8.0.0-rc.6",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.6.tgz",
+      "integrity": "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.6.tgz",
+      "integrity": "sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/parser": {
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.6.tgz",
+      "integrity": "sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0-rc.6"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/types": {
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.6.tgz",
+      "integrity": "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0-rc.6",
+        "@babel/helper-validator-identifier": "^8.0.0-rc.6"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -220,19 +293,39 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -242,14 +335,24 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
-      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
         "regexpu-core": "^6.3.1",
         "semver": "^6.3.1"
       },
@@ -260,10 +363,20 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
-      "integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -278,9 +391,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -288,43 +401,43 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
-      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -334,22 +447,22 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -357,15 +470,15 @@
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
-      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-wrap-function": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-wrap-function": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -375,15 +488,15 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
-      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -393,41 +506,41 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -435,41 +548,41 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
-      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
+      "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -479,14 +592,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
-      "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
+      "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -496,13 +609,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
-      "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
+      "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -512,13 +625,30 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
-      "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
+      "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
+      "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -528,15 +658,15 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
-      "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -546,14 +676,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
-      "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
+      "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -576,13 +706,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
-      "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
+      "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -592,13 +722,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -625,13 +755,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
-      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -641,15 +771,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
-      "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
+      "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.29.0"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -659,15 +789,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
-      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -677,13 +807,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
-      "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
+      "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -693,13 +823,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
-      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
+      "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -709,14 +839,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
-      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -726,14 +856,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
-      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
+      "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -743,18 +873,18 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
-      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
+      "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -764,14 +894,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
-      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
+      "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/template": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/template": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -781,14 +911,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
-      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -798,14 +928,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
-      "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
+      "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -815,13 +945,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
-      "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
+      "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -831,14 +961,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
-      "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -848,13 +978,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
-      "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
+      "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -864,14 +994,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-explicit-resource-management": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
-      "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -881,13 +1011,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
-      "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
+      "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -897,13 +1027,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
-      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
+      "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -913,14 +1043,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
-      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
+      "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -930,15 +1060,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
-      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
+      "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -948,13 +1078,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
-      "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
+      "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -964,13 +1094,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
-      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
+      "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -980,13 +1110,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
-      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
+      "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -996,13 +1126,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
-      "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
+      "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1012,14 +1142,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
-      "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
+      "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1029,14 +1159,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
-      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1046,16 +1176,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.29.0"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1065,14 +1195,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
-      "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
+      "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1082,14 +1212,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
-      "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1099,13 +1229,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
-      "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
+      "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1115,13 +1245,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
-      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1131,13 +1261,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
-      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
+      "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1147,17 +1277,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
-      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
+      "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5",
-        "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1167,14 +1297,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
-      "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
+      "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1184,13 +1314,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
-      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
+      "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1200,14 +1330,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
-      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1217,13 +1347,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.27.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
-      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
+      "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1233,14 +1363,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
-      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1250,15 +1380,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
-      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
+      "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1268,13 +1398,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
-      "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
+      "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1284,13 +1414,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
-      "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
+      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1300,14 +1430,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
-      "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
+      "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1317,13 +1447,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
-      "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
+      "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1333,13 +1463,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
-      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
+      "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1349,14 +1479,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
-      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
+      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1366,13 +1496,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
-      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
+      "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1382,13 +1512,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
-      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1398,13 +1528,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
-      "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
+      "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1414,13 +1544,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
-      "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
+      "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1430,14 +1560,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
-      "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
+      "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1447,14 +1577,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
-      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
+      "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1464,14 +1594,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
-      "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
+      "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1481,76 +1611,77 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
-      "integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
+      "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.28.6",
-        "@babel/plugin-syntax-import-attributes": "^7.28.6",
+        "@babel/plugin-syntax-import-assertions": "^7.29.7",
+        "@babel/plugin-syntax-import-attributes": "^7.29.7",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.29.0",
-        "@babel/plugin-transform-async-to-generator": "^7.28.6",
-        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.28.6",
-        "@babel/plugin-transform-class-properties": "^7.28.6",
-        "@babel/plugin-transform-class-static-block": "^7.28.6",
-        "@babel/plugin-transform-classes": "^7.28.6",
-        "@babel/plugin-transform-computed-properties": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5",
-        "@babel/plugin-transform-dotall-regex": "^7.28.6",
-        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
-        "@babel/plugin-transform-dynamic-import": "^7.27.1",
-        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
-        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
-        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-        "@babel/plugin-transform-for-of": "^7.27.1",
-        "@babel/plugin-transform-function-name": "^7.27.1",
-        "@babel/plugin-transform-json-strings": "^7.28.6",
-        "@babel/plugin-transform-literals": "^7.27.1",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
-        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
-        "@babel/plugin-transform-modules-amd": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.29.0",
-        "@babel/plugin-transform-modules-umd": "^7.27.1",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
-        "@babel/plugin-transform-new-target": "^7.27.1",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
-        "@babel/plugin-transform-numeric-separator": "^7.28.6",
-        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
-        "@babel/plugin-transform-object-super": "^7.27.1",
-        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
-        "@babel/plugin-transform-optional-chaining": "^7.28.6",
-        "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/plugin-transform-private-methods": "^7.28.6",
-        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
-        "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.29.0",
-        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
-        "@babel/plugin-transform-reserved-words": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-spread": "^7.28.6",
-        "@babel/plugin-transform-sticky-regex": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
-        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
+        "@babel/plugin-transform-arrow-functions": "^7.29.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.7",
+        "@babel/plugin-transform-async-to-generator": "^7.29.7",
+        "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
+        "@babel/plugin-transform-block-scoping": "^7.29.7",
+        "@babel/plugin-transform-class-properties": "^7.29.7",
+        "@babel/plugin-transform-class-static-block": "^7.29.7",
+        "@babel/plugin-transform-classes": "^7.29.7",
+        "@babel/plugin-transform-computed-properties": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-dotall-regex": "^7.29.7",
+        "@babel/plugin-transform-duplicate-keys": "^7.29.7",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-dynamic-import": "^7.29.7",
+        "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
+        "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
+        "@babel/plugin-transform-export-namespace-from": "^7.29.7",
+        "@babel/plugin-transform-for-of": "^7.29.7",
+        "@babel/plugin-transform-function-name": "^7.29.7",
+        "@babel/plugin-transform-json-strings": "^7.29.7",
+        "@babel/plugin-transform-literals": "^7.29.7",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
+        "@babel/plugin-transform-member-expression-literals": "^7.29.7",
+        "@babel/plugin-transform-modules-amd": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.7",
+        "@babel/plugin-transform-modules-umd": "^7.29.7",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-new-target": "^7.29.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
+        "@babel/plugin-transform-numeric-separator": "^7.29.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.29.7",
+        "@babel/plugin-transform-object-super": "^7.29.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/plugin-transform-private-methods": "^7.29.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.29.7",
+        "@babel/plugin-transform-property-literals": "^7.29.7",
+        "@babel/plugin-transform-regenerator": "^7.29.7",
+        "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
+        "@babel/plugin-transform-reserved-words": "^7.29.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.29.7",
+        "@babel/plugin-transform-spread": "^7.29.7",
+        "@babel/plugin-transform-sticky-regex": "^7.29.7",
+        "@babel/plugin-transform-template-literals": "^7.29.7",
+        "@babel/plugin-transform-typeof-symbol": "^7.29.7",
+        "@babel/plugin-transform-unicode-escapes": "^7.29.7",
+        "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
         "babel-plugin-polyfill-corejs2": "^0.4.15",
         "babel-plugin-polyfill-corejs3": "^0.14.0",
@@ -1563,6 +1694,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -1581,9 +1722,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1591,47 +1732,64 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+    "node_modules/@babel/traverse/node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1661,9 +1819,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
       "dev": true,
       "funding": [
         {
@@ -1681,9 +1839,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "dev": true,
       "funding": [
         {
@@ -1705,9 +1863,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
       "dev": true,
       "funding": [
         {
@@ -1721,8 +1879,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.0.1",
-        "@csstools/css-calc": "^3.0.0"
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -1756,9 +1914,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
-      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
       "dev": true,
       "funding": [
         {
@@ -1770,7 +1928,15 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0"
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
@@ -1793,13 +1959,12 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1810,13 +1975,12 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1827,13 +1991,12 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1844,13 +2007,12 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1861,13 +2023,12 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1878,13 +2039,12 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1895,13 +2055,12 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1912,13 +2071,12 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1929,13 +2087,12 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1946,13 +2103,12 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,13 +2119,12 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1980,13 +2135,12 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,13 +2151,12 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,13 +2167,12 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2031,13 +2183,12 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2048,13 +2199,12 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2065,13 +2215,12 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2082,13 +2231,12 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2099,13 +2247,12 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2116,13 +2263,12 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2133,13 +2279,12 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2150,13 +2295,12 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2167,13 +2311,12 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2184,13 +2327,12 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2201,13 +2343,12 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2218,13 +2359,12 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2235,9 +2375,9 @@
       }
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.12.0.tgz",
-      "integrity": "sha512-BuCOHA/EJdPN0qQ5MdgAiJSt9fYDHbghlgrj33gRdy/Yp1/FMCDhU6vJfcKrLC0TPWGSrfH3vYXBQWmFHxlddw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2253,57 +2393,82 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "11.2.8",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.2.8.tgz",
-      "integrity": "sha512-nBq6Y1tVkjIUsLsdOjDSJj4AsjvD0UG3zsg9Fyc+OivwlA/oMHSKooUy9tpKj0HqZ+NWFifweHavdljlBLTwdA==",
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.5.tgz",
+      "integrity": "sha512-lja3F/iKVIvTa48mIwmrIeDcQUFZ0F0drvFvT8AwINOvbwnAzl/S/p8p2DxILZpWEUHRi1qewfWNIkMvhD3kKA==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/message-compiler": "11.2.8",
-        "@intlify/shared": "11.2.8"
+        "@intlify/devtools-types": "11.4.5",
+        "@intlify/message-compiler": "11.4.5",
+        "@intlify/shared": "11.4.5"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/devtools-types": {
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.5.tgz",
+      "integrity": "sha512-W5vydP9Yq3t82IyWqCM6aR0BTWCZrN5RAwjZEPpH8I2OQWp2RLy03Evh2ANZlSMhcvGAoyDg25k0so85Kwncpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.5",
+        "@intlify/shared": "11.4.5"
+      },
+      "engines": {
+        "node": ">= 22"
       },
       "funding": {
         "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "11.2.8",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.2.8.tgz",
-      "integrity": "sha512-A5n33doOjmHsBtCN421386cG1tWp5rpOjOYPNsnpjIJbQ4POF0QY2ezhZR9kr0boKwaHjbOifvyQvHj2UTrDFQ==",
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.5.tgz",
+      "integrity": "sha512-IEOZiHtbQopyPc/Dz2M869lOlZYX1SdcniNJwphATDYHhovvIneEKf1EFF37DE7NAABZtza1FNtnwwqZWInfpw==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "11.2.8",
+        "@intlify/shared": "11.4.5",
         "source-map-js": "^1.0.2"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 22"
       },
       "funding": {
         "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "11.2.8",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.2.8.tgz",
-      "integrity": "sha512-l6e4NZyUgv8VyXXH4DbuucFOBmxLF56C/mqh2tvApbzl2Hrhi1aTDcuv5TKdxzfHYmpO3UB0Cz04fgDT9vszfw==",
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.5.tgz",
+      "integrity": "sha512-g/i5mtdUa9ia/8BaJ4w6ZRHgAXYQd9XyCaQPRMvsd8d5qmZwkjoTmHrNsI28Q/7I8h+2ijUkI4uEnnMCziKupQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": ">= 22"
       },
       "funding": {
         "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2339,7 +2504,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2433,9 +2598,9 @@
       }
     },
     "node_modules/@primevue/core": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.5.4.tgz",
-      "integrity": "sha512-lYJJB3wTrDJ8MkLctzHfrPZAqXVxoatjIsswSJzupatf6ZogJHVYADUKcn1JAkLLk8dtV1FA2AxDek663fHO5Q==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.5.5.tgz",
+      "integrity": "sha512-JpkXhq1ddc70JdsC3CC4dM+UbeeWuCW/8DpS9dNBfrOk824TLSlRlMEGFyVKqRMn5WPQvYLiy3xXfLQeNdSqhQ==",
       "license": "MIT",
       "dependencies": {
         "@primeuix/styled": "^0.7.4",
@@ -2449,13 +2614,13 @@
       }
     },
     "node_modules/@primevue/icons": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-4.5.4.tgz",
-      "integrity": "sha512-DxgryEc7ZmUqcEhYMcxGBRyFzdtLIoy3jLtlH1zsVSRZaG+iSAcjQ88nvfkZxGUZtZBFL7sRjF6KLq3bJZJwUw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-4.5.5.tgz",
+      "integrity": "sha512-eteOhTdAOXEYE9qW1AOrBBgDxQ2szHJxSkEK1XVdV2TKxGM5FQf03Ovms0VDyZTc16XBIgvwYjXJQS0BPbhPaA==",
       "license": "MIT",
       "dependencies": {
         "@primeuix/utils": "^0.6.2",
-        "@primevue/core": "4.5.4"
+        "@primevue/core": "4.5.5"
       },
       "engines": {
         "node": ">=12.11.0"
@@ -2476,16 +2641,43 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
-      "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz",
+      "integrity": "sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
-      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2507,19 +2699,41 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "serialize-javascript": "^6.0.1",
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0||^3.0.0||^4.0.0"
@@ -2531,9 +2745,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2554,13 +2768,12 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2568,13 +2781,12 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2582,13 +2794,12 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2596,13 +2807,12 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2610,13 +2820,12 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2624,13 +2833,12 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2638,13 +2846,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2652,13 +2862,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2666,13 +2878,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2680,13 +2894,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2694,13 +2910,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
       "cpu": [
         "loong64"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2708,13 +2926,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
       "cpu": [
         "loong64"
       ],
-      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2722,13 +2942,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2736,13 +2958,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2750,13 +2974,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2764,13 +2990,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2778,13 +3006,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
       "cpu": [
         "s390x"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2792,13 +3022,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2806,13 +3038,15 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2820,13 +3054,12 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2834,13 +3067,12 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2848,13 +3080,12 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2862,13 +3093,12 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2876,13 +3106,12 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2890,13 +3119,12 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2916,27 +3144,20 @@
       "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/@surma/rollup-plugin-off-main-thread": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
-      "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
+    "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
+      "version": "3.0.0-pre1",
+      "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
+      "integrity": "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "ejs": "^3.1.6",
-        "json5": "^2.2.0",
-        "magic-string": "^0.25.0",
-        "string.prototype.matchall": "^4.0.6"
-      }
-    },
-    "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
+        "ejs": "^3.1.10",
+        "json5": "^2.2.3",
+        "magic-string": "^0.30.21",
+        "string.prototype.matchall": "^4.0.12"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@types/chai": {
@@ -2967,19 +3188,25 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/qrcode": {
@@ -3005,46 +3232,46 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.4.tgz",
-      "integrity": "sha512-uM5iXipgYIn13UUQCZNdWkYk+sysBeA97d5mHsAoAt1u/wpN3+zxOmsVJWosuzX+IMGRzeYUNytztrYznboIkQ==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
+      "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.2"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.18",
-        "ast-v8-to-istanbul": "^0.3.10",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.18",
-        "vitest": "4.0.18"
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -3053,31 +3280,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3086,7 +3313,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -3108,26 +3335,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3135,13 +3362,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3150,9 +3378,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3160,14 +3388,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -3230,53 +3459,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.29.tgz",
-      "integrity": "sha512-cuzPhD8fwRHk8IGfmYaR4eEe4cAyJEL66Ove/WZL7yWNL134nqLddSLwNRIsFlnnW1kK+p8Ck3viFnC0chXCXw==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz",
+      "integrity": "sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@vue/shared": "3.5.29",
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.35",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.29.tgz",
-      "integrity": "sha512-n0G5o7R3uBVmVxjTIYcz7ovr8sy7QObFG8OQJ3xGCDNhbG60biP/P5KnyY8NLd81OuT1WJflG7N4KWYHaeeaIg==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz",
+      "integrity": "sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.29",
-        "@vue/shared": "3.5.29"
+        "@vue/compiler-core": "3.5.35",
+        "@vue/shared": "3.5.35"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.29.tgz",
-      "integrity": "sha512-oJZhN5XJs35Gzr50E82jg2cYdZQ78wEwvRO6Y63TvLVTc+6xICzJHP1UIecdSPPYIbkautNBanDiWYa64QSFIA==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.35.tgz",
+      "integrity": "sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@vue/compiler-core": "3.5.29",
-        "@vue/compiler-dom": "3.5.29",
-        "@vue/compiler-ssr": "3.5.29",
-        "@vue/shared": "3.5.29",
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.35",
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/compiler-ssr": "3.5.35",
+        "@vue/shared": "3.5.35",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.15",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.29.tgz",
-      "integrity": "sha512-Y/ARJZE6fpjzL5GH/phJmsFwx3g6t2KmHKHx5q+MLl2kencADKIrhH5MLF6HHpRMmlRAYBRSvv347Mepf1zVNw==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.35.tgz",
+      "integrity": "sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.29",
-        "@vue/shared": "3.5.29"
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/shared": "3.5.35"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -3313,80 +3542,90 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.5.tgz",
-      "integrity": "sha512-d3OIxN/+KRedeM5wQ6H6NIpwS3P5gC9nmyaHgBk+rO6dIsjY+tOh4UlPpiZbAh3YtLdCGEX4M16RmsBqPmJV+g==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.4.tgz",
+      "integrity": "sha512-IuHqQ5zGGOE7CXP72VX6A42IVeIzYv4WAhO6arej11TRNqtdZfGyH8Yr2FOCaDX0dSQG+JwULLoFHGY1igYVjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^3.0.0",
+        "alien-signals": "^3.2.0",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1",
-        "picomatch": "^4.0.2"
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.29.tgz",
-      "integrity": "sha512-zcrANcrRdcLtmGZETBxWqIkoQei8HaFpZWx/GHKxx79JZsiZ8j1du0VUJtu4eJjgFvU/iKL5lRXFXksVmI+5DA==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.35.tgz",
+      "integrity": "sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.29"
+        "@vue/shared": "3.5.35"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.29.tgz",
-      "integrity": "sha512-8DpW2QfdwIWOLqtsNcds4s+QgwSaHSJY/SUe04LptianUQ/0xi6KVsu/pYVh+HO3NTVvVJjIPL2t6GdeKbS4Lg==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.35.tgz",
+      "integrity": "sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.29",
-        "@vue/shared": "3.5.29"
+        "@vue/reactivity": "3.5.35",
+        "@vue/shared": "3.5.35"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.29.tgz",
-      "integrity": "sha512-AHvvJEtcY9tw/uk+s/YRLSlxxQnqnAkjqvK25ZiM4CllCZWzElRAoQnCM42m9AHRLNJ6oe2kC5DCgD4AUdlvXg==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.35.tgz",
+      "integrity": "sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.29",
-        "@vue/runtime-core": "3.5.29",
-        "@vue/shared": "3.5.29",
+        "@vue/reactivity": "3.5.35",
+        "@vue/runtime-core": "3.5.35",
+        "@vue/shared": "3.5.35",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.29.tgz",
-      "integrity": "sha512-G/1k6WK5MusLlbxSE2YTcqAAezS+VuwHhOvLx2KnQU7G2zCH6KIb+5Wyt6UjMq7a3qPzNEjJXs1hvAxDclQH+g==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.35.tgz",
+      "integrity": "sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.29",
-        "@vue/shared": "3.5.29"
+        "@vue/compiler-ssr": "3.5.35",
+        "@vue/shared": "3.5.35"
       },
       "peerDependencies": {
-        "vue": "3.5.29"
+        "vue": "3.5.35"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.29.tgz",
-      "integrity": "sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.35.tgz",
+      "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
-      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.11.tgz",
+      "integrity": "sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-beautify": "^1.14.9",
-        "vue-component-type-helpers": "^2.0.0"
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vue/tsconfig": {
@@ -3419,9 +3658,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3431,19 +3670,21 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3458,9 +3699,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
-      "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3566,9 +3807,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
-      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3587,21 +3828,15 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ast-walker-scope": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
-      "integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.9.0.tgz",
+      "integrity": "sha512-IJdzo2vLiElBxKzwS36VsCue/62d6IdWjnPB2v3nuPKeWGynp6FF/CYoLa5i/3jXH/z97ZDdsXz6abpgM6w07A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.4",
-        "ast-kit": "^2.1.3"
+        "@babel/parser": "^7.29.2",
+        "@babel/types": "^7.29.0",
+        "ast-kit": "^2.2.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -3660,9 +3895,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
+      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -3670,39 +3905,50 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
-      "integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.0.tgz",
-      "integrity": "sha512-AvDcMxJ34W4Wgy4KBIIePQTAOP1Ie2WFwkQp3dB7FQ/f0lI5+nM96zUnYEOE1P9sEg0es5VCP0HxiWu5fUHZAQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
         "core-js-compat": "^3.48.0"
       },
       "peerDependencies": {
@@ -3710,13 +3956,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
-      "integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.6"
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -3733,13 +3979,16 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.34",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
+      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -3762,9 +4011,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3775,9 +4024,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -3795,11 +4044,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3812,19 +4061,19 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -3874,9 +4123,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "dev": true,
       "funding": [
         {
@@ -4044,11 +4293,14 @@
       }
     },
     "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/common-tags": {
       "version": "1.8.2",
@@ -4100,9 +4352,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4139,43 +4391,33 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/cssstyle": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
-      "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
         "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.5"
+        "lru-cache": "^11.2.6"
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -4193,44 +4435,6 @@
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/data-urls/node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/data-urls/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
-      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -4294,7 +4498,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4393,9 +4596,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4423,15 +4626,15 @@
       "license": "MIT"
     },
     "node_modules/editorconfig": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
-      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@one-ini/wasm": "0.1.1",
         "commander": "^10.0.0",
-        "minimatch": "9.0.1",
+        "minimatch": "^9.0.1",
         "semver": "^7.5.3"
       },
       "bin": {
@@ -4439,29 +4642,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/editorconfig/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/editorconfig/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ejs": {
@@ -4481,9 +4661,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.369",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.369.tgz",
+      "integrity": "sha512-XM22K9FNaaCOvMMrBn1caIc8v0g6+pKt660ZbfQqUZvfil0hEzr8ZoiY7VcSLGM3L/x3rz5PqZrk+bKOOmVM9w==",
       "dev": true,
       "license": "ISC"
     },
@@ -4507,9 +4687,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4594,16 +4774,16 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4646,10 +4826,10 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4659,32 +4839,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -4711,6 +4891,19 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
+      "integrity": "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
     "node_modules/expect-type": {
@@ -4744,9 +4937,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -4778,16 +4971,13 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.5.tgz",
-      "integrity": "sha512-ct/ckWBV/9Dg3MlvCXsLcSUyoWwv9mCKqlhLNB2DAuXR/NZolSXlQqP5dyy6guWlPXBhodZyZ5lGPQcbQDxrEQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^10.2.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
+        "minimatch": "^5.0.1"
       }
     },
     "node_modules/find-up": {
@@ -4804,9 +4994,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4892,7 +5082,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5035,25 +5224,22 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5175,9 +5361,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5226,18 +5412,27 @@
         "node": ">= 14"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
+        "agent-base": "6",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
     "node_modules/idb": {
@@ -5364,13 +5559,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5760,19 +5955,19 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
+        "@isaacs/cliui": "^8.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jake": {
@@ -5815,100 +6010,17 @@
         "node": ">=14"
       }
     },
-    "node_modules/js-beautify/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/js-beautify/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/js-beautify/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/js-beautify/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/js-beautify/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5953,42 +6065,28 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "punycode": "^2.3.1"
+        "agent-base": "^7.1.2",
+        "debug": "4"
       },
       "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/jsdom/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
-      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/jsesc": {
@@ -6002,13 +6100,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -6030,9 +6121,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6063,9 +6154,9 @@
       }
     },
     "node_modules/local-pkg": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
-      "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
       "license": "MIT",
       "dependencies": {
         "mlly": "^1.7.4",
@@ -6091,17 +6182,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -6120,13 +6204,13 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/magic-string": {
@@ -6154,13 +6238,13 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
+        "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
@@ -6181,19 +6265,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6204,9 +6275,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -6242,13 +6313,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6258,11 +6329,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -6274,15 +6345,15 @@
       "license": "MIT"
     },
     "node_modules/mlly": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "pathe": "^2.0.3",
         "pkg-types": "^1.3.1",
-        "ufo": "^1.6.1"
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/mlly/node_modules/confbox": {
@@ -6306,7 +6377,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {
@@ -6316,9 +6386,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -6334,11 +6404,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nopt": {
       "version": "7.2.1",
@@ -6401,15 +6474,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -6473,26 +6549,26 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -6532,31 +6608,28 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -6610,13 +6683,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -6640,9 +6713,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6659,7 +6732,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6687,16 +6760,16 @@
       "license": "MIT"
     },
     "node_modules/primevue": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.5.4.tgz",
-      "integrity": "sha512-nTyEohZABFJhVIpeUxgP0EJ8vKcJAhD+Z7DYj95e7ie/MNUCjRNcGjqmE1cXtXi4z54qDfTSI9h2uJ51qz2DIw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.5.5.tgz",
+      "integrity": "sha512-Kv5REIewCdP806QaoU+4nBXfmpzOGFKkZ9qH4KsL6MjiAQVc4PUzypt8erl4r3Vzh3nr3aWZIxkxYRRsLGiX2A==",
       "license": "MIT",
       "dependencies": {
         "@primeuix/styled": "^0.7.4",
-        "@primeuix/styles": "^2.0.2",
+        "@primeuix/styles": "^2.0.3",
         "@primeuix/utils": "^0.6.2",
-        "@primevue/core": "4.5.4",
-        "@primevue/icons": "4.5.4"
+        "@primevue/core": "4.5.5",
+        "@primevue/icons": "4.5.5"
       },
       "engines": {
         "node": ">=12.11.0"
@@ -6710,10 +6783,13 @@
       "license": "ISC"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6875,9 +6951,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6913,12 +6989,13 @@
       "license": "ISC"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -6940,13 +7017,13 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -6956,44 +7033,44 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -7059,13 +7136,16 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/serialize-javascript": {
@@ -7157,15 +7237,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -7177,14 +7257,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7253,11 +7333,14 @@
       }
     },
     "node_modules/smob": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
-      "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+      "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.8.0-beta.0",
@@ -7286,7 +7369,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -7297,19 +7380,40 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+    "node_modules/source-map/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/source-map/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/source-map/node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "node_modules/speakingurl": {
       "version": "14.0.1",
@@ -7328,9 +7432,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7441,19 +7545,20 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7463,16 +7568,16 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7515,13 +7620,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -7652,10 +7757,10 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
-      "dev": true,
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -7670,6 +7775,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7678,9 +7790,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7688,13 +7800,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7704,9 +7816,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7714,29 +7826,29 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
-      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.23"
+        "tldts-core": "^7.4.2"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
-      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7747,13 +7859,16 @@
       }
     },
     "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "punycode": "^2.1.0"
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/type-fest": {
@@ -7827,18 +7942,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7862,9 +7977,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "license": "MIT"
     },
     "node_modules/unbox-primitive": {
@@ -7887,9 +8002,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
-      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7897,9 +8012,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -8042,10 +8157,10 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-      "dev": true,
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -8117,17 +8232,17 @@
       }
     },
     "node_modules/vite-plugin-pwa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.2.0.tgz",
-      "integrity": "sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.3.0.tgz",
+      "integrity": "sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.6",
         "pretty-bytes": "^6.1.1",
         "tinyglobby": "^0.2.10",
-        "workbox-build": "^7.4.0",
-        "workbox-window": "^7.4.0"
+        "workbox-build": "^7.4.1",
+        "workbox-window": "^7.4.1"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -8137,9 +8252,9 @@
       },
       "peerDependencies": {
         "@vite-pwa/assets-generator": "^1.0.0",
-        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-        "workbox-build": "^7.4.0",
-        "workbox-window": "^7.4.0"
+        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "workbox-build": "^7.4.1",
+        "workbox-window": "^7.4.1"
       },
       "peerDependenciesMeta": {
         "@vite-pwa/assets-generator": {
@@ -8148,31 +8263,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -8188,12 +8303,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -8214,6 +8332,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -8222,6 +8346,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -8251,16 +8378,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.29.tgz",
-      "integrity": "sha512-BZqN4Ze6mDQVNAni0IHeMJ5mwr8VAJ3MQC9FmprRhcBYENw+wOAAjRj8jfmN6FLl0j96OXbR+CjWhmAmM+QGnA==",
+      "version": "3.5.35",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz",
+      "integrity": "sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.29",
-        "@vue/compiler-sfc": "3.5.29",
-        "@vue/runtime-dom": "3.5.29",
-        "@vue/server-renderer": "3.5.29",
-        "@vue/shared": "3.5.29"
+        "@vue/compiler-dom": "3.5.35",
+        "@vue/compiler-sfc": "3.5.35",
+        "@vue/runtime-dom": "3.5.35",
+        "@vue/server-renderer": "3.5.35",
+        "@vue/shared": "3.5.35"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -8272,24 +8399,25 @@
       }
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
-      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.4.tgz",
+      "integrity": "sha512-joip1uZTaQR0nD23N400gIdJ7xY+WiiiMA/BCKz842gvGBknqDQAzklUvDEhqFvvrhQY8S2ZANBMu4X70VMFGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vue-i18n": {
-      "version": "11.2.8",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.2.8.tgz",
-      "integrity": "sha512-vJ123v/PXCZntd6Qj5Jumy7UBmIuE92VrtdX+AXr+1WzdBHojiBxnAxdfctUFL+/JIN+VQH4BhsfTtiGsvVObg==",
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.5.tgz",
+      "integrity": "sha512-rm8YJ6RpjOrkcgS2GLrZwLvs/VbhxbTSuEspbyXDo233+fPK0OMFNLOj3fdQYVKdOgcpSfLW91JhbqgpkkcBWA==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "11.2.8",
-        "@intlify/shared": "11.2.8",
+        "@intlify/core-base": "11.4.5",
+        "@intlify/devtools-types": "11.4.5",
+        "@intlify/shared": "11.4.5",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 22"
       },
       "funding": {
         "url": "https://github.com/sponsors/kazupon"
@@ -8305,37 +8433,38 @@
       "license": "MIT"
     },
     "node_modules/vue-router": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.3.tgz",
-      "integrity": "sha512-nG1c7aAFac7NYj8Hluo68WyWfc41xkEjaR0ViLHCa3oDvTQ/nIuLJlXJX1NUPw/DXzx/8+OKMng045HHQKQKWw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.1.0.tgz",
+      "integrity": "sha512-HAbiLzLEHQwxPgvsbOJDAwtavszEgLwri6XfyrsPECIFez8+59xc9LofWVdc/HEaSRT822lJ8H9Ns38VVond5g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/generator": "^7.28.6",
+        "@babel/generator": "^8.0.0-rc.4",
         "@vue-macros/common": "^3.1.1",
-        "@vue/devtools-api": "^8.0.6",
-        "ast-walker-scope": "^0.8.3",
+        "@vue/devtools-api": "^8.1.2",
+        "ast-walker-scope": "^0.9.0",
         "chokidar": "^5.0.0",
         "json5": "^2.2.3",
         "local-pkg": "^1.1.2",
         "magic-string": "^0.30.21",
-        "mlly": "^1.8.0",
+        "mlly": "^1.8.2",
         "muggle-string": "^0.4.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
         "scule": "^1.3.0",
-        "tinyglobby": "^0.2.15",
+        "tinyglobby": "^0.2.16",
         "unplugin": "^3.0.0",
         "unplugin-utils": "^0.3.1",
-        "yaml": "^2.8.2"
+        "yaml": "^2.9.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
         "@pinia/colada": ">=0.21.2",
-        "@vue/compiler-sfc": "^3.5.17",
+        "@vue/compiler-sfc": "^3.5.34",
         "pinia": "^3.0.4",
-        "vue": "^3.5.0"
+        "vite": "^7.0.0 || ^8.0.0",
+        "vue": "^3.5.34"
       },
       "peerDependenciesMeta": {
         "@pinia/colada": {
@@ -8346,41 +8475,38 @@
         },
         "pinia": {
           "optional": true
+        },
+        "vite": {
+          "optional": true
         }
       }
     },
     "node_modules/vue-router/node_modules/@vue/devtools-api": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.0.6.tgz",
-      "integrity": "sha512-+lGBI+WTvJmnU2FZqHhEB8J1DXcvNlDeEalz77iYgOdY1jTj1ipSBaKj3sRhYcy+kqA8v/BSuvOz1XJucfQmUA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.2.tgz",
+      "integrity": "sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.0.6"
+        "@vue/devtools-kit": "^8.1.2"
       }
     },
     "node_modules/vue-router/node_modules/@vue/devtools-kit": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.0.6.tgz",
-      "integrity": "sha512-9zXZPTJW72OteDXeSa5RVML3zWDCRcO5t77aJqSs228mdopYj5AiTpihozbsfFJ0IodfNs7pSgOGO3qfCuxDtw==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.2.tgz",
+      "integrity": "sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^8.0.6",
+        "@vue/devtools-shared": "^8.1.2",
         "birpc": "^2.6.1",
         "hookable": "^5.5.3",
-        "mitt": "^3.0.1",
-        "perfect-debounce": "^2.0.0",
-        "speakingurl": "^14.0.1",
-        "superjson": "^2.2.2"
+        "perfect-debounce": "^2.0.0"
       }
     },
     "node_modules/vue-router/node_modules/@vue/devtools-shared": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.0.6.tgz",
-      "integrity": "sha512-Pp1JylTqlgMJvxW6MGyfTF8vGvlBSCAvMFaDCYa82Mgw7TT5eE5kkHgDvmOGHWeJE4zIDfCpCxHapsK2LtIAJg==",
-      "license": "MIT",
-      "dependencies": {
-        "rfdc": "^1.4.1"
-      }
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.2.tgz",
+      "integrity": "sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==",
+      "license": "MIT"
     },
     "node_modules/vue-router/node_modules/perfect-debounce": {
       "version": "2.1.0",
@@ -8389,14 +8515,14 @@
       "license": "MIT"
     },
     "node_modules/vue-tsc": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.5.tgz",
-      "integrity": "sha512-/htfTCMluQ+P2FISGAooul8kO4JMheOTCbCy4M6dYnYYjqLe3BExZudAua6MSIKSFYQtFOYAll7XobYwcpokGA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.4.tgz",
+      "integrity": "sha512-XA/JqmQwS2GZmfgpjOEGdrKwaTSEuPwxpHa7/t6f4yiGrJb3gVHTPb9wBfByMNZwQ+xDXs41b8gaS2DKsOozUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.2.5"
+        "@vue/language-core": "3.3.4"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -8419,11 +8545,14 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
@@ -8442,15 +8571,18 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -8543,14 +8675,14 @@
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -8582,30 +8714,30 @@
       }
     },
     "node_modules/workbox-background-sync": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.0.tgz",
-      "integrity": "sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
+      "integrity": "sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-broadcast-update": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.0.tgz",
-      "integrity": "sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.1.tgz",
+      "integrity": "sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-build": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.0.tgz",
-      "integrity": "sha512-Ntk1pWb0caOFIvwz/hfgrov/OJ45wPEhI5PbTywQcYjyZiVhT3UrwwUPl6TRYbTm4moaFYithYnl1lvZ8UjxcA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.1.tgz",
+      "integrity": "sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8613,135 +8745,110 @@
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.11.0",
         "@babel/runtime": "^7.11.2",
-        "@rollup/plugin-babel": "^5.2.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-replace": "^2.4.1",
-        "@rollup/plugin-terser": "^0.4.3",
-        "@surma/rollup-plugin-off-main-thread": "^2.2.3",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
+        "@rollup/plugin-terser": "^1.0.0",
+        "@trickfilm400/rollup-plugin-off-main-thread": "^3.0.0-pre1",
         "ajv": "^8.6.0",
         "common-tags": "^1.8.0",
+        "eta": "^4.5.1",
         "fast-json-stable-stringify": "^2.1.0",
         "fs-extra": "^9.0.1",
         "glob": "^11.0.1",
-        "lodash": "^4.17.20",
         "pretty-bytes": "^5.3.0",
-        "rollup": "^2.79.2",
+        "rollup": "^4.53.3",
         "source-map": "^0.8.0-beta.0",
         "stringify-object": "^3.3.0",
         "strip-comments": "^2.0.1",
         "tempy": "^0.6.0",
         "upath": "^1.2.0",
-        "workbox-background-sync": "7.4.0",
-        "workbox-broadcast-update": "7.4.0",
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-google-analytics": "7.4.0",
-        "workbox-navigation-preload": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-range-requests": "7.4.0",
-        "workbox-recipes": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0",
-        "workbox-streams": "7.4.0",
-        "workbox-sw": "7.4.0",
-        "workbox-window": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-broadcast-update": "7.4.1",
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-google-analytics": "7.4.1",
+        "workbox-navigation-preload": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-range-requests": "7.4.1",
+        "workbox-recipes": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1",
+        "workbox-streams": "7.4.1",
+        "workbox-sw": "7.4.1",
+        "workbox-window": "7.4.1"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/workbox-build/node_modules/@rollup/plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
+    "node_modules/workbox-build/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
       "dev": true,
-      "license": "MIT",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/workbox-build/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@rollup/pluginutils": "^3.1.0"
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/workbox-build/node_modules/@rollup/plugin-replace": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
-      "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/workbox-build/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/workbox-build/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/workbox-build/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
+        "node": "20 || >=22"
       },
       "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/workbox-build/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/workbox-build/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/workbox-build/node_modules/pretty-bytes": {
@@ -8757,157 +8864,141 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/workbox-build/node_modules/rollup": {
-      "version": "2.80.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
-      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/workbox-cacheable-response": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.0.tgz",
-      "integrity": "sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.1.tgz",
+      "integrity": "sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.0.tgz",
-      "integrity": "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
+      "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-expiration": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.0.tgz",
-      "integrity": "sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.1.tgz",
+      "integrity": "sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-google-analytics": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.0.tgz",
-      "integrity": "sha512-MVPXQslRF6YHkzGoFw1A4GIB8GrKym/A5+jYDUSL+AeJw4ytQGrozYdiZqUW1TPQHW8isBCBtyFJergUXyNoWQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.1.tgz",
+      "integrity": "sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-background-sync": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-navigation-preload": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.0.tgz",
-      "integrity": "sha512-etzftSgdQfjMcfPgbfaZCfM2QuR1P+4o8uCA2s4rf3chtKTq/Om7g/qvEOcZkG6v7JZOSOxVYQiOu6PbAZgU6w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.1.tgz",
+      "integrity": "sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-precaching": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.0.tgz",
-      "integrity": "sha512-VQs37T6jDqf1rTxUJZXRl3yjZMf5JX/vDPhmx2CPgDDKXATzEoqyRqhYnRoxl6Kr0rqaQlp32i9rtG5zTzIlNg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.1.tgz",
+      "integrity": "sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-range-requests": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.0.tgz",
-      "integrity": "sha512-3Vq854ZNuP6Y0KZOQWLaLC9FfM7ZaE+iuQl4VhADXybwzr4z/sMmnLgTeUZLq5PaDlcJBxYXQ3U91V7dwAIfvw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.1.tgz",
+      "integrity": "sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-recipes": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.0.tgz",
-      "integrity": "sha512-kOkWvsAn4H8GvAkwfJTbwINdv4voFoiE9hbezgB1sb/0NLyTG4rE7l6LvS8lLk5QIRIto+DjXLuAuG3Vmt3cxQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.1.tgz",
+      "integrity": "sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-routing": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.0.tgz",
-      "integrity": "sha512-C/ooj5uBWYAhAqwmU8HYQJdOjjDKBp9MzTQ+otpMmd+q0eF59K+NuXUek34wbL0RFrIXe/KKT+tUWcZcBqxbHQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.1.tgz",
+      "integrity": "sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-strategies": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.0.tgz",
-      "integrity": "sha512-T4hVqIi5A4mHi92+5EppMX3cLaVywDp8nsyUgJhOZxcfSV/eQofcOA6/EMo5rnTNmNTpw0rUgjAI6LaVullPpg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.1.tgz",
+      "integrity": "sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-streams": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.0.tgz",
-      "integrity": "sha512-QHPBQrey7hQbnTs5GrEVoWz7RhHJXnPT+12qqWM378orDMo5VMJLCkCM1cnCk+8Eq92lccx/VgRZ7WAzZWbSLg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.1.tgz",
+      "integrity": "sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1"
       }
     },
     "node_modules/workbox-sw": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.0.tgz",
-      "integrity": "sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.1.tgz",
+      "integrity": "sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-window": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.0.tgz",
-      "integrity": "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.1.tgz",
+      "integrity": "sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/wrap-ansi": {
@@ -9039,9 +9130,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,14 +34,14 @@
     "@pinia/testing": "^1.0.3",
     "@types/node": "^25.3.0",
     "@vitejs/plugin-vue": "^6.0.2",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.8",
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.8.1",
     "jsdom": "^28.1.0",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1",
+    "vite": "^7.3.5",
     "vite-plugin-pwa": "^1.2.0",
-    "vitest": "^4.0.18",
+    "vitest": "^4.1.8",
     "vitest-axe": "^0.1.0",
     "vue-tsc": "^3.2.5"
   }

--- a/frontend/src/components/rooms/RoomDiscussions.vue
+++ b/frontend/src/components/rooms/RoomDiscussions.vue
@@ -5,6 +5,7 @@ import { useLocaleDate } from '@/composables/useLocaleDate'
 import { useDiscussionsStore } from '@/stores/discussions'
 import { useAuthStore } from '@/stores/auth'
 import { useRoomsStore } from '@/stores/rooms'
+import { useToast } from 'primevue/usetoast'
 import DiscussionThreadView from './DiscussionThreadView.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -23,6 +24,7 @@ const { formatCompactDateTime } = useLocaleDate()
 const discussions = useDiscussionsStore()
 const auth = useAuthStore()
 const rooms = useRoomsStore()
+const toast = useToast()
 
 const selectedThreadId = ref<string | null>(null)
 const showCreateDialog = ref(false)
@@ -45,8 +47,10 @@ const filteredThreads = computed(() => discussions.threads)
 onMounted(async () => {
   try {
     await discussions.fetchThreads(props.roomId)
-  } catch {
-    // Threads not accessible (e.g. permission issue)
+  } catch (e: any) {
+    if (e?.response?.status !== 403) {
+      toast.add({ severity: 'error', summary: t('common.error'), detail: t('discussions.loadError'), life: 4000 })
+    }
   }
   // Check if current user is LEADER and determine room role
   const member = rooms.currentRoom?.members?.find(m => m.userId === auth.user?.id)

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1016,6 +1016,7 @@ export default {
     audienceAlle: 'Alle',
     audienceEltern: 'Eltern',
     audienceKinder: 'Kinder',
+    loadError: 'Diskussionen konnten nicht geladen werden',
   },
   calendar: {
     title: 'Kalender',

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1016,6 +1016,7 @@ export default {
     audienceAlle: 'Everyone',
     audienceEltern: 'Parents',
     audienceKinder: 'Children',
+    loadError: 'Could not load discussions',
   },
   calendar: {
     title: 'Calendar',

--- a/frontend/src/stores/__tests__/auth-multirole.test.ts
+++ b/frontend/src/stores/__tests__/auth-multirole.test.ts
@@ -246,6 +246,13 @@ describe('Auth Store - Multi-Role', () => {
         assignedRoles: ['TEACHER', 'PARENT'],
       } as any
       expect(auth.canHaveFamily).toBe(true)
+
+      // US-040: students must NOT see the "Familie" nav item
+      auth.user = {
+        role: 'STUDENT',
+        assignedRoles: ['STUDENT'],
+      } as any
+      expect(auth.canHaveFamily).toBe(false)
     })
   })
 })

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -50,8 +50,10 @@ export const useAuthStore = defineStore('auth', () => {
     user.value?.specialRoles?.some((r: string) => r === 'PUTZORGA' || r.startsWith('PUTZORGA:')) ?? false
   )
   const isSectionAdmin = computed(() => user.value?.role === 'SECTION_ADMIN')
+  // US-040: Students do NOT get a "Familie" nav item (a family is created/managed by
+  // parents, not by the student themselves). Only PARENT and SUPERADMIN see it.
   const canHaveFamily = computed(() =>
-    user.value?.role === 'PARENT' || user.value?.role === 'STUDENT' || user.value?.role === 'SUPERADMIN'
+    user.value?.role === 'PARENT' || user.value?.role === 'SUPERADMIN'
   )
   const assignedRoles = computed(() => user.value?.assignedRoles ?? [])
   const canSwitchRole = computed(() => assignedRoles.value.length > 1)

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -52,7 +52,7 @@ onMounted(async () => {
 
 function canManage() {
   if (!calendar.currentEvent) return false
-  if (auth.isAdmin) return true
+  if (auth.isAdmin || auth.isSectionAdmin) return true
   return calendar.currentEvent.createdBy === auth.user?.id
 }
 

--- a/frontend/src/views/__tests__/EventDetailView.test.ts
+++ b/frontend/src/views/__tests__/EventDetailView.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import EventDetailView from '@/views/EventDetailView.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useCalendarStore } from '@/stores/calendar'
 
 vi.mock('vue-router', () => ({
   useRouter: vi.fn(() => ({ push: vi.fn(), back: vi.fn() })),
@@ -113,8 +115,7 @@ const stubs = {
   Select: { template: '<select class="select-stub" />', props: ['modelValue', 'options', 'optionLabel', 'optionValue', 'placeholder'] },
 }
 
-function mountEventDetail() {
-  const pinia = createPinia()
+function mountEventDetail(pinia = createPinia()) {
   return mount(EventDetailView, {
     props: { id: 'evt-1' },
     global: {
@@ -147,5 +148,48 @@ describe('EventDetailView', () => {
     await wrapper.vm.$nextTick()
     // Either loading or page-title should be rendered
     expect(wrapper.find('.loading-stub').exists() || wrapper.find('.page-title-stub').exists()).toBe(true)
+  })
+
+  it('canManage() returns true for a SECTION_ADMIN who is not the creator', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    // SECTION_ADMIN with a different id than the event creator (createdBy: 'user-1')
+    useAuthStore().user = { id: 'admin-9', role: 'SECTION_ADMIN' } as never
+    const wrapper = mountEventDetail(pinia)
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+    expect(useCalendarStore().currentEvent?.createdBy).toBe('user-1')
+    expect((wrapper.vm as unknown as { canManage: () => boolean }).canManage()).toBe(true)
+  })
+
+  it('canManage() returns true for a SUPERADMIN who is not the creator', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useAuthStore().user = { id: 'super-1', role: 'SUPERADMIN' } as never
+    const wrapper = mountEventDetail(pinia)
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+    expect((wrapper.vm as unknown as { canManage: () => boolean }).canManage()).toBe(true)
+  })
+
+  it('canManage() returns false for a PARENT who is not the creator', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useAuthStore().user = { id: 'parent-3', role: 'PARENT' } as never
+    const wrapper = mountEventDetail(pinia)
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+    expect((wrapper.vm as unknown as { canManage: () => boolean }).canManage()).toBe(false)
+  })
+
+  it('canManage() returns true for the event creator regardless of role', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    // createdBy in the mock is 'user-1'
+    useAuthStore().user = { id: 'user-1', role: 'PARENT' } as never
+    const wrapper = mountEventDetail(pinia)
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+    expect((wrapper.vm as unknown as { canManage: () => boolean }).canManage()).toBe(true)
   })
 })

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,10 @@
+# Real client IP for per-client rate limiting (forwarded as X-Real-IP).
+# Prefer Cloudflare's CF-Connecting-IP; fall back to the direct peer.
+map $http_cf_connecting_ip $real_client_ip {
+    ""      $remote_addr;
+    default $http_cf_connecting_ip;
+}
+
 upstream backend {
     server backend:8080;
 }
@@ -31,7 +38,7 @@ server {
     location /api/ {
         proxy_pass http://backend;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $real_client_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
@@ -48,7 +55,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $real_client_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
@@ -59,7 +66,7 @@ server {
     location = /actuator/health {
         proxy_pass http://backend;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $real_client_ip;
     }
 
     location /actuator/ {


### PR DESCRIPTION
## Comprehensive review: security · dependencies · use-case audit (+ fixes)

Full multi-agent review of the project (~120k LOC, 24 modules) with adversarial
verification, fixes for all **Critical/High/Medium** findings, a re-review pass, a
use-case documentation/correctness audit, and the follow-up fixes it surfaced.

**10 commits · 120 files · all green:** backend **673 tests · 0 failures**, frontend **1994 tests**, `mvn test` BUILD SUCCESS.

### Phase 1 — Review (122 findings, verified)
6 security lenses + 6 code-quality clusters + 2 dependency reviews, each finding adversarially re-verified → 28 high, 27 medium, 51 low, 16 info.

### Phase 2 — Fixes (Critical/High/Medium)
- **Deps:** 13 frontend CVEs → 0 (vitest/vite/lodash/postcss), BouncyCastle 1.84, pom cleanup.
- **Broken access control / IDOR (read paths):** calendar, feed, fotobox-audience, room discussions, **Solr search per-room filter**, tasks, wiki, **jobboard family-hours export (admin-only)**, message reactions, parent-letter attachments.
- **Admin-role consistency**, **auth hardening** (WebSocket `type`-claim, single-use 2FA token, OIDC `email_verified`, anti-enumeration login).
- **Config/infra:** fail-closed secret validation, OnlyOffice JWT + loopback, Grafana/Prometheus loopback, 4xx client-error mapping, multipart limit, nginx `CF-Connecting-IP` rate-limit key.
- **Billing integrity**, SSRF redirect re-validation, ClamAV wiring, async listeners → `@ApplicationModuleListener`.

### Phase 3 — Re-review
55 findings re-verified: 47 resolved, **8 partial → all closed** (incl. splitting fail-closed secret validation into fatal-crypto vs warn-infra so it can't unexpectedly hard-stop an existing deploy).

### Phase 4–5 — Use-case audit → [`docs/audits/UC-AUDIT-2026-06-09.md`](docs/audits/UC-AUDIT-2026-06-09.md)
296 documented stories vs code: ~477/600 correct; **145 deviations (33 high / 53 medium)** + **165 undocumented** capabilities.

### Resolved decisions (now applied)
1. **UC-surfaced authz bugs → fixed (High+Medium):** create-room/post/form/thread now require staff (PARENT/STUDENT → 403); folder-delete, jobboard-confirm, cleaning-minutes role checks; comm-rules enforced in group conversations; can't remove last SUPERADMIN / self-deactivate; audit logging (US-348). `doc_outdated` cases where the hardened code is correct were left as code and the docs updated instead.
2. **SECTION_ADMIN → section-scoped system-wide:** SUPERADMIN stays global; SECTION_ADMIN only admins rooms in its own section (`SECTION_ADMIN:<sectionId>`) across calendar/files/wiki/tasks/fotobox (matching the room module).
3. **Docs:** new `## Modul: Elternbriefe` (US-375–US-390) for the previously-undocumented parentletter module + 29 stale stories corrected → **312 stories**.

Also fixed along the way: US-016 mandatory-2FA self-enrollment at login (new temp-token endpoints), fundgrube school-wide section filter, feed banner links (V117 migration), a real Postgres null-param bug in the new audit-filter query.

### ⚠️ Action required before deploying
Production `.env` must use strong secrets — the backend now **fails closed** on a weak/placeholder `JWT_SECRET`, `ENCRYPTION_SECRET`, or cleaning QR secret (DB/Redis/MinIO defaults only warn). For local dev: `SPRING_PROFILES_ACTIVE=dev`.

### Follow-ups (documented, not in this PR)
Frontend role/UI gating (hiding create buttons, US-016 enrollment UI), ClamAV for messaging/parentletter/avatar uploads, and the remaining low/feature-gap UC items (recurring-event expansion, wiki-bookmark UI) — see the UC audit report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
